### PR TITLE
Fix registration

### DIFF
--- a/libsignal-service/src/provisioning/mod.rs
+++ b/libsignal-service/src/provisioning/mod.rs
@@ -4,9 +4,8 @@ mod pipe;
 
 pub use cipher::ProvisioningCipher;
 pub use manager::{
-    ConfirmCodeMessage, ConfirmCodeResponse, ConfirmDeviceMessage,
-    LinkingManager, ProvisioningManager, SecondaryDeviceProvisioning,
-    VerificationCodeResponse,
+    ConfirmCodeMessage, ConfirmCodeResponse, LinkingManager,
+    ProvisioningManager, SecondaryDeviceProvisioning, VerificationCodeResponse,
 };
 
 use crate::prelude::ServiceError;

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -86,8 +86,6 @@ pub struct DeviceInfo {
 pub struct AccountAttributes {
     #[serde(default, with = "serde_optional_base64")]
     pub signaling_key: Option<Vec<u8>>,
-    #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
-    pub device_name: Option<String>,
     pub registration_id: u32,
     pub voice: bool,
     pub video: bool,
@@ -146,7 +144,9 @@ impl ProfileKey {
         let cipher = Aes256Gcm::new(key);
         let nonce = GenericArray::from_slice(&[0u8; 12]);
         let buf = [0u8; 16];
-        cipher.encrypt(nonce, &buf[..]).unwrap()
+        let mut ciphertext = cipher.encrypt(nonce, &buf[..]).unwrap();
+        ciphertext.truncate(16);
+        ciphertext
     }
 }
 


### PR DESCRIPTION
* On registration, `AccountAttributes` are now directly serialized and sent to /v1/accounts/code/
* Truncate the unidentified access key to 16 bytes (see: https://github.com/signalapp/Signal-Server/commit/e6237480f88ff95c56a34ad4bebd62da5c1a070b)

TODO: 
- [x] Rebase after #125 is reviewed and merged