### PR TITLE
Fix sealed sender decryption

### DIFF
--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -144,7 +144,10 @@ where
                     .await?
                     .ok_or(SignalProtocolError::SessionNotFound(sender))?;
 
-                strip_padding_version(session_record.session_version()?, &mut data)?;
+                strip_padding_version(
+                    session_record.session_version()?,
+                    &mut data,
+                )?;
                 Plaintext { metadata, data }
             },
             Type::Ciphertext => {
@@ -179,7 +182,10 @@ where
                     .await?
                     .ok_or(SignalProtocolError::SessionNotFound(sender))?;
 
-                strip_padding_version(session_record.session_version()?, &mut data)?;
+                strip_padding_version(
+                    session_record.session_version()?,
+                    &mut data,
+                )?;
                 Plaintext { metadata, data }
             },
             Type::UnidentifiedSender => {
@@ -226,8 +232,8 @@ where
                 strip_padding(&mut message)?;
 
                 Plaintext {
-                    metadata: metadata,
-                    data: message
+                    metadata,
+                    data: message,
                 }
             },
             _ => {
@@ -373,9 +379,7 @@ fn strip_padding_version(
 }
 
 #[allow(clippy::comparison_chain)]
-fn strip_padding(
-    contents: &mut Vec<u8>,
-) -> Result<(), ServiceError> {
+fn strip_padding(contents: &mut Vec<u8>) -> Result<(), ServiceError> {
     let new_length = Iso7816::unpad(contents)
         .map_err(|e| ServiceError::InvalidFrameError {
             reason: format!("Invalid message padding: {:?}", e),

--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -120,7 +120,7 @@ where
                 let metadata = Metadata {
                     sender: envelope.source_address(),
                     sender_device: envelope.source_device(),
-                    timestamp: envelope.timestamp(),
+                    timestamp: envelope.server_timestamp(),
                     needs_receipt: false,
                 };
 


### PR DESCRIPTION
I mixed up the local UUID and device_id with the recipient's one... I really don't know what went through my mind at the time 😓 

You can see it now works because the message correctly deserializes (it didn't before, and actually never even reached this code).

```
[2022-07-12T14:40:10Z DEBUG libsignal_protocol::sealed_sender] deserializing UnidentifiedSenderMessage with version 1
[2022-07-12T14:40:10Z INFO  libsignal_protocol::sealed_sender] deserialized UnidentifiedSenderMessageContent from 779a6c6b-0985-479a-86fc-ce435a3db130.20 with type PreKey
[2022-07-12T14:40:10Z DEBUG libsignal_protocol::session_cipher] 779a6c6b-0985-479a-86fc-ce435a3db130.20 has existing receiver chain.
[2022-07-12T14:40:10Z INFO  libsignal_protocol::session_cipher] decrypted PreKey message from 779a6c6b-0985-479a-86fc-ce435a3db130.20 with current session state (base key e017108322351554646c10d04f011c4b67bb83cb52acfed23f4429e005f9c90f)
```

This will fix issues like https://github.com/whisperfish/presage/issues/62