### PR TITLE
Refactor common websocket code into a SignalWebSocket system

### DIFF
--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -11,8 +11,8 @@ use hyper::{
 use hyper_rustls::HttpsConnector;
 use hyper_timeout::TimeoutConnector;
 use libsignal_service::{
-    configuration::*, messagepipe::WebSocketService, prelude::ProtobufMessage,
-    push_service::*, MaybeSend,
+    configuration::*, prelude::ProtobufMessage, push_service::*,
+    websocket::SignalWebSocket, MaybeSend,
 };
 use serde::{Deserialize, Serialize};
 use tokio_rustls::rustls;
@@ -463,20 +463,17 @@ impl PushService for HyperPushService {
         &mut self,
         path: &str,
         credentials: Option<ServiceCredentials>,
-    ) -> Result<
-        (
-            Self::WebSocket,
-            <Self::WebSocket as WebSocketService>::Stream,
-        ),
-        ServiceError,
-    > {
-        Ok(TungsteniteWebSocket::with_tls_config(
+    ) -> Result<SignalWebSocket, ServiceError> {
+        let (ws, stream) = TungsteniteWebSocket::with_tls_config(
             Self::tls_config(&self.cfg),
             self.cfg.base_url(Endpoint::Service),
             path,
             credentials.as_ref(),
         )
-        .await?)
+        .await?;
+        let (ws, task) = SignalWebSocket::from_socket(ws, stream);
+        tokio::task::spawn_local(task);
+        Ok(ws)
     }
 }
 

--- a/libsignal-service/src/envelope.rs
+++ b/libsignal-service/src/envelope.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // XXX: remove when all constants on bottom are used.
-
 use prost::Message;
 use uuid::Uuid;
 

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -24,6 +24,7 @@ pub mod sender;
 pub mod service_address;
 mod session_store;
 pub mod utils;
+pub mod websocket;
 
 pub use crate::account_manager::{
     decrypt_device_name, AccountManager, Profile, ProfileManagerError,

--- a/libsignal-service/src/messagepipe.rs
+++ b/libsignal-service/src/messagepipe.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use bytes::Bytes;
 use futures::{
     channel::{
@@ -7,9 +5,8 @@ use futures::{
         oneshot,
     },
     prelude::*,
-    stream::{FusedStream, FuturesUnordered},
+    stream::FusedStream,
 };
-use prost::Message;
 
 pub use crate::{
     configuration::ServiceCredentials,
@@ -19,7 +16,7 @@ pub use crate::{
     },
 };
 
-use crate::push_service::ServiceError;
+use crate::{push_service::ServiceError, websocket::SignalWebSocket};
 
 pub enum WebSocketStreamItem {
     Message(Bytes),
@@ -34,242 +31,79 @@ pub trait WebSocketService {
     async fn send_message(&mut self, msg: Bytes) -> Result<(), ServiceError>;
 }
 
-pub struct MessagePipe<WS: WebSocketService> {
-    ws: WS,
-    stream: WS::Stream,
+pub struct MessagePipe {
+    ws: SignalWebSocket,
     credentials: ServiceCredentials,
-    requests: HashMap<u64, oneshot::Sender<WebSocketResponseMessage>>,
 }
 
-impl<WS: WebSocketService> MessagePipe<WS> {
+impl MessagePipe {
     pub fn from_socket(
-        ws: WS,
-        stream: WS::Stream,
+        ws: SignalWebSocket,
         credentials: ServiceCredentials,
     ) -> Self {
-        MessagePipe {
-            ws,
-            stream,
-            credentials,
-            requests: HashMap::new(),
-        }
+        MessagePipe { ws, credentials }
     }
 
-    async fn send_response(
-        &mut self,
-        r: WebSocketResponseMessage,
-    ) -> Result<(), ServiceError> {
-        let msg = WebSocketMessage {
-            r#type: Some(web_socket_message::Type::Response.into()),
-            response: Some(r),
-            ..Default::default()
-        };
-        let buffer = msg.encode_to_vec();
-        self.ws.send_message(buffer.into()).await
-    }
-
-    /// Sends a request without returning a response.
-    async fn transmit_request(
-        &mut self,
-        r: WebSocketRequestMessage,
-    ) -> Result<(), ServiceError> {
-        log::trace!("Sending request {:?}", r);
-        let msg = WebSocketMessage {
-            r#type: Some(web_socket_message::Type::Request.into()),
-            request: Some(r),
-            ..Default::default()
-        };
-        let buffer = msg.encode_to_vec();
-        self.ws.send_message(buffer.into()).await?;
-        log::trace!("request on route.");
-        Ok(())
-    }
-
-    /// Send request and returns the response as a *nested* Future.
-    ///
-    /// The outer Future sends the request, the inner Future resolves to the
-    /// response.
-    pub async fn send_request(
-        &mut self,
-        r: WebSocketRequestMessage,
-    ) -> Result<
-        impl Future<Output = Result<WebSocketResponseMessage, ServiceError>>,
-        ServiceError,
-    > {
-        let id = r.id;
-
-        self.transmit_request(r).await?;
-
-        let (sink, send) = oneshot::channel();
-
-        if let Some(id) = id {
-            self.requests.insert(id, sink);
-            Ok(send.map_err(|_| ServiceError::WsClosing {
-                reason: "WebSocket closing while sending request.".into(),
-            }))
-        } else {
-            Err(ServiceError::InvalidFrameError {
-                reason: "Send request without ID".into(),
-            })
-        }
-    }
-
-    /// Worker task that
+    /// Worker task that processes the websocket into Envelopes
     async fn run(
         mut self,
         mut sink: Sender<Result<Envelope, ServiceError>>,
     ) -> Result<(), mpsc::SendError> {
-        use futures::future::LocalBoxFuture;
+        let mut ws = self.ws.clone();
+        let mut stream = ws
+            .take_request_stream()
+            .expect("web socket request handler not in use");
 
-        // This is a runtime-agnostic, poor man's `::spawn(Future<Output=()>)`.
-        let mut background_work = FuturesUnordered::<LocalBoxFuture<()>>::new();
-        // a pending task is added, as to never end the background worker until
-        // it's dropped.
-        background_work.push(futures::future::pending().boxed_local());
-
-        loop {
-            futures::select! {
-                // WebsocketConnection::onMessage(ByteString)
-                frame = self.stream.next() => match frame {
-                    Some(WebSocketStreamItem::Message(frame)) => {
-                        let env = self.process_frame(frame).await.transpose();
-                        if let Some(env) = env {
-                            sink.send(env).await?;
-                        }
-                    },
-                    Some(WebSocketStreamItem::KeepAliveRequest) => {
-                        let request = self.send_keep_alive().await;
-                        match request {
-                            Ok(request) => {
-                                let request = request.map(|response| {
-                                    if let Err(e) = response {
-                                        log::warn!("Error from keep alive: {:?}", e);
-                                    }
-                                });
-                                background_work.push(request.boxed_local());
-                            },
-                            Err(e) => log::warn!("Could not send keep alive: {}", e),
-                        }
-                    },
-                    None => {
-                        log::debug!("WebSocket stream ended.");
-                        break;
-                    },
-                },
-                _ = background_work.next() => {
-                    // no op
-                },
-                complete => {
-                    log::info!("select! complete");
-                }
+        while let Some((request, responder)) = stream.next().await {
+            // WebsocketConnection::onMessage(ByteString)
+            let env =
+                self.process_request(request, responder).await.transpose();
+            if let Some(env) = env {
+                sink.send(env).await?;
             }
         }
+
+        ws.return_request_stream(stream);
 
         Ok(())
     }
 
-    async fn send_keep_alive(
+    async fn process_request(
         &mut self,
-    ) -> Result<impl Future<Output = Result<(), ServiceError>>, ServiceError>
-    {
-        let request = WebSocketRequestMessage {
-            id: Some(
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as u64,
-            ),
-            path: Some("/v1/keepalive".into()),
-            verb: Some("GET".into()),
-            ..Default::default()
-        };
-        let request = self.send_request(request).await?;
-        Ok(async move {
-            let response = request.await?;
-            if response.status() == 200 {
-                Ok(())
-            } else {
-                log::warn!(
-                    "Response code for keep-alive is not 200: {:?}",
-                    response
-                );
-                Err(ServiceError::UnhandledResponseCode {
-                    http_code: response.status() as u16,
-                })
-            }
-        })
-    }
-
-    async fn process_frame(
-        &mut self,
-        frame: Bytes,
+        request: WebSocketRequestMessage,
+        responder: oneshot::Sender<WebSocketResponseMessage>,
     ) -> Result<Option<Envelope>, ServiceError> {
-        let msg = WebSocketMessage::decode(frame)?;
-        log::trace!("Decoded {:?}", msg);
+        // Java: MessagePipe::read
+        let response = WebSocketResponseMessage::from_request(&request);
 
-        use web_socket_message::Type;
-        match (msg.r#type(), msg.request, msg.response) {
-            (Type::Unknown, _, _) => Err(ServiceError::InvalidFrameError {
-                reason: "Unknown frame type".into(),
-            }),
-            (Type::Request, Some(request), _) => {
-                // Java: MessagePipe::read
-                let response = WebSocketResponseMessage::from_request(&request);
+        // XXX Change the signature of this method to yield an enum of Envelope and EndOfQueue
+        let result = if request.is_signal_service_envelope() {
+            let body = if let Some(body) = request.body.as_ref() {
+                body
+            } else {
+                return Err(ServiceError::InvalidFrameError {
+                    reason: "Request without body.".into(),
+                });
+            };
+            Some(Envelope::decrypt(
+                body,
+                self.credentials
+                    .signaling_key
+                    .as_ref()
+                    .expect("signaling_key required to decrypt envelopes"),
+                request.is_signal_key_encrypted(),
+            )?)
+        } else {
+            None
+        };
 
-                let result = if request.is_signal_service_envelope() {
-                    let body = if let Some(body) = request.body.as_ref() {
-                        body
-                    } else {
-                        return Err(ServiceError::InvalidFrameError {
-                            reason: "Request without body.".into(),
-                        });
-                    };
-                    Some(Envelope::decrypt(
-                        body,
-                        self.credentials.signaling_key.as_ref().expect(
-                            "signaling_key required to decrypt envelopes",
-                        ),
-                        request.is_signal_key_encrypted(),
-                    )?)
-                } else {
-                    None
-                };
+        responder
+            .send(response)
+            .map_err(|_| ServiceError::WsClosing {
+                reason: "could not respond to message pipe request".into(),
+            })?;
 
-                if let Err(e) = self.send_response(response).await {
-                    log::error!("Could not send response: {}", e);
-                }
-
-                Ok(result)
-            },
-            (Type::Request, None, _) => Err(ServiceError::InvalidFrameError {
-                reason: "Type was request, but does not contain request."
-                    .into(),
-            }),
-            (Type::Response, _, Some(response)) => {
-                if let Some(id) = response.id {
-                    if let Some(responder) = self.requests.remove(&id) {
-                        if let Err(e) = responder.send(response) {
-                            log::warn!(
-                                "Could not deliver response for id {}: {:?}",
-                                id,
-                                e
-                            );
-                        }
-                    } else {
-                        log::warn!(
-                            "Response for non existing request: {:?}",
-                            response
-                        );
-                    }
-                }
-
-                Ok(None)
-            },
-            (Type::Response, _, None) => Err(ServiceError::InvalidFrameError {
-                reason: "Type was response, but does not contain response."
-                    .into(),
-            }),
-        }
+        Ok(result)
     }
 
     /// Returns the stream of `Envelope`s

--- a/libsignal-service/src/messagepipe.rs
+++ b/libsignal-service/src/messagepipe.rs
@@ -44,6 +44,11 @@ impl MessagePipe {
         MessagePipe { ws, credentials }
     }
 
+    /// Return a SignalWebSocket for sending messages and other purposes beyond receiving messages.
+    pub fn ws(&self) -> SignalWebSocket {
+        self.ws.clone()
+    }
+
     /// Worker task that processes the websocket into Envelopes
     async fn run(
         mut self,

--- a/libsignal-service/src/proto.rs
+++ b/libsignal-service/src/proto.rs
@@ -47,7 +47,7 @@ impl WebSocketResponseMessage {
     /// Equivalent of
     /// `SignalServiceMessagePipe::isSignalServiceEnvelope(WebSocketMessage)`.
     pub fn from_request(msg: &WebSocketRequestMessage) -> Self {
-        if msg.is_signal_service_envelope() {
+        if msg.is_signal_service_envelope() || msg.is_queue_empty() {
             WebSocketResponseMessage {
                 id: msg.id,
                 status: Some(200),

--- a/libsignal-service/src/proto.rs
+++ b/libsignal-service/src/proto.rs
@@ -9,6 +9,11 @@ impl WebSocketRequestMessage {
             && self.path.as_deref() == Some("/api/v1/message")
     }
 
+    pub fn is_queue_empty(&self) -> bool {
+        self.verb.as_deref() == Some("PUT")
+            && self.path.as_deref() == Some("/api/v1/queue/empty")
+    }
+
     /// Equivalent of
     /// `SignalServiceMessagePipe::isSignalKeyEncrypted(WebSocketMessage)`.
     pub fn is_signal_key_encrypted(&self) -> bool {

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -234,7 +234,7 @@ impl<P: PushService> LinkingManager<P> {
         mut tx: Sender<SecondaryDeviceProvisioning>,
     ) -> Result<(), ProvisioningError> {
         // open a websocket without authentication, to receive a tsurl://
-        let (ws, stream) = self
+        let ws = self
             .push_service
             .ws("/v1/websocket/provisioning/", None)
             .await?;
@@ -242,7 +242,7 @@ impl<P: PushService> LinkingManager<P> {
         // see libsignal-protocol-c / signal_protocol_key_helper_generate_registration_id
         let registration_id = csprng.gen_range(1, 256);
 
-        let provisioning_pipe = ProvisioningPipe::from_socket(ws, stream)?;
+        let provisioning_pipe = ProvisioningPipe::from_socket(ws)?;
         let provision_stream = provisioning_pipe.stream();
         pin_mut!(provision_stream);
         while let Some(step) = provision_stream.next().await {

--- a/libsignal-service/src/provisioning/mod.rs
+++ b/libsignal-service/src/provisioning/mod.rs
@@ -1,6 +1,6 @@
-mod cipher;
-mod manager;
-mod pipe;
+pub(crate) mod cipher;
+pub(crate) mod manager;
+pub(crate) mod pipe;
 
 pub use cipher::ProvisioningCipher;
 pub use manager::{

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -9,6 +9,7 @@ use crate::{
     proto::{attachment_pointer::AttachmentIdentifier, AttachmentPointer},
     sender::{OutgoingPushMessages, SendMessageResponse},
     utils::{serde_base64, serde_optional_base64},
+    websocket::SignalWebSocket,
     MaybeSend, ServiceAddress,
 };
 
@@ -413,13 +414,7 @@ pub trait PushService: MaybeSend {
         &mut self,
         path: &str,
         credentials: Option<ServiceCredentials>,
-    ) -> Result<
-        (
-            Self::WebSocket,
-            <Self::WebSocket as WebSocketService>::Stream,
-        ),
-        ServiceError,
-    >;
+    ) -> Result<SignalWebSocket, ServiceError>;
 
     /// Fetches a list of all devices tied to the authenticated account.
     ///

--- a/libsignal-service/src/receiver.rs
+++ b/libsignal-service/src/receiver.rs
@@ -53,12 +53,12 @@ impl<Service: PushService> MessageReceiver<Service> {
     pub async fn create_message_pipe(
         &mut self,
         credentials: ServiceCredentials,
-    ) -> Result<MessagePipe<Service::WebSocket>, MessageReceiverError> {
-        let (ws, stream) = self
+    ) -> Result<MessagePipe, MessageReceiverError> {
+        let ws = self
             .service
             .ws("/v1/websocket/", Some(credentials.clone()))
             .await?;
-        Ok(MessagePipe::from_socket(ws, stream, credentials))
+        Ok(MessagePipe::from_socket(ws, credentials))
     }
 
     pub async fn retrieve_contacts(

--- a/libsignal-service/src/websocket.rs
+++ b/libsignal-service/src/websocket.rs
@@ -1,0 +1,330 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use std::future::Future;
+
+use bytes::Bytes;
+use futures::channel::oneshot::Canceled;
+use futures::channel::{mpsc, oneshot};
+use futures::future::BoxFuture;
+use futures::stream::FuturesUnordered;
+use futures::{SinkExt, Stream, StreamExt};
+use prost::Message;
+
+use crate::messagepipe::{WebSocketService, WebSocketStreamItem};
+use crate::proto::{
+    web_socket_message, WebSocketMessage, WebSocketRequestMessage,
+    WebSocketResponseMessage,
+};
+use crate::push_service::ServiceError;
+
+type RequestStreamItem = (
+    WebSocketRequestMessage,
+    oneshot::Sender<WebSocketResponseMessage>,
+);
+
+pub struct SignalRequestStream {
+    inner: mpsc::Receiver<RequestStreamItem>,
+}
+
+impl Stream for SignalRequestStream {
+    type Item = RequestStreamItem;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let inner = &mut self.inner;
+        futures::pin_mut!(inner);
+        Stream::poll_next(inner, cx)
+    }
+}
+
+/// A dispatching web socket client for the Signal web socket API.
+///
+/// This structure can be freely cloned.
+#[derive(Clone)]
+pub struct SignalWebSocket {
+    inner: Arc<Mutex<SignalWebSocketInner>>,
+    request_sink: mpsc::Sender<(
+        WebSocketRequestMessage,
+        oneshot::Sender<Result<WebSocketResponseMessage, ServiceError>>,
+    )>,
+}
+
+struct SignalWebSocketInner {
+    stream: Option<SignalRequestStream>,
+}
+
+struct SignalWebSocketProcess<WS: WebSocketService> {
+    /// Receives requests from the application, which we forward to Signal.
+    requests: mpsc::Receiver<(
+        WebSocketRequestMessage,
+        oneshot::Sender<Result<WebSocketResponseMessage, ServiceError>>,
+    )>,
+    /// Signal's requests should go in here, to be delivered to the application.
+    request_sink: mpsc::Sender<RequestStreamItem>,
+
+    outgoing_request_map: HashMap<
+        u64,
+        oneshot::Sender<Result<WebSocketResponseMessage, ServiceError>>,
+    >,
+
+    outgoing_responses: FuturesUnordered<
+        BoxFuture<'static, Result<WebSocketResponseMessage, Canceled>>,
+    >,
+
+    // WS backend stuff
+    ws: WS,
+    stream: WS::Stream,
+}
+
+impl<WS: WebSocketService> SignalWebSocketProcess<WS> {
+    async fn process_frame(
+        &mut self,
+        frame: Bytes,
+    ) -> Result<(), ServiceError> {
+        let msg = WebSocketMessage::decode(frame)?;
+        log::trace!("Decoded {:?}", msg);
+
+        use web_socket_message::Type;
+        match (msg.r#type(), msg.request, msg.response) {
+            (Type::Unknown, _, _) => Err(ServiceError::InvalidFrameError {
+                reason: "Unknown frame type".into(),
+            }),
+            (Type::Request, Some(request), _) => {
+                let (sink, recv) = oneshot::channel();
+                self.request_sink.send((request, sink)).await.map_err(
+                    |_| ServiceError::WsError {
+                        reason: "request handler failed".into(),
+                    },
+                )?;
+                self.outgoing_responses.push(Box::pin(recv));
+
+                Ok(())
+            },
+            (Type::Request, None, _) => Err(ServiceError::InvalidFrameError {
+                reason: "Type was request, but does not contain request."
+                    .into(),
+            }),
+            (Type::Response, _, Some(response)) => {
+                if let Some(id) = response.id {
+                    if let Some(responder) =
+                        self.outgoing_request_map.remove(&id)
+                    {
+                        if let Err(e) = responder.send(Ok(response)) {
+                            log::warn!(
+                                "Could not deliver response for id {}: {:?}",
+                                id,
+                                e
+                            );
+                        }
+                    } else {
+                        log::warn!(
+                            "Response for non existing request: {:?}",
+                            response
+                        );
+                    }
+                }
+
+                Ok(())
+            },
+            (Type::Response, _, None) => Err(ServiceError::InvalidFrameError {
+                reason: "Type was response, but does not contain response."
+                    .into(),
+            }),
+        }
+    }
+
+    // XXX Maybe this should return a Result
+    async fn run(mut self) {
+        loop {
+            futures::select! {
+                // Process requests from the application, forward them to Signal
+                x = self.requests.next() => {
+                    match x {
+                        Some((mut request, responder)) => {
+                            // Regenerate ID if already in the table
+                            request.id = Some(
+                                request.id.filter(|x| self.outgoing_request_map.contains_key(x)).unwrap_or(
+                                    std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .unwrap()
+                                        .as_millis() as u64,
+                                ),
+                            );
+                            log::trace!("Sending request {:?}", request);
+
+                            self.outgoing_request_map.insert(request.id.unwrap(), responder);
+                            let msg = WebSocketMessage {
+                                r#type: Some(web_socket_message::Type::Request.into()),
+                                request: Some(request),
+                                ..Default::default()
+                            };
+                            let buffer = msg.encode_to_vec();
+                            if let Err(e) = self.ws.send_message(buffer.into()).await {
+                                log::error!("sending message: {}", e);
+                            }
+                        }
+                        None => {
+                            log::debug!("SignalWebSocket: end of application request stream; socket closing");
+                            break;
+                        }
+                    }
+                }
+                web_socket_item = self.stream.next() => {
+                    match web_socket_item {
+                        Some(WebSocketStreamItem::Message(frame)) => {
+                            if let Err(e) = self.process_frame(frame).await {
+                                log::error!("Processing incoming frame: {}.  Stopping WebSocket.", e);
+                                break;
+                            }
+                        }
+                        Some(WebSocketStreamItem::KeepAliveRequest) => {
+                            todo!()
+                            // let request = self.send_keep_alive().await;
+                            // match request {
+                            //     Ok(request) => {
+                            //         let request = request.map(|response| {
+                            //             if let Err(e) = response {
+                            //                 log::warn!("Error from keep alive: {:?}", e);
+                            //             }
+                            //         });
+                            //         background_work.push(request.boxed_local());
+                            //     },
+                            //     Err(e) => log::warn!("Could not send keep alive: {}", e),
+                            // }
+                        }
+                        None => {
+                            log::debug!("SignalWebSocket: end of web request stream; socket closing");
+                            break;
+                        }
+                    }
+                }
+                response = self.outgoing_responses.next() => {
+                    match response {
+                        Some(Ok(response)) => {
+                            log::trace!("Sending response {:?}", response);
+
+                            let msg = WebSocketMessage {
+                                r#type: Some(web_socket_message::Type::Response.into()),
+                                response: Some(response),
+                                ..Default::default()
+                            };
+                            let buffer = msg.encode_to_vec();
+                            if let Err(e) = self.ws.send_message(buffer.into()).await {
+                                log::error!("sending message: {}", e);
+                            }
+                        }
+                        Some(Err(e)) => {
+                            log::error!("could not generate response to a Signal request; responder was canceled: {}", e);
+                        }
+                        None => {
+                            unreachable!("outgoing responses should never fuse")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl SignalWebSocket {
+    fn inner_locked(&self) -> MutexGuard<'_, SignalWebSocketInner> {
+        self.inner.lock().unwrap()
+    }
+
+    pub fn from_socket<WS: WebSocketService + 'static>(
+        ws: WS,
+        stream: WS::Stream,
+    ) -> (Self, std::pin::Pin<Box<dyn Future<Output = ()>>>) {
+        // Create process
+        let (incoming_request_sink, incoming_request_stream) = mpsc::channel(1);
+        let (outgoing_request_sink, outgoing_requests) = mpsc::channel(1);
+
+        let process = SignalWebSocketProcess {
+            requests: outgoing_requests,
+            request_sink: incoming_request_sink,
+            outgoing_request_map: HashMap::default(),
+            // Initializing the FuturesUnordered with a `pending` future means it will never fuse
+            // itself, so an "empty" FuturesUnordered will still allow new futures to be added.
+            outgoing_responses: vec![
+                Box::pin(futures::future::pending()) as BoxFuture<_>
+            ]
+            .into_iter()
+            .collect(),
+            ws,
+            stream,
+        };
+        let process = process.run();
+
+        (
+            Self {
+                request_sink: outgoing_request_sink,
+                inner: Arc::new(Mutex::new(SignalWebSocketInner {
+                    stream: Some(SignalRequestStream {
+                        inner: incoming_request_stream,
+                    }),
+                })),
+            },
+            Box::pin(process),
+        )
+    }
+
+    pub(crate) fn take_request_stream(
+        &mut self,
+    ) -> Option<SignalRequestStream> {
+        self.inner_locked().stream.take()
+    }
+
+    pub(crate) fn return_request_stream(&mut self, r: SignalRequestStream) {
+        self.inner_locked().stream.replace(r);
+    }
+
+    // XXX Ideally, this should take an *async* closure, then we could get rid of the
+    // `take_request_stream` and `return_request_stream`.
+    pub async fn with_request_stream<
+        R: 'static,
+        F: FnOnce(&mut SignalRequestStream) -> R,
+    >(
+        &mut self,
+        f: F,
+    ) -> R {
+        let mut s = self
+            .inner_locked()
+            .stream
+            .take()
+            .expect("request stream invariant");
+        let r = f(&mut s);
+        self.inner_locked().stream.replace(s);
+        r
+    }
+
+    pub fn request(
+        &mut self,
+        r: WebSocketRequestMessage,
+    ) -> impl Future<Output = Result<WebSocketResponseMessage, ServiceError>>
+    {
+        let (sink, recv): (
+            oneshot::Sender<Result<WebSocketResponseMessage, ServiceError>>,
+            _,
+        ) = oneshot::channel();
+
+        let mut request_sink = self.request_sink.clone();
+        async move {
+            if let Err(_e) = request_sink.send((r, sink)).await {
+                return Err(ServiceError::WsClosing {
+                    reason: "WebSocket closing while sending request.".into(),
+                });
+            }
+            // Handle the oneshot sender error for dropped senders.
+            match recv.await {
+                Ok(x) => x,
+                Err(_) => Err(ServiceError::WsClosing {
+                    reason: "WebSocket closing while waiting for a response."
+                        .into(),
+                }),
+            }
+        }
+    }
+}

--- a/libsignal-service/src/websocket.rs
+++ b/libsignal-service/src/websocket.rs
@@ -42,7 +42,8 @@ impl Stream for SignalRequestStream {
 
 /// A dispatching web socket client for the Signal web socket API.
 ///
-/// This structure can be freely cloned.
+/// This structure can be freely cloned, since this acts as a *facade* for multiple entry and exit
+/// points.
 #[derive(Clone)]
 pub struct SignalWebSocket {
     inner: Arc<Mutex<SignalWebSocketInner>>,


### PR DESCRIPTION
TODO:
- [x] Reimplement keep-alive in `SignalWebSocket`.
- ~~[ ] Move keep-alive trigger code over to SignalWebSocket, if possible. I think it is possible...~~ Never mind, time is executor-dependent.
- ~~[ ] Clean-up pass over MessagePipe and ProvisioningPipe~~ I don't think we can make these more minimal.

This lays the foundation of sending messages via the WebSocket instead of a separate REST endpoint, and thus supersedes #101.