### PR TITLE
MessageSender to use the WS instead of a service

### DIFF
--- a/libsignal-service-actix/src/push_service.rs
+++ b/libsignal-service-actix/src/push_service.rs
@@ -123,7 +123,6 @@ impl AwcPushService {
 impl PushService for AwcPushService {
     // This is in principle known at compile time, but long to write out.
     type ByteStream = Box<dyn futures::io::AsyncRead + Unpin>;
-    type WebSocket = AwcWebSocket;
 
     async fn get_json<T>(
         &mut self,

--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -252,7 +252,6 @@ impl HyperPushService {
 impl PushService for HyperPushService {
     // This is in principle known at compile time, but long to write out.
     type ByteStream = Box<dyn futures::io::AsyncRead + Unpin>;
-    type WebSocket = TungsteniteWebSocket;
 
     async fn get_json<T>(
         &mut self,

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -4,7 +4,6 @@ use crate::{
     configuration::{Endpoint, ServiceCredentials},
     envelope::*,
     groups_v2::GroupDecryptionError,
-    messagepipe::WebSocketService,
     pre_keys::{PreKeyEntity, PreKeyState, SignedPreKeyEntity},
     profile_cipher::ProfileCipherError,
     proto::{attachment_pointer::AttachmentIdentifier, AttachmentPointer},
@@ -404,7 +403,6 @@ pub enum ServiceError {
 #[cfg_attr(feature = "unsend-futures", async_trait::async_trait(?Send))]
 #[cfg_attr(not(feature = "unsend-futures"), async_trait::async_trait)]
 pub trait PushService: MaybeSend {
-    type WebSocket: WebSocketService;
     type ByteStream: futures::io::AsyncRead + Unpin;
 
     async fn get_json<T>(

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -229,7 +229,7 @@ pub struct PreKeyResponseItem {
 }
 
 impl PreKeyResponseItem {
-    fn into_bundle(
+    pub(crate) fn into_bundle(
         self,
         identity: IdentityKey,
     ) -> Result<PreKeyBundle, SignalProtocolError> {

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -19,6 +19,7 @@ use crate::{
     },
     push_service::*,
     session_store::SessionStoreExt,
+    websocket::SignalWebSocket,
     ServiceAddress,
 };
 
@@ -75,6 +76,7 @@ pub struct AttachmentSpec {
 /// Equivalent of Java's `SignalServiceMessageSender`.
 #[derive(Clone)]
 pub struct MessageSender<Service, S, I, SP, P, SK, R> {
+    ws: SignalWebSocket,
     service: Service,
     cipher: ServiceCipher<S, I, SP, P, SK, R>,
     csprng: R,
@@ -135,6 +137,7 @@ where
     R: Rng + CryptoRng + Clone,
 {
     pub fn new(
+        ws: SignalWebSocket,
         service: Service,
         cipher: ServiceCipher<S, I, SP, P, SK, R>,
         csprng: R,
@@ -145,6 +148,7 @@ where
     ) -> Self {
         MessageSender {
             service,
+            ws,
             cipher,
             csprng,
             session_store,
@@ -199,7 +203,7 @@ where
 
         // Request upload attributes
         log::trace!("Requesting upload attributes");
-        let attrs = self.service.get_attachment_v2_upload_attributes().await?;
+        let attrs = self.ws.get_attachment_v2_upload_attributes().await?;
 
         log::trace!("Uploading attachment");
         let (id, digest) = self
@@ -479,7 +483,7 @@ where
                 online,
             };
 
-            match self.service.send_messages(messages).await {
+            match self.ws.send_messages(messages).await {
                 Ok(SendMessageResponse { needs_sync }) => {
                     log::debug!("message sent!");
                     return Ok(SentMessage {

--- a/libsignal-service/src/websocket/attachment_service.rs
+++ b/libsignal-service/src/websocket/attachment_service.rs
@@ -1,0 +1,11 @@
+use crate::push_service::AttachmentV2UploadAttributes;
+
+use super::*;
+
+impl SignalWebSocket {
+    pub async fn get_attachment_v2_upload_attributes(
+        &mut self,
+    ) -> Result<AttachmentV2UploadAttributes, ServiceError> {
+        self.get_json("/v2/attachments/form/upload").await
+    }
+}

--- a/libsignal-service/src/websocket/sender.rs
+++ b/libsignal-service/src/websocket/sender.rs
@@ -1,0 +1,13 @@
+use crate::sender::{OutgoingPushMessages, SendMessageResponse};
+
+use super::*;
+
+impl SignalWebSocket {
+    pub async fn send_messages<'a>(
+        &mut self,
+        messages: OutgoingPushMessages<'a>,
+    ) -> Result<SendMessageResponse, ServiceError> {
+        let path = format!("/v1/messages/{}", messages.destination);
+        self.put_json(&path, messages).await
+    }
+}


### PR DESCRIPTION
This seems to have been deprecated for a long time now, and it minimizes the amount of needed connections.