### PR TITLE
Send messages using the (websocket) message pipe

### DIFF
--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -17,6 +17,7 @@ futures = "0.3"
 pin-project = "1.0"
 thiserror = "1.0"
 serde = {version = "1.0", features=["derive"]}
+serde_json = "1.0"
 prost = "0.7"
 http = "0.2.2"
 chrono = { version = "0.4", features = ["serde"] }

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -425,7 +425,6 @@ impl<Service: PushService> AccountManager<Service> {
             unidentified_access_key,
             unrestricted_unidentified_access,
             discoverable_by_phone_number,
-
             capabilities,
         };
         self.service.set_account_attributes(attribs).await?;

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -54,7 +54,7 @@ pub mod prelude {
         },
         push_service::{PushService, ServiceError},
         receiver::MessageReceiver,
-        sender::{MessageSender, MessageSenderError},
+        sender::{MessageSender, MessageSenderError, OutgoingPushMessages},
     };
     pub use phonenumber;
     pub use prost::Message as ProtobufMessage;

--- a/libsignal-service/src/messagepipe.rs
+++ b/libsignal-service/src/messagepipe.rs
@@ -146,7 +146,7 @@ where
     }
 
     /// Worker task that
-    async fn run<'a>(
+    async fn run(
         mut self,
         mut outgoing_sender: Sender<Result<Envelope, ServiceError>>,
         incoming_sender: Sender<MessageToSend>,

--- a/libsignal-service/src/messagepipe.rs
+++ b/libsignal-service/src/messagepipe.rs
@@ -26,7 +26,7 @@ pub use crate::{
 
 use crate::{
     content::ContentBody,
-    prelude::MessageSender,
+    prelude::{MessageSender, MessageSenderError},
     push_service::{PushService, ServiceError},
     sealed_session_cipher::UnidentifiedAccess,
     sender::{
@@ -45,7 +45,7 @@ pub enum WebSocketStreamItem {
 pub struct MessageToSend {
     pub recipients: Vec<ServiceAddress>,
     pub unidentified_access: Option<UnidentifiedAccess>,
-    pub content_body: ContentBody,
+    pub message: ContentBody,
     pub timestamp: u64,
     pub online: bool,
 }
@@ -132,8 +132,8 @@ where
         &mut self,
         r: WebSocketRequestMessage,
     ) -> Result<
-        impl Future<Output = Result<WebSocketResponseMessage, ServiceError>>,
-        ServiceError,
+        impl Future<Output = Result<WebSocketResponseMessage, MessageSenderError>>,
+        MessageSenderError,
     > {
         let id = r.id;
 
@@ -143,13 +143,17 @@ where
 
         if let Some(id) = id {
             self.requests.insert(id, sink);
-            Ok(send.map_err(|_| ServiceError::WsClosing {
-                reason: "WebSocket closing while sending request.".into(),
+            Ok(send.map_err(|_| {
+                ServiceError::WsClosing {
+                    reason: "WebSocket closing while sending request.".into(),
+                }
+                .into()
             }))
         } else {
             Err(ServiceError::InvalidFrameError {
                 reason: "Send request without ID".into(),
-            })
+            }
+            .into())
         }
     }
 
@@ -157,11 +161,13 @@ where
     /// and processes frames received in the web-socket
     async fn run(
         mut self,
-        mut outgoing_sender: Sender<Result<Envelope, ServiceError>>,
+        mut outgoing_sender: Sender<Result<Envelope, MessageSenderError>>,
         incoming_sender: Sender<MessageToSend>,
         mut incoming_receiver: Receiver<MessageToSend>,
     ) -> Result<(), mpsc::SendError> {
         use futures::future::LocalBoxFuture;
+
+        let inner_local_address = self.message_sender.local_address.clone();
 
         // This is a runtime-agnostic, poor man's `::spawn(Future<Output=()>)`.
         let mut background_work = FuturesUnordered::<LocalBoxFuture<()>>::new();
@@ -201,39 +207,70 @@ where
                 },
                 // When we have a message to send (from either the outside, or re-injected)
                 message_to_send = incoming_receiver.next() => {
-                    if let Some(MessageToSend { recipients, unidentified_access, content_body, timestamp, online }) = message_to_send {
+                    if let Some(MessageToSend { recipients, unidentified_access, message, timestamp, online }) = message_to_send {
                         // this is mirrored logic from MessageSender::send_message
-                        for recipient in recipients {
-                            let mut inner_outgoing_sender = outgoing_sender.clone();
-                            let mut inner_incoming_sender = incoming_sender.clone();
-                            let local_address = self.message_sender.local_address.clone();
-                            let content_body = content_body.clone();
-                            let unidentified_access = unidentified_access.clone();
-                            match self.send_message(&recipient, unidentified_access.as_ref(), &content_body, timestamp, online).await {
-                                Ok(response_fut) => {
-                                    // we want to wait for the response in the background to avoid blocking the message loop
-                                    background_work.push(async move {
-                                        match Self::process_send_response(recipient, unidentified_access, content_body, timestamp, response_fut).await {
-                                            Ok(Some(content_body)) => {
-                                                // we re-inject the new sync message in the pipe!
-                                                inner_incoming_sender.send(MessageToSend {
-                                                    recipients: vec![local_address],
-                                                    unidentified_access: None,
-                                                    content_body,
-                                                    timestamp,
-                                                    online: false,
-                                                }).await.expect("working incoming sender");
-                                            }
-                                            Err(e) => { inner_outgoing_sender.send(Err(e)).await.expect("working outgoing sender"); }
-                                            _ => (),
-                                        };
-                                    }.boxed_local());
+                        let mut response_futures = vec![];
+                        let mut inner_outgoing_sender = outgoing_sender.clone();
+                        let mut inner_incoming_sender = incoming_sender.clone();
+                        for recipient in recipients.into_iter() {
+                            let message = message.clone();
+                            match self.send_message(&recipient, unidentified_access.as_ref(), message, timestamp, online).await {
+                                Ok(response_future) => {
+                                    response_futures.push((recipient, response_future));
                                 }
                                 Err(e) => {
                                     outgoing_sender.send(Err(e)).await?;
                                 }
                             }
                         }
+
+                        // we will wait for the result in the background
+                        let inner_local_address = inner_local_address.clone();
+
+                        // FIXME: this means we can't easily delete the mismatched devices...
+                        // since we can't access the session-store here
+                        background_work.push(async move {
+                            let mut needs_sync_in_results = false;
+                            let mut results = vec![];
+                            for (recipient, response_fut) in response_futures {
+                                let result = Self::process_send_response(recipient, unidentified_access.as_ref(), response_fut).await;
+                                match result {
+                                    Ok(SentMessage { needs_sync, .. }) => {
+                                        if needs_sync {
+                                            needs_sync_in_results = true;
+                                        }
+                                        results.push(result);
+                                    }
+                                    Err(e) => {
+                                        // FIXME: if the error was mismatched devices here, we need to submit a message
+                                        // for the loop to delete the offending sessions
+
+                                        inner_outgoing_sender.send(Err(e)).await.expect("working outgoing sender"); }
+                                };
+                            }
+
+                            if let ContentBody::DataMessage(data_message) = message {
+                                if needs_sync_in_results {
+                                    let sync_message: ContentBody = create_multi_device_sent_transcript_content(
+                                        None,
+                                        Some(data_message),
+                                        timestamp,
+                                        &results,
+                                    ).into();
+                                    log::debug!("submitting sync message from background");
+
+                                    // inject the sync message in the message pipe
+                                    inner_incoming_sender.send(MessageToSend {
+                                        recipients: vec![inner_local_address],
+                                        unidentified_access,
+                                        message: sync_message,
+                                        timestamp,
+                                        online,
+                                    }).await.expect("working incoming sender");
+                                }
+                            }
+
+                        }.boxed_local());
                     }
 
                 }
@@ -253,15 +290,16 @@ where
         &mut self,
         recipient: &ServiceAddress,
         unidentified_access: Option<&UnidentifiedAccess>,
-        content_body: &ContentBody,
+        content_body: impl Into<ContentBody>,
         timestamp: u64,
         online: bool,
     ) -> Result<
-        impl Future<Output = Result<WebSocketResponseMessage, ServiceError>>,
-        ServiceError,
+        impl Future<Output = Result<WebSocketResponseMessage, MessageSenderError>>,
+        MessageSenderError,
     > {
         use crate::proto::data_message::Flags;
 
+        let content_body = content_body.into();
         let content = content_body.clone().into_proto();
         let mut content_bytes = Vec::with_capacity(content.encoded_len());
         content
@@ -276,8 +314,7 @@ where
                 unidentified_access,
                 &content_bytes,
             )
-            .await
-            .unwrap();
+            .await?;
 
         let destination = recipient.identifier();
         let messages = OutgoingPushMessages {
@@ -298,81 +335,56 @@ where
         let response_fut = self.send_request(message_request).await;
 
         // check if we need to end the session after sending this message
-        let end_session = match &content_body {
-            ContentBody::DataMessage(message) => {
-                message.flags == Some(Flags::EndSession as u32)
+        match &content_body {
+            ContentBody::DataMessage(message)
+                if message.flags == Some(Flags::EndSession as u32) =>
+            {
+                log::debug!("ending session with {}", recipient);
+                if let Some(ref uuid) = recipient.uuid {
+                    self.message_sender
+                        .session_store
+                        .delete_all_sessions(&uuid.to_string())
+                        .await?;
+                }
+                if let Some(e164) = recipient.e164() {
+                    self.message_sender
+                        .session_store
+                        .delete_all_sessions(&e164)
+                        .await?;
+                }
             }
-            _ => false,
+            _ => (),
         };
-
-        if end_session {
-            log::debug!("ending session with {}", recipient);
-            if let Some(ref uuid) = recipient.uuid {
-                self.message_sender
-                    .session_store
-                    .delete_all_sessions(&uuid.to_string())
-                    .await?;
-            }
-            if let Some(e164) = recipient.e164() {
-                self.message_sender
-                    .session_store
-                    .delete_all_sessions(&e164)
-                    .await?;
-            }
-        }
 
         response_fut
     }
 
     async fn process_send_response(
         recipient: ServiceAddress,
-        unidentified_access: Option<UnidentifiedAccess>,
-        content_body: ContentBody,
-        timestamp: u64,
+        unidentified_access: Option<&UnidentifiedAccess>,
         response_fut: impl Future<
-            Output = Result<WebSocketResponseMessage, ServiceError>,
+            Output = Result<WebSocketResponseMessage, MessageSenderError>,
         >,
-    ) -> Result<Option<ContentBody>, ServiceError> {
+    ) -> Result<SentMessage, MessageSenderError> {
         match response_fut.await {
             Ok(WebSocketResponseMessage {
                 status: Some(status),
                 body: Some(body),
                 ..
-            }) if status == 200 => {
-                match (content_body, serde_json::from_slice(&body)) {
-                    (
-                        ContentBody::DataMessage(message),
-                        Ok(SendMessageResponse { needs_sync }),
-                    ) if needs_sync => {
-                        log::debug!("sending multi-device sync message");
-                        let sync_message =
-                            create_multi_device_sent_transcript_content(
-                                Some(&recipient.clone()),
-                                Some(message),
-                                timestamp,
-                                &[Ok(SentMessage {
-                                    recipient,
-                                    unidentified: unidentified_access.is_some(),
-                                    needs_sync,
-                                })],
-                            );
-                        Ok(Some(sync_message))
+            }) if status == 200 => match serde_json::from_slice(&body) {
+                Ok(SendMessageResponse { needs_sync }) => Ok(SentMessage {
+                    recipient,
+                    unidentified: unidentified_access.is_some(),
+                    needs_sync,
+                }),
+                Err(e) => {
+                    log::error!("Failed to decode HTTP 200 response: {}", e);
+                    Err(ServiceError::JsonDecodeError {
+                        reason: e.to_string(),
                     }
-                    (_, Err(e)) => {
-                        log::error!(
-                            "Failed to decode HTTP 200 response: {}",
-                            e
-                        );
-                        Err(ServiceError::UnhandledResponseCode {
-                            http_code: 200,
-                        })
-                    }
-                    (content_body, response) => {
-                        eprintln!("{:?}, {:?}", content_body, response);
-                        Ok(None)
-                    }
+                    .into())
                 }
-            }
+            },
 
             Ok(WebSocketResponseMessage {
                 status: Some(status),
@@ -382,11 +394,15 @@ where
                 Ok(mismatched_devices) => {
                     Err(ServiceError::MismatchedDevicesException(
                         mismatched_devices,
-                    ))
+                    )
+                    .into())
                 }
                 Err(e) => {
                     log::error!("Failed to decode HTTP 409 response: {}", e);
-                    Err(ServiceError::UnhandledResponseCode { http_code: 409 })
+                    Err(ServiceError::JsonDecodeError {
+                        reason: e.to_string(),
+                    }
+                    .into())
                 }
             },
             Ok(WebSocketResponseMessage {
@@ -398,19 +414,23 @@ where
                 log::trace!("Unhandled response with body: {:?}", body);
                 Err(ServiceError::UnhandledResponseCode {
                     http_code: status as u16,
-                })
+                }
+                .into())
             }
             Ok(_) => Err(ServiceError::WsError {
                 reason: "malformed websocket response".into(),
-            }),
+            }
+            .into()),
             Err(e) => Err(e),
         }
     }
 
     async fn send_keep_alive(
         &mut self,
-    ) -> Result<impl Future<Output = Result<(), ServiceError>>, ServiceError>
-    {
+    ) -> Result<
+        impl Future<Output = Result<(), MessageSenderError>>,
+        MessageSenderError,
+    > {
         let request = WebSocketRequestMessage {
             id: Some(
                 std::time::SystemTime::now()
@@ -434,7 +454,8 @@ where
                 );
                 Err(ServiceError::UnhandledResponseCode {
                     http_code: response.status() as u16,
-                })
+                }
+                .into())
             }
         })
     }
@@ -442,15 +463,17 @@ where
     async fn process_frame(
         &mut self,
         frame: Bytes,
-    ) -> Result<Option<Envelope>, ServiceError> {
-        let msg = WebSocketMessage::decode(frame)?;
+    ) -> Result<Option<Envelope>, MessageSenderError> {
+        let msg = WebSocketMessage::decode(frame)
+            .map_err(ServiceError::ProtobufDecodeError)?;
         log::trace!("Decoded {:?}", msg);
 
         use web_socket_message::Type;
         match (msg.r#type(), msg.request, msg.response) {
             (Type::Unknown, _, _) => Err(ServiceError::InvalidFrameError {
                 reason: "Unknown frame type".into(),
-            }),
+            }
+            .into()),
             (Type::Request, Some(request), _) => {
                 // Java: MessagePipe::read
                 let response = WebSocketResponseMessage::from_request(&request);
@@ -461,7 +484,8 @@ where
                     } else {
                         return Err(ServiceError::InvalidFrameError {
                             reason: "Request without body.".into(),
-                        });
+                        }
+                        .into());
                     };
                     Some(Envelope::decrypt(
                         body,
@@ -483,7 +507,8 @@ where
             (Type::Request, None, _) => Err(ServiceError::InvalidFrameError {
                 reason: "Type was request, but does not contain request."
                     .into(),
-            }),
+            }
+            .into()),
             (Type::Response, _, Some(response)) => {
                 if let Some(id) = response.id {
                     if let Some(responder) = self.requests.remove(&id) {
@@ -507,7 +532,8 @@ where
             (Type::Response, _, None) => Err(ServiceError::InvalidFrameError {
                 reason: "Type was response, but does not contain response."
                     .into(),
-            }),
+            }
+            .into()),
         }
     }
 
