### PR TITLE
Change get_sub_device_sessions doc

### DIFF
--- a/libsignal-service/src/session_store.rs
+++ b/libsignal-service/src/session_store.rs
@@ -10,7 +10,9 @@ use crate::{push_service::DEFAULT_DEVICE_ID, ServiceAddress};
 #[cfg_attr(feature = "unsend-futures", async_trait::async_trait(?Send))]
 #[cfg_attr(not(feature = "unsend-futures"), async_trait::async_trait)]
 pub trait SessionStoreExt: SessionStore {
-    /// Get the IDs of all known devices with active sessions for a recipient.
+    /// Get the IDs of all known sub devices with active sessions for a recipient.
+    ///
+    /// This should return every device except for the main device [DEFAULT_DEVICE_ID].
     async fn get_sub_device_sessions(
         &self,
         name: &str,


### PR DESCRIPTION
The root cause of #156 is that the implementor of `SessionStoreExt::get_sub_device_sessions` should never include the main device (because it is no sub device). This patch documents this fact. We should, additionally, include something along the line of #156 in spirit of defensive programming.