### PR TITLE
Use futures::future::select instead of select! macro

### DIFF
--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -398,7 +398,7 @@ impl<Service: PushService> AccountManager<Service> {
 
     /// Set profile attributes
     ///
-    /// Signal Android does not allow unsetting voice/video.
+    /// Signal Android does not allow un-setting voice/video.
     #[allow(clippy::too_many_arguments)]
     pub async fn set_account_attributes(
         &mut self,


### PR DESCRIPTION
I always found the usage of `select!` macro makes it harder to understand what's happening. OTOH it's not really a necessary change, so I'd understand if you don't want it!

On top of this, `rust-analyzer` manages to understand this code, but fails with `select!`.

(this change will please @boxdot)