### PR TITLE
Update MSRV to 1.61

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,9 +53,7 @@ jobs:
         toolchain: ["stable", "nightly"]
         include:
           - project: "libsignal-service-actix"
-            # toolchain: "1.52.1"
-            toolchain: "nightly-2021-05-06"
-            features: "rust-1-52"
+            toolchain: "1.61.0"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with Signal servers.
 a SailfishOS application.
 The SailfishOS Rust compiler is relatively old, and therefore the MSRV for `libsignal-service-actix` maps on the compiler for that operating system,
 including some lag.
-At moment of writing, this is **Rust 1.52.1**.
+At moment of writing, this is **Rust 1.61**.
 For `libsignal-service-hyper`, we don't mandate MSRV.
 
 ## Contributing

--- a/libsignal-service-actix/Cargo.toml
+++ b/libsignal-service-actix/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2018"
 # the Send requirement in libsignal-service needs to be lifted by enabling `unsend-futures`.
 libsignal-service = { path = "../libsignal-service", features = ["unsend-futures"] }
 
-awc = { version = "3.0.0-beta.19", features=["rustls"] }
+awc = { version = "3.0", features=["rustls"] }
 actix = "0.12"
-actix-http = "3.0.0-beta.19"
+actix-http = "3.0"
 actix-rt = "2.4"
 # mpart-async 0.6 requires Rust 2021, violating MSRV = 1.52
 mpart-async = "0.5"

--- a/libsignal-service-actix/Cargo.toml
+++ b/libsignal-service-actix/Cargo.toml
@@ -13,8 +13,7 @@ awc = { version = "3.0", features=["rustls"] }
 actix = "0.13"
 actix-http = "3.0"
 actix-rt = "2.4"
-# mpart-async 0.6 requires Rust 2021, violating MSRV = 1.52
-mpart-async = "0.5"
+mpart-async = "0.6"
 serde_json = "1.0"
 futures = "0.3"
 bytes = "1"

--- a/libsignal-service-actix/Cargo.toml
+++ b/libsignal-service-actix/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 libsignal-service = { path = "../libsignal-service", features = ["unsend-futures"] }
 
 awc = { version = "3.0", features=["rustls"] }
-actix = "0.12"
+actix = "0.13"
 actix-http = "3.0"
 actix-rt = "2.4"
 # mpart-async 0.6 requires Rust 2021, violating MSRV = 1.52

--- a/libsignal-service-actix/Cargo.toml
+++ b/libsignal-service-actix/Cargo.toml
@@ -31,10 +31,6 @@ base64 = "0.13"
 
 phonenumber = "0.3"
 
-# Pin this for 1.52.1 compat
-proc-macro2 = { version = "=1.0.26", optional = true }
-quote = { version = "=1.0.10", optional = true }
-
 [dev-dependencies]
 env_logger = "0.9"
 image = { version = "0.23", default-features = false, features = ["png"] }
@@ -44,6 +40,3 @@ rand = "0.7"
 structopt = "0.3"
 tokio = { version = "1", features=["macros"] }
 anyhow = "1.0"
-
-[features]
-rust-1-52 = ["proc-macro2", "quote"]


### PR DESCRIPTION
I'm working to get 1.61 on Sailfish OS. https://github.com/sailfishos/rust/pull/15

When the above is more or less approved, we can move on with libsignal-service.