### PR TITLE
Don't send messages to recipients default device twice

### DIFF
--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -653,7 +653,12 @@ where
         devices
             .extend(recipient.sub_device_sessions(&self.session_store).await?);
         devices.sort_unstable();
+
+        let original_device_count = devices.len();
         devices.dedup();
+        if devices.len() != original_device_count {
+            log::warn!("SessionStoreExt::get_sub_device_sessions should return unique device id's, and should not include DEFAULT_DEVICE_ID.");
+        }
 
         // When sending to ourselves, don't include the local device
         if myself {

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -652,14 +652,13 @@ where
 
         devices
             .extend(recipient.sub_device_sessions(&self.session_store).await?);
+        devices.sort_unstable();
         devices.dedup();
 
         // When sending to ourselves, don't include the local device
         if myself {
             devices.retain(|id| *id != self.device_id);
         }
-
-        devices.sort_unstable();
 
         for device_id in devices {
             trace!("sending message to device {}", device_id);


### PR DESCRIPTION
I'm not sure if this is the correct place to correct the issue, or if the logic behind this is even correct, but it seems to work for me.

For some time, Whisperfish seems to be sending double messages to some recipients. I believe this is what happens:

- Send the message to the default device ID (in my Whisperfish, this is always `1`)
- Get the list of sub-device session IDs (list of all IDs: `1,2,3...`)
- Send the message to all IDs
- Default device ID gets the message sent twice

I tested this with both p2p conversations (with myself using my spare SIM, and another contact) and group messages, and it seems to prevent duplicates - but only for the most part. One user of Flare reported still getting duplicates, so I don't really know what could be causing that.