### PR TITLE
Expose proto::Content::from_proto

### DIFF
--- a/libsignal-service/src/content.rs
+++ b/libsignal-service/src/content.rs
@@ -32,7 +32,7 @@ impl Content {
     }
 
     /// Converts a proto::Content into a public Content, including metadata.
-    pub(crate) fn from_proto(
+    pub fn from_proto(
         p: crate::proto::Content,
         metadata: Metadata,
     ) -> Option<Self> {


### PR DESCRIPTION
This is useful when serializing messages with prost externally, for example.