### PR TITLE
Throw a compilation error when hyper is compiled with unsend-futures

### DIFF
--- a/libsignal-service-hyper/src/lib.rs
+++ b/libsignal-service-hyper/src/lib.rs
@@ -1,5 +1,8 @@
 #![recursion_limit = "256"]
 
+#[cfg(feature = "unsend-futures")]
+compile_error!("`libsignal-service-hyper` cannot be compiled with the feature `unsend-futures` from `libsignal-service`.");
+
 pub mod push_service;
 pub mod websocket;
 


### PR DESCRIPTION
This throws a descriptive compilation error when libsignal-service-hyper is compiled with unsend-futures like discussed in the Matrix.