@@ -518,7 +544,7 @@ where
         self,
     ) -> (
         impl Sink<MessageToSend>,
-        impl Stream<Item = Result<Envelope, ServiceError>>,
+        impl Stream<Item = Result<Envelope, MessageSenderError>>,
     ) {
         let (sink, stream) = mpsc::channel(1);
         let (message_sender, message_receiver) = mpsc::channel(1);

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -513,9 +513,9 @@ pub trait PushService {
         }
     }
 
-    async fn send_messages<'a>(
+    async fn send_messages(
         &mut self,
-        messages: OutgoingPushMessages<'a>,
+        messages: OutgoingPushMessages,
     ) -> Result<SendMessageResponse, ServiceError> {
         let path = format!("/v1/messages/{}", messages.destination);
         self.put_json(

--- a/libsignal-service/src/receiver.rs
+++ b/libsignal-service/src/receiver.rs
@@ -2,9 +2,7 @@ use bytes::{Buf, Bytes};
 
 use crate::{
     attachment_cipher::decrypt_in_place,
-    configuration::ServiceCredentials,
     envelope::Envelope,
-    messagepipe::MessagePipe,
     models::{Contact, ParseContactError},
     push_service::*,
 };
@@ -50,16 +48,16 @@ impl<Service: PushService> MessageReceiver<Service> {
         Ok(entities)
     }
 
-    pub async fn create_message_pipe(
-        &mut self,
-        credentials: ServiceCredentials,
-    ) -> Result<MessagePipe<Service::WebSocket>, MessageReceiverError> {
-        let (ws, stream) = self
-            .service
-            .ws("/v1/websocket/", Some(credentials.clone()))
-            .await?;
-        Ok(MessagePipe::from_socket(ws, stream, credentials))
-    }
+    // pub async fn create_message_pipe(
+    //     &mut self,
+    //     credentials: ServiceCredentials,
+    // ) -> Result<MessagePipe<Service::WebSocket>, MessageReceiverError> {
+    //     let (ws, stream) = self
+    //         .service
+    //         .ws("/v1/websocket/", Some(credentials.clone()))
+    //         .await?;
+    //     Ok(MessagePipe::from_socket(ws, stream, credentials))
+    // }
 
     pub async fn retrieve_contacts(
         &mut self,

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -95,7 +95,7 @@ pub enum AttachmentUploadError {
 
 #[derive(thiserror::Error, Debug)]
 pub enum MessageSenderError {
-    #[error("{0}")]
+    #[error(transparent)]
     ServiceError(#[from] ServiceError),
     #[error("protocol error: {0}")]
     ProtocolError(#[from] SignalProtocolError),
@@ -354,7 +354,7 @@ where
                 self.try_send_message(
                     (&self.local_address).clone(),
                     None,
-                    &sync_message,
+                    &sync_message.into(),
                     timestamp,
                     false,
                 )
@@ -426,7 +426,7 @@ where
                 .try_send_message(
                     self.local_address.clone(),
                     unidentified_access,
-                    &sync_message,
+                    &sync_message.into(),
                     timestamp,
                     false,
                 )
@@ -754,7 +754,7 @@ pub fn create_multi_device_sent_transcript_content(
     data_message: Option<crate::proto::DataMessage>,
     timestamp: u64,
     send_message_results: &[SendMessageResult],
-) -> ContentBody {
+) -> SyncMessage {
     use sync_message::sent::UnidentifiedDeliveryStatus;
     let unidentified_status: Vec<UnidentifiedDeliveryStatus> =
         send_message_results
@@ -773,7 +773,7 @@ pub fn create_multi_device_sent_transcript_content(
                 }
             })
             .collect();
-    ContentBody::SynchronizeMessage(SyncMessage {
+    SyncMessage {
         sent: Some(sync_message::Sent {
             destination_uuid: recipient
                 .and_then(|r| r.uuid)
@@ -785,5 +785,5 @@ pub fn create_multi_device_sent_transcript_content(
             ..Default::default()
         }),
         ..Default::default()
-    })
+    }
 }

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -72,22 +72,13 @@ pub struct AttachmentSpec {
     pub blur_hash: Option<String>,
 }
 
-// TODO: switch to enum, such that you can send messages to group
-pub struct MessageToSend {
-    pub recipient: ServiceAddress,
-    pub unidentified_access: Option<UnidentifiedAccess>,
-    pub content_body: ContentBody,
-    pub timestamp: u64,
-    pub online: bool,
-}
-
 /// Equivalent of Java's `SignalServiceMessageSender`.
 #[derive(Clone)]
 pub struct MessageSender<Service, S, I, SP, P, R> {
     service: Service,
     cipher: ServiceCipher<S, I, SP, P, R>,
     csprng: R,
-    session_store: S,
+    pub(crate) session_store: S,
     identity_key_store: I,
     pub(crate) local_address: ServiceAddress,
     device_id: u32,


### PR DESCRIPTION
This adds the ability to submit messages to the `MessagePipe` (resolving #25).

Included is a new wrapper struct called `MessageToSend` which is deliberately not named `Message` as I thought it was too generic, any other name suggestion is appreciated.

From a high-level API view, it should look like:
```rust
let message_pipe = MessagePipe::from_socket(websocket, stream, credentials, message_sender);

// sender implements `Sink` and receiver implements `Stream` 
let (sender, receiver) = message_pipe.split();
```

TODO:
- [ ] Finish factoring the code to avoid duplication between `sender.rs` and `messagepipe.rs` _or_ remove sync message sending abilities altogether? Paging Dr. @rubdos
- [ ] Figure out how group messages should be sent (related to #75):
  1. the caller is responsible
  2. provide a helper method, like the one we have currently (`send_message_to_group`)
  3. something else
- [ ] Figure out if/why messages arrive only on the primary device, per @boxdot report when testing
- [ ] Maybe figure out the best way to have the `MessagePipe` work without having to poll on the receiving stream in order for sending to work... I suppose the obvious reflex would be to use `tokio::spawn`, which is not really available here. From a pure API point of view, we might want to `impl Future` on `MessagePipe` but then the user would be responsible to poll on 3 futures in order for the whole thing to work. I'm torn.

Should help @boxdot with https://github.com/boxdot/gurk-rs/issues/50