### PR TITLE
SessionStoreExt::compute_safety_number

### DIFF
--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -340,8 +340,8 @@ fn strip_padding(
 }
 
 /// Equivalent of `SignalServiceCipher::getPreferredProtocolAddress`
-pub async fn get_preferred_protocol_address(
-    session_store: &dyn SessionStore,
+pub async fn get_preferred_protocol_address<S: SessionStore>(
+    session_store: &S,
     address: &ServiceAddress,
     device_id: u32,
 ) -> Result<ProtocolAddress, libsignal_protocol::error::SignalProtocolError> {

--- a/libsignal-service/src/service_address.rs
+++ b/libsignal-service/src/service_address.rs
@@ -96,6 +96,18 @@ impl ServiceAddress {
         (self.phonenumber.is_some() && self.phonenumber == other.phonenumber)
             || (self.uuid.is_some() && self.uuid == other.uuid)
     }
+
+    /// Returns e164 if present, uuid otherwise.
+    pub fn e164_or_uuid(&self) -> String {
+        if let Some(e164) = self.e164() {
+            return e164;
+        } else if let Some(ref uuid) = self.uuid {
+            return uuid.to_string();
+        }
+        unreachable!(
+            "an address requires either a UUID or a E164 phone number"
+        );
+    }
 }
 
 impl From<Uuid> for ServiceAddress {


### PR DESCRIPTION
Helper method to bundle all the necessary SessionStore requests into computation of the safety number. Maybe some day we should get rid of the magical constants in here. 5200, really?