### PR TITLE
Set avatar true if there's no request for deletion.

### DIFF
--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -819,7 +819,7 @@ pub trait PushService: MaybeSend {
             name,
             about,
             about_emoji: emoji,
-            avatar: matches!(avatar, AvatarWrite::NewAvatar(_)),
+            avatar: !matches!(avatar, AvatarWrite::NoAvatar),
             same_avatar: matches!(avatar, AvatarWrite::RetainAvatar),
             commitment: &commitment,
         };


### PR DESCRIPTION
As far as the server code goes, this should work.

https://github.com/signalapp/Signal-Server/blob/main/service/src/main/java/org/whispersystems/textsecuregcm/entities/CreateProfileRequest.java#L97

@gferon would you mind double-checking my logic here?