### PR TITLE
Fix sending a sync message to the same device twice.

### DIFF
--- a/libsignal-service/src/service_address.rs
+++ b/libsignal-service/src/service_address.rs
@@ -47,6 +47,8 @@ impl ServiceAddress {
             sub_device_sessions
                 .extend(session_store.get_sub_device_sessions(&e164).await?);
         }
+        sub_device_sessions.sort_unstable();
+        sub_device_sessions.dedup();
         Ok(sub_device_sessions)
     }
 }


### PR DESCRIPTION
This happens when the session store contains overlapping sessions for
the uuid and the e164 phone number of the same account. A device
which has both session receives and shows a sync message twice.