### PR TITLE
Update AccountAttributes/DeviceCapabilities from Signal Android

### DIFF
--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -106,10 +106,13 @@ pub struct DeviceCapabilities {
     pub announcement_group: bool,
     #[serde(rename = "gv2-3")]
     pub gv2: bool,
+    pub storage: bool,
     #[serde(rename = "gv1-migration")]
     pub gv1_migration: bool,
     pub sender_key: bool,
     pub change_number: bool,
+    pub stories: bool,
+    pub gift_badges: bool,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Some fields were removed in 4876e9555, while still present in Android. @gferon, could you elaborate why you removed them?

Additionally, I would want to point out that the same commit changed an example, in which `DeviceCapabilities::default()` is now used instead of manually setting capabilities. Maybe it should document that this is not how a real application should behave.