### PR TITLE
Remove our own ProfileKey type and expose the zkgroup one

### DIFF
--- a/libsignal-service-hyper/examples/registering.rs
+++ b/libsignal-service-hyper/examples/registering.rs
@@ -2,12 +2,13 @@ use std::str::FromStr;
 
 use libsignal_service::configuration::{ServiceCredentials, SignalServers};
 use libsignal_service::prelude::phonenumber::PhoneNumber;
+use libsignal_service::prelude::ProfileKey;
 use libsignal_service::provisioning::{
     generate_registration_id, ProvisioningManager, VerificationCodeResponse,
     VerifyAccountResponse,
 };
 use libsignal_service::push_service::{
-    AccountAttributes, DeviceCapabilities, ProfileKey, PushService,
+    AccountAttributes, DeviceCapabilities, ProfileKeyExt, PushService,
     ServiceError,
 };
 use libsignal_service::USER_AGENT;
@@ -81,7 +82,7 @@ async fn confirm_registration<'a, T: PushService>(
     let signaling_key = generate_signaling_key();
     let mut profile_key = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut profile_key);
-    let profile_key = ProfileKey(profile_key);
+    let profile_key = ProfileKey::create(profile_key);
 
     manager
         .confirm_verification_code(

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -81,7 +81,10 @@ pub mod prelude {
     pub use phonenumber;
     pub use prost::Message as ProtobufMessage;
     pub use uuid::{Error as UuidError, Uuid};
-    pub use zkgroup::groups::{GroupMasterKey, GroupSecretParams};
+    pub use zkgroup::{
+        groups::{GroupMasterKey, GroupSecretParams},
+        profiles::ProfileKey,
+    };
 
     pub mod protocol {
         pub use crate::session_store::SessionStoreExt;

--- a/libsignal-service/src/models.rs
+++ b/libsignal-service/src/models.rs
@@ -1,8 +1,11 @@
+use std::convert::TryInto;
+
 use crate::{proto::Verified, ParseServiceAddressError, ServiceAddress};
 
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use zkgroup::profiles::ProfileKey;
 
 /// Attachment represents an attachment received from a peer
 #[derive(Debug, Serialize, Deserialize)]
@@ -74,5 +77,14 @@ impl Contact {
                 }
             }),
         })
+    }
+
+    pub fn profile_key(&self) -> Result<ProfileKey, ParseContactError> {
+        Ok(ProfileKey::create(
+            self.profile_key
+                .clone()
+                .try_into()
+                .map_err(|_| ParseContactError::MissingProfileKey)?,
+        ))
     }
 }


### PR DESCRIPTION
Trying to remove inconsistencies with types from `libsignal` and our own. We only used this one for the `.derive_access_key` method, which I moved into a `ProfileKeyExt` trait instead.