### PR TITLE
Use new URL scheme for secondary device linking

### DIFF
--- a/libsignal-service/src/provisioning/pipe.rs
+++ b/libsignal-service/src/provisioning/pipe.rs
@@ -139,7 +139,7 @@ impl<WS: WebSocketService> ProvisioningPipe<WS> {
                     {
                         let uuid: ProvisioningUuid =
                             prost::Message::decode(Bytes::from(body.unwrap()))?;
-                        let mut provisioning_url = Url::parse("sgnl://")
+                        let mut provisioning_url = Url::parse("sgnl://linkdevice")
                             .map_err(|e| ProvisioningError::WsError {
                                 reason: e.to_string(),
                             })?;

--- a/libsignal-service/src/provisioning/pipe.rs
+++ b/libsignal-service/src/provisioning/pipe.rs
@@ -139,7 +139,7 @@ impl<WS: WebSocketService> ProvisioningPipe<WS> {
                     {
                         let uuid: ProvisioningUuid =
                             prost::Message::decode(Bytes::from(body.unwrap()))?;
-                        let mut provisioning_url = Url::parse("tsdevice://")
+                        let mut provisioning_url = Url::parse("sgnl://")
                             .map_err(|e| ProvisioningError::WsError {
                                 reason: e.to_string(),
                             })?;


### PR DESCRIPTION
See: https://github.com/signalapp/Signal-Desktop/commit/8064560a5f649c58a98ee4749851d8c923aecc47#diff-b1c3e328d2990b0ab3c57959f539ceb86e248258450042b593428fde18f50e66