### PR TITLE
Propagate NotFoundError

### DIFF
--- a/libsignal-service-actix/src/push_service.rs
+++ b/libsignal-service-actix/src/push_service.rs
@@ -79,6 +79,10 @@ impl AwcPushService {
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
                 Err(ServiceError::Unauthorized)
             },
+            StatusCode::NOT_FOUND => {
+                // This is 404 and means that e.g. recipient is not registered
+                Err(ServiceError::NotFoundError)
+            },
             StatusCode::PAYLOAD_TOO_LARGE => {
                 // This is 413 and means rate limit exceeded for Signal.
                 Err(ServiceError::RateLimitExceeded)
@@ -119,7 +123,11 @@ impl AwcPushService {
             // XXX: fill in rest from PushServiceSocket
             code => {
                 let contents = response.body().await;
-                log::trace!("Unhandled response with body: {:?}", contents);
+                log::trace!(
+                    "Unhandled response {} with body: {:?}",
+                    code.as_u16(),
+                    contents,
+                );
                 Err(ServiceError::UnhandledResponseCode {
                     http_code: code.as_u16(),
                 })

--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -143,6 +143,10 @@ impl HyperPushService {
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
                 Err(ServiceError::Unauthorized)
             },
+            StatusCode::NOT_FOUND => {
+                // This is 404 and means that e.g. recipient is not registered
+                Err(ServiceError::NotFoundError)
+            },
             StatusCode::PAYLOAD_TOO_LARGE => {
                 // This is 413 and means rate limit exceeded for Signal.
                 Err(ServiceError::RateLimitExceeded)
@@ -192,8 +196,9 @@ impl HyperPushService {
             // XXX: fill in rest from PushServiceSocket
             code => {
                 log::trace!(
-                    "Unhandled response with body: {}",
-                    Self::text(&mut response).await?
+                    "Unhandled response {} with body: {}",
+                    code.as_u16(),
+                    Self::text(&mut response).await?,
                 );
                 Err(ServiceError::UnhandledResponseCode {
                     http_code: code.as_u16(),

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -382,6 +382,9 @@ pub enum ServiceError {
 
     #[error(transparent)]
     ParseServiceAddress(#[from] ParseServiceAddressError),
+
+    #[error("Not found.")]
+    NotFoundError,
 }
 
 #[cfg_attr(feature = "unsend-futures", async_trait::async_trait(?Send))]

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -734,17 +734,12 @@ where
                     log::trace!("Get prekeys OK");
                     ok
                 },
-                Err(e) => {
-                    log::trace!("Get prekeys failed: {}", e);
-                    return match e {
-                        ServiceError::NotFoundError => {
-                            Err(MessageSenderError::NotFound {
-                                uuid: recipient.uuid,
-                            })
-                        },
-                        _ => Err(From::from(e)),
-                    };
+                Err(ServiceError::NotFoundError) => {
+                    return Err(MessageSenderError::NotFound {
+                        uuid: recipient.uuid,
+                    });
                 },
+                Err(e) => Err(e)?,
             };
             for pre_key_bundle in pre_keys {
                 if recipient == &self.local_address

--- a/libsignal-service/src/session_store.rs
+++ b/libsignal-service/src/session_store.rs
@@ -39,7 +39,7 @@ pub trait SessionStoreExt: SessionStore {
         address: &ProtocolAddress,
     ) -> Result<usize, SignalProtocolError> {
         let mut count = 0;
-        match self.delete_session(&address).await {
+        match self.delete_session(address).await {
             Ok(()) => {
                 count += 1;
             },

--- a/libsignal-service/src/websocket.rs
+++ b/libsignal-service/src/websocket.rs
@@ -397,6 +397,7 @@ impl SignalWebSocket {
         match response.status() {
             200 | 204 => json(response.body()),
             401 | 403 => Err(ServiceError::Unauthorized),
+            404 => Err(ServiceError::NotFoundError),
             413 /* PAYLOAD_TOO_LARGE */ => Err(ServiceError::RateLimitExceeded) ,
             409 /* CONFLICT */ => {
                 let mismatched_devices: MismatchedDevices =


### PR DESCRIPTION
When getting prekeys, getting a 404 reply means that the recipient is unregistered. This needs to be handled in the application side, so let's propagate this error out of libsignal-service.

Required by https://gitlab.com/whisperfish/whisperfish/-/merge_requests/396 which doesn't compile against master, but it soon should!