### PR TITLE
Refactor delete_service_addr_device_session, catch non-existing session on deletion

### DIFF
--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -484,22 +484,12 @@ where
                             "dropping session with device {}",
                             extra_device_id
                         );
-                        if let Some(uuid) = recipient.uuid {
-                            self.session_store
-                                .delete_session(&ProtocolAddress::new(
-                                    uuid.to_string(),
-                                    *extra_device_id,
-                                ))
-                                .await?;
-                        }
-                        if let Some(e164) = recipient.e164() {
-                            self.session_store
-                                .delete_session(&ProtocolAddress::new(
-                                    e164,
-                                    *extra_device_id,
-                                ))
-                                .await?;
-                        }
+                        self.session_store
+                            .delete_service_addr_device_session(
+                                &recipient,
+                                *extra_device_id,
+                            )
+                            .await?;
                     }
 
                     for missing_device_id in &m.missing_devices {
@@ -540,22 +530,12 @@ where
                             "dropping session with device {}",
                             extra_device_id
                         );
-                        if let Some(ref uuid) = recipient.uuid {
-                            self.session_store
-                                .delete_session(&ProtocolAddress::new(
-                                    uuid.to_string(),
-                                    *extra_device_id,
-                                ))
-                                .await?;
-                        }
-                        if let Some(e164) = recipient.e164() {
-                            self.session_store
-                                .delete_session(&ProtocolAddress::new(
-                                    e164,
-                                    *extra_device_id,
-                                ))
-                                .await?;
-                        }
+                        self.session_store
+                            .delete_service_addr_device_session(
+                                &recipient,
+                                *extra_device_id,
+                            )
+                            .await?;
                     }
                 }
                 Err(e) => return Err(MessageSenderError::ServiceError(e)),

--- a/libsignal-service/src/session_store.rs
+++ b/libsignal-service/src/session_store.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 use libsignal_protocol::{ProtocolAddress, SessionStore, SignalProtocolError};
 
+use crate::ServiceAddress;
+
 /// This is additional functions required to handle
 /// session deletion. It might be a candidate for inclusion into
 /// the bigger `SessionStore` trait.
@@ -26,4 +28,42 @@ pub trait SessionStoreExt: SessionStore {
         &self,
         address: &str,
     ) -> Result<usize, SignalProtocolError>;
+
+    /// Remove a session record for a recipient ID + device ID tuple.
+    async fn delete_service_addr_device_session(
+        &self,
+        address: &ServiceAddress,
+        device_id: u32,
+    ) -> Result<usize, SignalProtocolError> {
+        let mut count = 0;
+        if let Some(ref uuid) = address.uuid {
+            match self
+                .delete_session(&ProtocolAddress::new(
+                    uuid.to_string(),
+                    device_id,
+                ))
+                .await
+            {
+                Ok(()) => {
+                    count += 1;
+                }
+                Err(SignalProtocolError::SessionNotFound(_)) => (),
+                Err(e) => return Err(e),
+            }
+        }
+        if let Some(e164) = address.e164() {
+            match self
+                .delete_session(&ProtocolAddress::new(e164, device_id))
+                .await
+            {
+                Ok(()) => {
+                    count += 1;
+                }
+                Err(SignalProtocolError::SessionNotFound(_)) => (),
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(count)
+    }
 }


### PR DESCRIPTION
We had `.unwrap()` in Whisperfish on `delete_session`. Since `delete_session` was called on both e164 and uuid sessions, this unconditionally causes a panic.

I have altered Whisperfish (https://gitlab.com/whisperfish/whisperfish/-/commit/246869a7ab293b79aa5299fb53ad7bebbd2688a0) to return `SignalProtocolError::SessionNotFound`, and this pull request makes libsignal-service understand that that's an error to be expected.

Meanwhile, I take the opportunity to refactor the deletion logic, since it was copy-pasted a few times. A better suggestion for that method name is appreciated.