### PR TITLE
Add missing #[serde(default)] when using serde_optional_base64

### DIFF
--- a/libsignal-service/src/envelope.rs
+++ b/libsignal-service/src/envelope.rs
@@ -186,9 +186,9 @@ pub struct EnvelopeEntity {
     pub source: Option<String>,
     pub source_uuid: Option<String>,
     pub source_device: u32,
-    #[serde(with = "serde_optional_base64")]
+    #[serde(default, with = "serde_optional_base64")]
     pub message: Option<Vec<u8>>,
-    #[serde(with = "serde_optional_base64")]
+    #[serde(default, with = "serde_optional_base64")]
     pub content: Option<Vec<u8>>,
     pub server_timestamp: u64,
     pub guid: String,

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -31,7 +31,7 @@ pub struct ConfirmCodeMessage {
     pub video: bool,
     pub fetches_messages: bool,
     pub pin: Option<String>,
-    #[serde(with = "serde_optional_base64")]
+    #[serde(default, with = "serde_optional_base64")]
     pub unidentified_access_key: Option<Vec<u8>>,
     pub unrestricted_unidentified_access: bool,
     pub discoverable_by_phone_number: bool,

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -84,7 +84,7 @@ pub struct DeviceInfo {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountAttributes {
-    #[serde(with = "serde_optional_base64")]
+    #[serde(default, with = "serde_optional_base64")]
     pub signaling_key: Option<Vec<u8>>,
     pub registration_id: u32,
     pub voice: bool,
@@ -92,7 +92,7 @@ pub struct AccountAttributes {
     pub fetches_messages: bool,
     pub pin: Option<String>,
     pub registration_lock: Option<String>,
-    #[serde(with = "serde_optional_base64")]
+    #[serde(default, with = "serde_optional_base64")]
     pub unidentified_access_key: Option<Vec<u8>>,
     pub unrestricted_unidentified_access: bool,
     pub discoverable_by_phone_number: bool,
@@ -245,11 +245,11 @@ pub struct StaleDevices {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SignalServiceProfile {
-    #[serde(with = "serde_optional_base64")]
+    #[serde(default, with = "serde_optional_base64")]
     pub name: Option<Vec<u8>>,
-    #[serde(with = "serde_optional_base64")]
+    #[serde(default, with = "serde_optional_base64")]
     pub about: Option<Vec<u8>>,
-    #[serde(with = "serde_optional_base64")]
+    #[serde(default, with = "serde_optional_base64")]
     pub about_emoji: Option<Vec<u8>>,
 }
 


### PR DESCRIPTION
The default behaviour of struct deserialization is to assign fields with their respective default value when they are not present in their serialized form.

When using `#[serde(with = "...")`, this is not the case anymore without using `#[serde(default)]`.

This was only discovered because there's a bunch of issues right now around device names and `SignalServiceProfile`.