### PR TITLE
Blanket impl for mutable references to credentialcache

### DIFF
--- a/libsignal-service/src/groups_v2/manager.rs
+++ b/libsignal-service/src/groups_v2/manager.rs
@@ -108,6 +108,26 @@ impl CredentialsCache for InMemoryCredentialsCache {
     }
 }
 
+impl<T: CredentialsCache> CredentialsCache for &mut T {
+    fn clear(&mut self) -> Result<(), CredentialsCacheError> {
+        (**self).clear()
+    }
+
+    fn get(
+        &self,
+        key: &i64,
+    ) -> Result<Option<&AuthCredentialResponse>, CredentialsCacheError> {
+        (**self).get(key)
+    }
+
+    fn write(
+        &mut self,
+        map: HashMap<i64, AuthCredentialResponse>,
+    ) -> Result<(), CredentialsCacheError> {
+        (**self).write(map)
+    }
+}
+
 pub struct GroupsManager<S: PushService, C: CredentialsCache> {
     self_uuid: Uuid,
     push_service: S,


### PR DESCRIPTION
Before, the GroupManager took `&mut CredentialCache`, but I cannot move my impl into the GroupManager, so I need a blanket `impl CredentialCache for &mut CredentialCache` :-)