### PR TITLE
Bump uuid to ~1

### DIFF
--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -35,7 +35,7 @@ aes-gcm = "0.9"
 block-modes = "0.8"
 rand = "0.7"
 
-uuid = { version = "0.8", features = ["serde"] }
+uuid = { version = "1", features = ["serde"] }
 phonenumber = "0.3"
 hkdf = "0.12"
 serde_json = "1.0.85"


### PR DESCRIPTION
libsignal-protocol is on this version now, gives version clashes.