### PR TITLE
Implement device name encryption and decryption

### DIFF
--- a/libsignal-service-actix/examples/link.rs
+++ b/libsignal-service-actix/examples/link.rs
@@ -15,11 +15,6 @@ use structopt::StructOpt;
 struct Args {
     #[structopt(long = "servers", short = "s", default_value = "staging")]
     servers: SignalServers,
-    #[structopt(
-        long = "device-name",
-        help = "Name of the device to register in the primary client"
-    )]
-    pub device_name: String,
 }
 
 #[actix_rt::main]

--- a/libsignal-service-hyper/examples/registering.rs
+++ b/libsignal-service-hyper/examples/registering.rs
@@ -97,12 +97,8 @@ async fn confirm_registration<'a, T: PushService>(
                 unidentified_access_key: Some(profile_key.derive_access_key()),
                 unrestricted_unidentified_access: false, // TODO: make this configurable?
                 discoverable_by_phone_number: true,
-                capabilities: DeviceCapabilities {
-                    uuid: true,
-                    gv2: true,
-                    storage: false,
-                    gv1_migration: true,
-                },
+                name: "libsignal-service-hyper test".into(),
+                capabilities: DeviceCapabilities::default(),
             },
         )
         .await

--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -148,6 +148,9 @@ impl HyperPushService {
                 Err(ServiceError::RateLimitExceeded)
             },
             StatusCode::CONFLICT => {
+                let v: serde_json::Value = Self::json(&mut response).await?;
+                println!("{:#?}", v);
+
                 let mismatched_devices =
                     Self::json(&mut response).await.map_err(|e| {
                         log::error!(
@@ -300,13 +303,15 @@ impl PushService for HyperPushService {
     ) -> Result<D, ServiceError>
     where
         for<'de> D: Deserialize<'de>,
-        S: MaybeSend + Serialize,
+        S: MaybeSend + Serialize + std::marker::Send,
     {
         let json = serde_json::to_vec(&value).map_err(|e| {
             ServiceError::JsonDecodeError {
                 reason: e.to_string(),
             }
         })?;
+
+        println!("{}", serde_json::to_string_pretty(&value).unwrap());
 
         let mut response = self
             .request(

--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -45,7 +45,7 @@ prost-build = "0.10"
 
 [dev-dependencies]
 anyhow = "1.0"
-tokio = { version = "1.0", features = ["rt", "macros"] }
+tokio = { version = "1.0", features = ["macros", "rt"] }
 
 rustls = "0.20"
 

--- a/libsignal-service/protobuf/DeviceName.proto
+++ b/libsignal-service/protobuf/DeviceName.proto
@@ -1,0 +1,10 @@
+// Copyright 2018-2021 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package signalservice;
+
+message DeviceName {
+  optional bytes ephemeralPublic = 1;
+  optional bytes syntheticIv     = 2;
+  optional bytes ciphertext      = 3;
+}

--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -43,6 +43,7 @@ where
     P: PreKeyStore + Clone,
     R: Rng + CryptoRng + Clone,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         session_store: S,
         identity_key_store: I,

--- a/libsignal-service/src/groups_v2/operations.rs
+++ b/libsignal-service/src/groups_v2/operations.rs
@@ -44,7 +44,7 @@ impl fmt::Debug for Member {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PendingMember {
     pub uuid: Uuid,
     pub role: Role,
@@ -185,12 +185,12 @@ impl fmt::Debug for GroupChange {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Timer {
     pub duration: u32,
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct GroupJoinInfo {
     pub title: String,
     pub avatar: String,

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -15,6 +15,7 @@ pub mod messagepipe;
 pub mod models;
 pub mod pre_keys;
 pub mod profile_name;
+#[allow(clippy::derive_partial_eq_without_eq)]
 pub mod proto;
 pub mod provisioning;
 pub mod push_service;
@@ -25,7 +26,7 @@ mod session_store;
 pub mod utils;
 
 pub use crate::account_manager::{
-    AccountManager, Profile, ProfileManagerError,
+    decrypt_device_name, AccountManager, Profile, ProfileManagerError,
 };
 pub use crate::service_address::*;
 

--- a/libsignal-service/src/provisioning/mod.rs
+++ b/libsignal-service/src/provisioning/mod.rs
@@ -4,8 +4,9 @@ mod pipe;
 
 pub use cipher::ProvisioningCipher;
 pub use manager::{
-    LinkingManager, ProvisioningManager, SecondaryDeviceProvisioning,
-    VerificationCodeResponse, VerifyAccountResponse,
+    ConfirmCodeResponse, LinkingManager, ProvisioningManager,
+    SecondaryDeviceProvisioning, VerificationCodeResponse,
+    VerifyAccountResponse,
 };
 
 use crate::prelude::ServiceError;

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -97,17 +97,21 @@ pub struct AccountAttributes {
     pub unrestricted_unidentified_access: bool,
     pub discoverable_by_phone_number: bool,
     pub capabilities: DeviceCapabilities,
+    pub name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceCapabilities {
-    pub uuid: bool,
+    // pub uuid: bool,
+    // pub storage: bool,
+    pub announcement_group: bool,
     #[serde(rename = "gv2-3")]
     pub gv2: bool,
-    pub storage: bool,
     #[serde(rename = "gv1-migration")]
     pub gv1_migration: bool,
+    pub sender_key: bool,
+    pub change_number: bool,
 }
 
 #[derive(Clone)]

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -103,8 +103,6 @@ pub struct AccountAttributes {
 #[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceCapabilities {
-    // pub uuid: bool,
-    // pub storage: bool,
     pub announcement_group: bool,
     #[serde(rename = "gv2-3")]
     pub gv2: bool,


### PR DESCRIPTION
This was introduced in Signal-Desktop a few months ago. I'll implement encryption and decryption. In the meantime to make sure people can properly register their devices, we should stop passing a value to the `name` field.

TODO:

- [ ] Use websocket to call the provisioning API

Resolves #124