### PR TITLE
Log sanitization

### DIFF
--- a/libsignal-service-actix/src/websocket.rs
+++ b/libsignal-service-actix/src/websocket.rs
@@ -137,15 +137,25 @@ impl AwcWebSocket {
         url.set_scheme("wss").expect("valid https base url");
 
         if let Some(credentials) = credentials {
+            log::trace!(
+                "Will start websocket at {:?} with credentials {:?}",
+                url,
+                credentials
+            );
+
             url.query_pairs_mut()
                 .append_pair("login", credentials.login().as_ref())
                 .append_pair(
                     "password",
                     credentials.password.as_ref().expect("a password"),
                 );
+        } else {
+            log::trace!(
+                "Will start websocket at {:?} without credentials",
+                url
+            );
         }
 
-        log::trace!("Will start websocket at {:?}", url);
         let (response, framed) = client.ws(url.as_str()).connect().await?;
 
         log::debug!("WebSocket connected: {:?}", response);

--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -35,6 +35,8 @@ uuid = { version = "0.8", features = [ "serde" ] }
 phonenumber = "0.3"
 hkdf = "0.11"
 
+desan = { version = "0.1.0", git = "https://gitlab.com/whisperfish/desan.git", features = ["uuid"] }
+
 [build-dependencies]
 prost-build = "0.9"
 

--- a/libsignal-service/src/configuration.rs
+++ b/libsignal-service/src/configuration.rs
@@ -24,7 +24,7 @@ pub struct ServiceConfiguration {
 
 pub type SignalingKey = [u8; CIPHER_KEY_SIZE + MAC_KEY_SIZE];
 
-#[derive(Clone)]
+#[derive(Clone, desan::SanitizeDebug)]
 pub struct ServiceCredentials {
     pub uuid: Option<uuid::Uuid>,
     pub phonenumber: phonenumber::PhoneNumber,


### PR DESCRIPTION
I've introduced a new crate [`desan`](https://gitlab.com/whisperfish/desan) under MIT+Apache. `desan` allows to write `#[derive(SanitizeDebug)]`, which derives `Debug` with additional filters for e.g. phone numbers or UUIDs or generic strings.

TODO:

- [ ] Sync desan to the Whisperfish group on Github for visibility.
- [ ] Implement [sanitization for Optionals](https://gitlab.com/whisperfish/desan/-/merge_requests/1) in desan.
- [ ] Add desan to more places: go over everything that derives Debug.
- [ ] Sanitize log statements: go over every `{:?}`-style format and check whether it's either Desan or clean of its own.

FWIW, desan is a "purely compile time dependency" and is basically just a macro. Shouldn't add any overhead that a manual sanitization implementation would have.

Fixes #53