### PR TITLE
Disable oldtime feature of chrono

### DIFF
--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 prost = "0.10"
 http = "0.2"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde", "clock"], default-features = false }
 log = "0.4"
 bincode = "1.3"
 


### PR DESCRIPTION
This will make us benefit from the fix to https://rustsec.org/advisories/RUSTSEC-2020-0071