### PR TITLE
Fix device linking

### DIFF
--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -308,8 +308,6 @@ impl PushService for HyperPushService {
             }
         })?;
 
-        println!("{}", serde_json::to_string_pretty(&value).unwrap());
-
         let mut response = self
             .request(
                 Method::PUT,

--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -148,9 +148,6 @@ impl HyperPushService {
                 Err(ServiceError::RateLimitExceeded)
             },
             StatusCode::CONFLICT => {
-                let v: serde_json::Value = Self::json(&mut response).await?;
-                println!("{:#?}", v);
-
                 let mismatched_devices =
                     Self::json(&mut response).await.map_err(|e| {
                         log::error!(


### PR DESCRIPTION
The reason behind <https://github.com/whisperfish/libsignal-service-rs/pull/119#issuecomment-1217704738> was a rouge second `Self::json`. This would lead to the whole response being consumed by the first `Self::json` to print the response, the second `Self::json` would then not have to decode a empty response.