### PR TITLE
Restore parsing of contacts phone numbers

### DIFF
--- a/libsignal-service/src/receiver.rs
+++ b/libsignal-service/src/receiver.rs
@@ -130,7 +130,7 @@ impl Iterator for DeviceContactsIterator {
 
         let contact_details: ContactDetails =
             prost::Message::decode_length_delimited(&mut self.decrypted_buffer)
-                .map_err(ParseContactError::ProtobufError)
+                .map_err(ParseContactError::Protobuf)
                 .ok()?;
 
         let avatar_data = if let Some(Avatar {


### PR DESCRIPTION
This got lost as part of #198 because we decided to use the `ServiceAddress` type in the `Contact` struct, which doesn't really work anymore.