### PR TITLE
Use string instead of u32 for confirmation_code

### DIFF
--- a/libsignal-service-hyper/examples/registering.rs
+++ b/libsignal-service-hyper/examples/registering.rs
@@ -75,7 +75,7 @@ pub async fn register_user<'a, T: PushService>(
 
 async fn confirm_registration<'a, T: PushService>(
     manager: &mut ProvisioningManager<'a, T>,
-    confirmation_code: u32,
+    confirmation_code: String,
 ) -> Result<VerifyAccountResponse, ServiceError> {
     let registration_id = generate_registration_id(&mut rand::thread_rng());
     let signaling_key = generate_signaling_key();
@@ -137,8 +137,8 @@ fn let_user_solve_captcha() -> String {
     "EnterCaptchaHere".to_string()
 }
 
-fn let_user_enter_confirmation_code() -> u32 {
-    12345
+fn let_user_enter_confirmation_code() -> String {
+    "12345".to_string()
 }
 
 fn does_user_want_voice_confirmation() -> bool {

--- a/libsignal-service-hyper/examples/registering.rs
+++ b/libsignal-service-hyper/examples/registering.rs
@@ -75,7 +75,7 @@ pub async fn register_user<'a, T: PushService>(
 
 async fn confirm_registration<'a, T: PushService>(
     manager: &mut ProvisioningManager<'a, T>,
-    confirmation_code: String,
+    confirmation_code: impl AsRef<str>,
 ) -> Result<VerifyAccountResponse, ServiceError> {
     let registration_id = generate_registration_id(&mut rand::thread_rng());
     let signaling_key = generate_signaling_key();
@@ -137,8 +137,8 @@ fn let_user_solve_captcha() -> String {
     "EnterCaptchaHere".to_string()
 }
 
-fn let_user_enter_confirmation_code() -> String {
-    "12345".to_string()
+fn let_user_enter_confirmation_code() -> &'static str {
+    "12345"
 }
 
 fn does_user_want_voice_confirmation() -> bool {

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -172,7 +172,7 @@ impl<'a, P: PushService + 'a> ProvisioningManager<'a, P> {
 
     pub async fn confirm_verification_code(
         &mut self,
-        confirm_code: u32,
+        confirm_code: String,
         account_attributes: AccountAttributes,
     ) -> Result<VerifyAccountResponse, ServiceError> {
         self.push_service

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -172,13 +172,13 @@ impl<'a, P: PushService + 'a> ProvisioningManager<'a, P> {
 
     pub async fn confirm_verification_code(
         &mut self,
-        confirm_code: String,
+        confirm_code: impl AsRef<str>,
         account_attributes: AccountAttributes,
     ) -> Result<VerifyAccountResponse, ServiceError> {
         self.push_service
             .put_json(
                 Endpoint::Service,
-                &format!("/v1/accounts/code/{}", confirm_code),
+                &format!("/v1/accounts/code/{}", confirm_code.as_ref()),
                 self.auth_override(),
                 account_attributes,
             )


### PR DESCRIPTION
The `confirmation_code` should be a string because else when the code contains a `0` as first digit this will be stripped.