### PR TITLE
More flags in Metadata

### DIFF
--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -142,6 +142,7 @@ where
                     sender_device: envelope.source_device(),
                     timestamp: envelope.server_timestamp(),
                     needs_receipt: false,
+                    unidentified_sender: false,
                 };
 
                 let mut data = message_decrypt_prekey(
@@ -182,6 +183,7 @@ where
                     sender_device: envelope.source_device(),
                     timestamp: envelope.timestamp(),
                     needs_receipt: false,
+                    unidentified_sender: false,
                 };
 
                 let mut data = message_decrypt_signal(
@@ -248,6 +250,7 @@ where
                     sender_device: device_id.into(),
                     timestamp: envelope.timestamp(),
                     needs_receipt: false,
+                    unidentified_sender: true,
                 };
 
                 strip_padding(&mut message)?;

--- a/libsignal-service/src/content.rs
+++ b/libsignal-service/src/content.rs
@@ -17,6 +17,7 @@ pub struct Metadata {
     pub sender_device: u32,
     pub timestamp: u64,
     pub needs_receipt: bool,
+    pub unidentified_sender: bool,
 }
 
 impl Metadata {


### PR DESCRIPTION
I want to store whether messages were received via sealed sending or sender keys, so I'm exposing these as flags in Metadata