### PR TITLE
Correct needs_receipt implementation

### DIFF
--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -245,12 +245,19 @@ where
                     relay: None,
                 };
 
+                let needs_receipt = if envelope.source_uuid.is_some() {
+                    log::warn!("Received an unidentified delivery over an identified channel.  Marking needs_receipt=false");
+                    false
+                } else {
+                    true
+                };
+
                 let metadata = Metadata {
                     sender,
                     sender_device: device_id.into(),
                     timestamp: envelope.timestamp(),
-                    needs_receipt: false,
                     unidentified_sender: true,
+                    needs_receipt,
                 };
 
                 strip_padding(&mut message)?;


### PR DESCRIPTION
Cfr. [SignalServiceCipher::decrypt](https://github.com/signalapp/Signal-Android/blob/4e871e2dd83c6ff4616bca1a32623608bd00e568/libsignal/service/src/main/java/org/whispersystems/signalservice/api/crypto/SignalServiceCipher.java#L204), is this correct, @gferon?