### PR TITLE
Split GroupsManager::get_group into two separate functions

### DIFF
--- a/libsignal-service/src/groups_v2/mod.rs
+++ b/libsignal-service/src/groups_v2/mod.rs
@@ -4,7 +4,7 @@ mod operations;
 pub mod utils;
 
 pub use manager::{
-    CredentialsCache, CredentialsCacheError, GroupsManager,
+    decrypt_group, CredentialsCache, CredentialsCacheError, GroupsManager,
     InMemoryCredentialsCache,
 };
 pub use operations::{Group, GroupChange, GroupChanges, GroupDecryptionError};

--- a/libsignal-service/src/groups_v2/operations.rs
+++ b/libsignal-service/src/groups_v2/operations.rs
@@ -74,7 +74,7 @@ impl fmt::Debug for RequestingMember {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Group {
     pub title: String,
     pub avatar: String,


### PR DESCRIPTION
I need this to be able to store the encrypted group data in the local DB of `presage`. This is also a slight improvement because we can hide a bunch of implementation details (no need to know how to build a `group_secret_params` and `credentials`).