### PR TITLE
Generated fields are now (De)Serializable

### DIFF
--- a/libsignal-service/build.rs
+++ b/libsignal-service/build.rs
@@ -28,5 +28,7 @@ fn main() {
         })
         .collect();
 
-    prost_build::compile_protos(&input, &[protobuf]).unwrap();
+    let mut config = prost_build::Config::new();
+    config.type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]");
+    config.compile_protos(&input, &[protobuf]).unwrap();
 }


### PR DESCRIPTION
Sometimes, it might be useful to be able to Serialize and Unserialize fields.

For instance, if you are fetching a message attachment (with an `AttachmentPointer`) and the internet becomes unavailable, it would be great to keep the message in a separate database to be able to get it later.

Doesn't cost much but might be useful for other future uses.