### PR TITLE
Fix device-name when linking as secondary device

### DIFF
--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -16,8 +16,7 @@ use crate::{
     proto::{ProvisionEnvelope, ProvisionMessage, ProvisioningVersion},
     provisioning::{ProvisioningCipher, ProvisioningError},
     push_service::{
-        AccountAttributes, DeviceCapabilities, HttpAuthOverride, PushService,
-        ServiceError,
+        AccountAttributes, HttpAuthOverride, PushService, ServiceError,
     },
 };
 
@@ -396,36 +395,10 @@ impl<Service: PushService> AccountManager<Service> {
     /// Set profile attributes
     ///
     /// Signal Android does not allow unsetting voice/video.
-    #[allow(clippy::too_many_arguments)]
     pub async fn set_account_attributes(
         &mut self,
-        signaling_key: Option<Vec<u8>>,
-        registration_id: u32,
-        voice: bool,
-        video: bool,
-        fetches_messages: bool,
-        pin: Option<String>,
-        registration_lock: Option<String>,
-        unidentified_access_key: Option<Vec<u8>>,
-        unrestricted_unidentified_access: bool,
-        discoverable_by_phone_number: bool,
-        capabilities: DeviceCapabilities,
+        attributes: AccountAttributes,
     ) -> Result<(), ServiceError> {
-        let attribs = AccountAttributes {
-            signaling_key,
-            registration_id,
-            voice,
-            video,
-            fetches_messages,
-            pin,
-            registration_lock,
-            unidentified_access_key,
-            unrestricted_unidentified_access,
-            discoverable_by_phone_number,
-
-            capabilities,
-        };
-        self.service.set_account_attributes(attribs).await?;
-        Ok(())
+        self.service.set_account_attributes(attributes).await
     }
 }

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -46,7 +46,8 @@ pub struct ConfirmDeviceMessage {
     pub supports_sms: bool,
     pub fetches_messages: bool,
     pub registration_id: u32,
-    pub name: String,
+    // FIXME: the name goes back here when we send this via the websocket
+    //pub name: String,
 }
 
 impl ConfirmCodeMessage {
@@ -281,7 +282,6 @@ impl<P: PushService> LinkingManager<P> {
         &mut self,
         csprng: &mut R,
         signaling_key: SignalingKey,
-        device_name: &str,
         mut tx: Sender<SecondaryDeviceProvisioning>,
     ) -> Result<(), ProvisioningError> {
         // open a websocket without authentication, to receive a tsurl://
@@ -373,7 +373,6 @@ impl<P: PushService> LinkingManager<P> {
                                 supports_sms: false,
                                 fetches_messages: true,
                                 registration_id,
-                                name: device_name.to_string(),
                             },
                         )
                         .await?;

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -86,6 +86,8 @@ pub struct DeviceInfo {
 pub struct AccountAttributes {
     #[serde(default, with = "serde_optional_base64")]
     pub signaling_key: Option<Vec<u8>>,
+    #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+    pub device_name: Option<String>,
     pub registration_id: u32,
     pub voice: bool,
     pub video: bool,


### PR DESCRIPTION
Also ~refactored~emptied a function that wasn't really useful, which will break compilation of downstream clients.

Resolves #121

Workaround before #124