### PR TITLE
Make groups struct ser/de

### DIFF
--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -9,30 +9,30 @@ readme = "../README.md"
 [dependencies]
 libsignal-protocol = { git = "https://github.com/signalapp/libsignal", tag = "v0.22.2" }
 zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.22.2" }
-async-trait = "0.1"
-url = { version = "2.1", features = ["serde"] }
-base64 = "0.13"
-bytes = "1"
-futures = "0.3"
-thiserror = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-prost = "0.10"
-chrono = { version = "0.4", features = ["serde", "clock"], default-features = false }
-log = "0.4"
-bincode = "1.3"
 
-sha2 = "0.10"
-hmac = "0.12"
-hex = "0.4"
 aes = { version = "0.7", features = ["ctr"] }
 aes-gcm = "0.9"
+async-trait = "0.1"
+base64 = "0.13"
+bincode = "1.3"
 block-modes = "0.8"
-rand = "0.7"
-
-uuid = { version = "1", features = ["serde"] }
-phonenumber = "0.3"
+bytes = "1"
+chrono = { version = "0.4", features = ["serde", "clock"], default-features = false }
+derivative = "2.2"
+futures = "0.3"
+hex = "0.4"
 hkdf = "0.12"
+hmac = "0.12"
+log = "0.4"
+phonenumber = "0.3"
+prost = "0.10"
+rand = "0.7"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"
+sha2 = "0.10"
+thiserror = "1.0"
+url = { version = "2.1", features = ["serde"] }
+uuid = { version = "1", features = ["serde"] }
 
 [build-dependencies]
 prost-build = "0.10"

--- a/libsignal-service/src/groups_v2/manager.rs
+++ b/libsignal-service/src/groups_v2/manager.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     configuration::Endpoint,
     groups_v2::model::{Group, GroupChanges},
-    groups_v2::operations::{GroupDecryptionError, GroupOperations},
+    groups_v2::operations::{GroupDecodingError, GroupOperations},
     prelude::{PushService, ServiceError},
     proto::GroupContextV2,
     push_service::{HttpAuth, HttpAuthOverride},
@@ -294,12 +294,12 @@ impl<S: PushService, C: CredentialsCache> GroupsManager<S, C> {
     pub fn decrypt_group_context(
         &self,
         group_context: GroupContextV2,
-    ) -> Result<Option<GroupChanges>, GroupDecryptionError> {
+    ) -> Result<Option<GroupChanges>, GroupDecodingError> {
         match (group_context.master_key, group_context.group_change) {
             (Some(master_key), Some(group_change)) => {
                 let master_key_bytes: [u8; 32] = master_key
                     .try_into()
-                    .map_err(|_| GroupDecryptionError::WrongBlob)?;
+                    .map_err(|_| GroupDecodingError::WrongBlob)?;
                 let group_master_key = GroupMasterKey::new(master_key_bytes);
                 let group_secret_params =
                     GroupSecretParams::derive_from_master_key(group_master_key);

--- a/libsignal-service/src/groups_v2/manager.rs
+++ b/libsignal-service/src/groups_v2/manager.rs
@@ -6,9 +6,8 @@ use std::{
 
 use crate::{
     configuration::Endpoint,
-    groups_v2::operations::{
-        Group, GroupChanges, GroupDecryptionError, GroupOperations,
-    },
+    groups_v2::model::{Group, GroupChanges},
+    groups_v2::operations::{GroupDecryptionError, GroupOperations},
     prelude::{PushService, ServiceError},
     proto::GroupContextV2,
     push_service::{HttpAuth, HttpAuthOverride},

--- a/libsignal-service/src/groups_v2/mod.rs
+++ b/libsignal-service/src/groups_v2/mod.rs
@@ -1,5 +1,6 @@
 //! Everything needed to support [Signal Groups v2](https://signal.org/blog/new-groups/)
 mod manager;
+mod model;
 mod operations;
 pub mod utils;
 
@@ -7,4 +8,5 @@ pub use manager::{
     decrypt_group, CredentialsCache, CredentialsCacheError, GroupsManager,
     InMemoryCredentialsCache,
 };
-pub use operations::{Group, GroupChange, GroupChanges, GroupDecryptionError};
+pub use model::{Group, GroupChange, GroupChanges};
+pub use operations::GroupDecryptionError;

--- a/libsignal-service/src/groups_v2/mod.rs
+++ b/libsignal-service/src/groups_v2/mod.rs
@@ -12,4 +12,4 @@ pub use model::{
     AccessControl, Group, GroupChange, GroupChanges, Member, PendingMember,
     RequestingMember, Timer,
 };
-pub use operations::GroupDecryptionError;
+pub use operations::GroupDecodingError;

--- a/libsignal-service/src/groups_v2/model.rs
+++ b/libsignal-service/src/groups_v2/model.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use zkgroup::profiles::ProfileKey;
 
-use super::GroupDecryptionError;
+use super::GroupDecodingError;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Role {
@@ -139,7 +139,7 @@ pub struct Timer {
 /// Conversion from protobuf definitions
 
 impl TryFrom<i32> for Role {
-    type Error = GroupDecryptionError;
+    type Error = GroupDecodingError;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         use crate::proto::member::Role::*;
@@ -147,13 +147,13 @@ impl TryFrom<i32> for Role {
             Some(Unknown) => Ok(Role::Unknown),
             Some(Default) => Ok(Role::Default),
             Some(Administrator) => Ok(Role::Administrator),
-            None => Err(GroupDecryptionError::WrongEnumValue),
+            None => Err(GroupDecodingError::WrongEnumValue),
         }
     }
 }
 
 impl TryFrom<i32> for AccessRequired {
-    type Error = GroupDecryptionError;
+    type Error = GroupDecodingError;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         use crate::proto::access_control::AccessRequired::*;
@@ -163,13 +163,13 @@ impl TryFrom<i32> for AccessRequired {
             Some(Member) => Ok(AccessRequired::Member),
             Some(Administrator) => Ok(AccessRequired::Administrator),
             Some(Unsatisfiable) => Ok(AccessRequired::Unsatisfiable),
-            None => Err(GroupDecryptionError::WrongEnumValue),
+            None => Err(GroupDecodingError::WrongEnumValue),
         }
     }
 }
 
 impl TryFrom<crate::proto::AccessControl> for AccessControl {
-    type Error = GroupDecryptionError;
+    type Error = GroupDecodingError;
 
     fn try_from(
         value: crate::proto::AccessControl,

--- a/libsignal-service/src/groups_v2/model.rs
+++ b/libsignal-service/src/groups_v2/model.rs
@@ -1,0 +1,257 @@
+use std::{convert::TryFrom, convert::TryInto, fmt};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use zkgroup::profiles::ProfileKey;
+
+use super::GroupDecryptionError;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Role {
+    Unknown,
+    Default,
+    Administrator,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct Member {
+    pub uuid: Uuid,
+    pub role: Role,
+    pub profile_key: ProfileKey,
+    pub joined_at_revision: u32,
+}
+
+impl PartialEq for Member {
+    fn eq(&self, other: &Self) -> bool {
+        self.uuid == other.uuid
+    }
+}
+
+impl fmt::Debug for Member {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Member")
+            .field("uuid", &self.uuid)
+            .field("role", &self.role)
+            .field("joined_at_revision", &self.joined_at_revision)
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct PendingMember {
+    pub uuid: Uuid,
+    pub role: Role,
+    pub added_by_uuid: Uuid,
+    pub timestamp: u64,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct RequestingMember {
+    pub uuid: Uuid,
+    pub profile_key: ProfileKey,
+    pub timestamp: u64,
+}
+
+impl PartialEq for RequestingMember {
+    fn eq(&self, other: &Self) -> bool {
+        self.uuid == other.uuid
+    }
+}
+
+impl fmt::Debug for RequestingMember {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RequestingMember")
+            .field("uuid", &self.uuid)
+            .field("timestamp", &self.timestamp)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum AccessRequired {
+    Unknown,
+    Any,
+    Member,
+    Administrator,
+    Unsatisfiable,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AccessControl {
+    pub attributes: AccessRequired,
+    pub members: AccessRequired,
+    pub add_from_invite_link: AccessRequired,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Group {
+    pub title: String,
+    pub avatar: String,
+    pub disappearing_messages_timer: Option<Timer>,
+    pub access_control: Option<AccessControl>,
+    pub revision: u32,
+    pub members: Vec<Member>,
+    pub pending_members: Vec<PendingMember>,
+    pub requesting_members: Vec<RequestingMember>,
+    pub invite_link_password: Vec<u8>,
+    pub description: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct GroupChanges {
+    pub editor: Uuid,
+    pub revision: u32,
+    pub changes: Vec<GroupChange>,
+}
+
+#[derive(Clone)]
+pub enum GroupChange {
+    NewMember(Member),
+    DeleteMember(Uuid),
+    ModifyMemberRole { uuid: Uuid, role: Role },
+    ModifyMemberProfileKey { uuid: Uuid, profile_key: ProfileKey },
+    // for open groups
+    NewPendingMember(PendingMember),
+    DeletePendingMember(Uuid),
+    PromotePendingMember { uuid: Uuid, profile_key: ProfileKey },
+    // when admin control is enabled
+    NewRequestingMember(RequestingMember),
+    DeleteRequestingMember(Uuid),
+    PromoteRequestingMember { uuid: Uuid, role: Role },
+    // group metadata
+    Title(String),
+    Avatar(String),
+    Timer(Option<Timer>),
+    Description(Option<String>),
+    AttributeAccess(AccessRequired),
+    MemberAccess(AccessRequired),
+    InviteLinkAccess(AccessRequired),
+    InviteLinkPassword(String),
+    AnnouncementOnly(bool),
+}
+
+impl fmt::Debug for GroupChange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NewMember(arg0) => {
+                f.debug_tuple("NewMember").field(arg0).finish()
+            },
+            Self::DeleteMember(arg0) => {
+                f.debug_tuple("DeleteMember").field(arg0).finish()
+            },
+            Self::ModifyMemberRole { uuid, role } => f
+                .debug_struct("ModifyMemberRole")
+                .field("uuid", uuid)
+                .field("role", role)
+                .finish(),
+            Self::ModifyMemberProfileKey { uuid, .. } => f
+                .debug_struct("ModifyMemberProfileKey")
+                .field("uuid", uuid)
+                .finish(),
+            Self::NewPendingMember(arg0) => {
+                f.debug_tuple("NewPendingMember").field(arg0).finish()
+            },
+            Self::DeletePendingMember(arg0) => {
+                f.debug_tuple("DeletePendingMember").field(arg0).finish()
+            },
+            Self::PromotePendingMember { uuid, .. } => f
+                .debug_struct("PromotePendingMember")
+                .field("uuid", uuid)
+                .finish(),
+            Self::NewRequestingMember(arg0) => {
+                f.debug_tuple("NewRequestingMember").field(arg0).finish()
+            },
+            Self::DeleteRequestingMember(arg0) => {
+                f.debug_tuple("DeleteRequestingMember").field(arg0).finish()
+            },
+            Self::PromoteRequestingMember { uuid, role } => f
+                .debug_struct("PromoteRequestingMember")
+                .field("uuid", uuid)
+                .field("role", role)
+                .finish(),
+            Self::Title(arg0) => f.debug_tuple("Title").field(arg0).finish(),
+            Self::Avatar(arg0) => f.debug_tuple("Avatar").field(arg0).finish(),
+            Self::Timer(arg0) => f.debug_tuple("Timer").field(arg0).finish(),
+            Self::Description(arg0) => {
+                f.debug_tuple("Description").field(arg0).finish()
+            },
+            Self::AttributeAccess(arg0) => {
+                f.debug_tuple("AttributeAccess").field(arg0).finish()
+            },
+            Self::MemberAccess(arg0) => {
+                f.debug_tuple("MemberAccess").field(arg0).finish()
+            },
+            Self::InviteLinkAccess(arg0) => {
+                f.debug_tuple("InviteLinkAccess").field(arg0).finish()
+            },
+            Self::InviteLinkPassword(arg0) => {
+                f.debug_tuple("InviteLinkPassword").field(arg0).finish()
+            },
+            Self::AnnouncementOnly(arg0) => {
+                f.debug_tuple("AnnouncementOnly").field(arg0).finish()
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct Timer {
+    pub duration: u32,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct GroupJoinInfo {
+    pub title: String,
+    pub avatar: String,
+    pub member_count: u32,
+    pub add_from_invite_link: i32,
+    pub revision: u32,
+    pub pending_admin_approval: bool,
+    pub description: String,
+}
+
+/// Conversion from protobuf definitions
+
+impl TryFrom<i32> for Role {
+    type Error = GroupDecryptionError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        use crate::proto::member::Role::*;
+        match crate::proto::member::Role::from_i32(value) {
+            Some(Unknown) => Ok(Role::Unknown),
+            Some(Default) => Ok(Role::Default),
+            Some(Administrator) => Ok(Role::Administrator),
+            None => Err(GroupDecryptionError::WrongEnumValue),
+        }
+    }
+}
+
+impl TryFrom<i32> for AccessRequired {
+    type Error = GroupDecryptionError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        use crate::proto::access_control::AccessRequired::*;
+        match crate::proto::access_control::AccessRequired::from_i32(value) {
+            Some(Unknown) => Ok(AccessRequired::Unknown),
+            Some(Any) => Ok(AccessRequired::Any),
+            Some(Member) => Ok(AccessRequired::Member),
+            Some(Administrator) => Ok(AccessRequired::Administrator),
+            Some(Unsatisfiable) => Ok(AccessRequired::Unsatisfiable),
+            None => Err(GroupDecryptionError::WrongEnumValue),
+        }
+    }
+}
+
+impl TryFrom<crate::proto::AccessControl> for AccessControl {
+    type Error = GroupDecryptionError;
+
+    fn try_from(
+        value: crate::proto::AccessControl,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            attributes: value.attributes.try_into()?,
+            members: value.members.try_into()?,
+            add_from_invite_link: value.add_from_invite_link.try_into()?,
+        })
+    }
+}

--- a/libsignal-service/src/groups_v2/model.rs
+++ b/libsignal-service/src/groups_v2/model.rs
@@ -1,5 +1,6 @@
-use std::{convert::TryFrom, convert::TryInto, fmt};
+use std::{convert::TryFrom, convert::TryInto};
 
+use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use zkgroup::profiles::ProfileKey;
@@ -13,10 +14,12 @@ pub enum Role {
     Administrator,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Derivative, Clone, Deserialize, Serialize)]
+#[derivative(Debug)]
 pub struct Member {
     pub uuid: Uuid,
     pub role: Role,
+    #[derivative(Debug = "ignore")]
     pub profile_key: ProfileKey,
     pub joined_at_revision: u32,
 }
@@ -24,16 +27,6 @@ pub struct Member {
 impl PartialEq for Member {
     fn eq(&self, other: &Self) -> bool {
         self.uuid == other.uuid
-    }
-}
-
-impl fmt::Debug for Member {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Member")
-            .field("uuid", &self.uuid)
-            .field("role", &self.role)
-            .field("joined_at_revision", &self.joined_at_revision)
-            .finish()
     }
 }
 
@@ -45,9 +38,11 @@ pub struct PendingMember {
     pub timestamp: u64,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Derivative, Clone, Deserialize, Serialize)]
+#[derivative(Debug)]
 pub struct RequestingMember {
     pub uuid: Uuid,
+    #[derivative(Debug = "ignore")]
     pub profile_key: ProfileKey,
     pub timestamp: u64,
 }
@@ -55,15 +50,6 @@ pub struct RequestingMember {
 impl PartialEq for RequestingMember {
     fn eq(&self, other: &Self) -> bool {
         self.uuid == other.uuid
-    }
-}
-
-impl fmt::Debug for RequestingMember {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RequestingMember")
-            .field("uuid", &self.uuid)
-            .field("timestamp", &self.timestamp)
-            .finish()
     }
 }
 
@@ -97,27 +83,42 @@ pub struct Group {
     pub description: Option<String>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct GroupChanges {
     pub editor: Uuid,
     pub revision: u32,
     pub changes: Vec<GroupChange>,
 }
 
-#[derive(Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub enum GroupChange {
     NewMember(Member),
     DeleteMember(Uuid),
-    ModifyMemberRole { uuid: Uuid, role: Role },
-    ModifyMemberProfileKey { uuid: Uuid, profile_key: ProfileKey },
+    ModifyMemberRole {
+        uuid: Uuid,
+        role: Role,
+    },
+    ModifyMemberProfileKey {
+        uuid: Uuid,
+        #[derivative(Debug = "ignore")]
+        profile_key: ProfileKey,
+    },
     // for open groups
     NewPendingMember(PendingMember),
     DeletePendingMember(Uuid),
-    PromotePendingMember { uuid: Uuid, profile_key: ProfileKey },
+    PromotePendingMember {
+        uuid: Uuid,
+        #[derivative(Debug = "ignore")]
+        profile_key: ProfileKey,
+    },
     // when admin control is enabled
     NewRequestingMember(RequestingMember),
     DeleteRequestingMember(Uuid),
-    PromoteRequestingMember { uuid: Uuid, role: Role },
+    PromoteRequestingMember {
+        uuid: Uuid,
+        role: Role,
+    },
     // group metadata
     Title(String),
     Avatar(String),
@@ -128,70 +129,6 @@ pub enum GroupChange {
     InviteLinkAccess(AccessRequired),
     InviteLinkPassword(String),
     AnnouncementOnly(bool),
-}
-
-impl fmt::Debug for GroupChange {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NewMember(arg0) => {
-                f.debug_tuple("NewMember").field(arg0).finish()
-            },
-            Self::DeleteMember(arg0) => {
-                f.debug_tuple("DeleteMember").field(arg0).finish()
-            },
-            Self::ModifyMemberRole { uuid, role } => f
-                .debug_struct("ModifyMemberRole")
-                .field("uuid", uuid)
-                .field("role", role)
-                .finish(),
-            Self::ModifyMemberProfileKey { uuid, .. } => f
-                .debug_struct("ModifyMemberProfileKey")
-                .field("uuid", uuid)
-                .finish(),
-            Self::NewPendingMember(arg0) => {
-                f.debug_tuple("NewPendingMember").field(arg0).finish()
-            },
-            Self::DeletePendingMember(arg0) => {
-                f.debug_tuple("DeletePendingMember").field(arg0).finish()
-            },
-            Self::PromotePendingMember { uuid, .. } => f
-                .debug_struct("PromotePendingMember")
-                .field("uuid", uuid)
-                .finish(),
-            Self::NewRequestingMember(arg0) => {
-                f.debug_tuple("NewRequestingMember").field(arg0).finish()
-            },
-            Self::DeleteRequestingMember(arg0) => {
-                f.debug_tuple("DeleteRequestingMember").field(arg0).finish()
-            },
-            Self::PromoteRequestingMember { uuid, role } => f
-                .debug_struct("PromoteRequestingMember")
-                .field("uuid", uuid)
-                .field("role", role)
-                .finish(),
-            Self::Title(arg0) => f.debug_tuple("Title").field(arg0).finish(),
-            Self::Avatar(arg0) => f.debug_tuple("Avatar").field(arg0).finish(),
-            Self::Timer(arg0) => f.debug_tuple("Timer").field(arg0).finish(),
-            Self::Description(arg0) => {
-                f.debug_tuple("Description").field(arg0).finish()
-            },
-            Self::AttributeAccess(arg0) => {
-                f.debug_tuple("AttributeAccess").field(arg0).finish()
-            },
-            Self::MemberAccess(arg0) => {
-                f.debug_tuple("MemberAccess").field(arg0).finish()
-            },
-            Self::InviteLinkAccess(arg0) => {
-                f.debug_tuple("InviteLinkAccess").field(arg0).finish()
-            },
-            Self::InviteLinkPassword(arg0) => {
-                f.debug_tuple("InviteLinkPassword").field(arg0).finish()
-            },
-            Self::AnnouncementOnly(arg0) => {
-                f.debug_tuple("AnnouncementOnly").field(arg0).finish()
-            },
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]

--- a/libsignal-service/src/groups_v2/operations.rs
+++ b/libsignal-service/src/groups_v2/operations.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use std::convert::TryInto;
 
 use bytes::Bytes;
 use prost::Message;
@@ -8,194 +8,21 @@ use zkgroup::{
     profiles::{AnyProfileKeyCredentialPresentation, ProfileKey},
 };
 
-use crate::proto::{
-    self, access_control::AccessRequired, group_attribute_blob, member::Role,
-    AccessControl, GroupAttributeBlob, Member as EncryptedMember,
+use crate::{
+    groups_v2::model::Timer,
+    proto::{
+        self, group_attribute_blob, GroupAttributeBlob,
+        Member as EncryptedMember,
+    },
+};
+
+use super::{
+    model::{Member, PendingMember, RequestingMember},
+    Group, GroupChange, GroupChanges,
 };
 
 pub(crate) struct GroupOperations {
     pub group_secret_params: GroupSecretParams,
-}
-
-#[derive(Clone)]
-pub struct Member {
-    pub uuid: Uuid,
-    pub role: Role,
-    pub profile_key: ProfileKey,
-    pub joined_at_revision: u32,
-}
-
-impl PartialEq for Member {
-    fn eq(&self, other: &Self) -> bool {
-        self.uuid == other.uuid
-    }
-}
-
-impl fmt::Debug for Member {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Member")
-            .field("uuid", &self.uuid)
-            .field("role", &self.role)
-            .field("joined_at_revision", &self.joined_at_revision)
-            .finish()
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PendingMember {
-    pub uuid: Uuid,
-    pub role: Role,
-    pub added_by_uuid: Uuid,
-    pub timestamp: u64,
-}
-
-#[derive(Clone)]
-pub struct RequestingMember {
-    pub uuid: Uuid,
-    pub profile_key: ProfileKey,
-    pub timestamp: u64,
-}
-
-impl PartialEq for RequestingMember {
-    fn eq(&self, other: &Self) -> bool {
-        self.uuid == other.uuid
-    }
-}
-
-impl fmt::Debug for RequestingMember {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RequestingMember")
-            .field("uuid", &self.uuid)
-            .field("timestamp", &self.timestamp)
-            .finish()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Group {
-    pub title: String,
-    pub avatar: String,
-    pub disappearing_messages_timer: Option<Timer>,
-    pub access_control: Option<AccessControl>,
-    pub revision: u32,
-    pub members: Vec<Member>,
-    pub pending_members: Vec<PendingMember>,
-    pub requesting_members: Vec<RequestingMember>,
-    pub invite_link_password: Vec<u8>,
-    pub description: Option<String>,
-}
-
-#[derive(Clone, Debug)]
-pub struct GroupChanges {
-    pub editor: Uuid,
-    pub revision: u32,
-    pub changes: Vec<GroupChange>,
-}
-
-#[derive(Clone)]
-pub enum GroupChange {
-    NewMember(Member),
-    DeleteMember(Uuid),
-    ModifyMemberRole { uuid: Uuid, role: Role },
-    ModifyMemberProfileKey { uuid: Uuid, profile_key: ProfileKey },
-    // for open groups
-    NewPendingMember(PendingMember),
-    DeletePendingMember(Uuid),
-    PromotePendingMember { uuid: Uuid, profile_key: ProfileKey },
-    // when admin control is enabled
-    NewRequestingMember(RequestingMember),
-    DeleteRequestingMember(Uuid),
-    PromoteRequestingMember { uuid: Uuid, role: Role },
-    // group metadata
-    Title(String),
-    Avatar(String),
-    Timer(Option<Timer>),
-    Description(Option<String>),
-    AttributeAccess(AccessRequired),
-    MemberAccess(AccessRequired),
-    InviteLinkAccess(AccessRequired),
-    InviteLinkPassword(String),
-    AnnouncementOnly(bool),
-}
-
-impl fmt::Debug for GroupChange {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NewMember(arg0) => {
-                f.debug_tuple("NewMember").field(arg0).finish()
-            },
-            Self::DeleteMember(arg0) => {
-                f.debug_tuple("DeleteMember").field(arg0).finish()
-            },
-            Self::ModifyMemberRole { uuid, role } => f
-                .debug_struct("ModifyMemberRole")
-                .field("uuid", uuid)
-                .field("role", role)
-                .finish(),
-            Self::ModifyMemberProfileKey { uuid, .. } => f
-                .debug_struct("ModifyMemberProfileKey")
-                .field("uuid", uuid)
-                .finish(),
-            Self::NewPendingMember(arg0) => {
-                f.debug_tuple("NewPendingMember").field(arg0).finish()
-            },
-            Self::DeletePendingMember(arg0) => {
-                f.debug_tuple("DeletePendingMember").field(arg0).finish()
-            },
-            Self::PromotePendingMember { uuid, .. } => f
-                .debug_struct("PromotePendingMember")
-                .field("uuid", uuid)
-                .finish(),
-            Self::NewRequestingMember(arg0) => {
-                f.debug_tuple("NewRequestingMember").field(arg0).finish()
-            },
-            Self::DeleteRequestingMember(arg0) => {
-                f.debug_tuple("DeleteRequestingMember").field(arg0).finish()
-            },
-            Self::PromoteRequestingMember { uuid, role } => f
-                .debug_struct("PromoteRequestingMember")
-                .field("uuid", uuid)
-                .field("role", role)
-                .finish(),
-            Self::Title(arg0) => f.debug_tuple("Title").field(arg0).finish(),
-            Self::Avatar(arg0) => f.debug_tuple("Avatar").field(arg0).finish(),
-            Self::Timer(arg0) => f.debug_tuple("Timer").field(arg0).finish(),
-            Self::Description(arg0) => {
-                f.debug_tuple("Description").field(arg0).finish()
-            },
-            Self::AttributeAccess(arg0) => {
-                f.debug_tuple("AttributeAccess").field(arg0).finish()
-            },
-            Self::MemberAccess(arg0) => {
-                f.debug_tuple("MemberAccess").field(arg0).finish()
-            },
-            Self::InviteLinkAccess(arg0) => {
-                f.debug_tuple("InviteLinkAccess").field(arg0).finish()
-            },
-            Self::InviteLinkPassword(arg0) => {
-                f.debug_tuple("InviteLinkPassword").field(arg0).finish()
-            },
-            Self::AnnouncementOnly(arg0) => {
-                f.debug_tuple("AnnouncementOnly").field(arg0).finish()
-            },
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Timer {
-    pub duration: u32,
-}
-
-#[derive(Clone, PartialEq, Eq)]
-pub struct GroupJoinInfo {
-    pub title: String,
-    pub avatar: String,
-    pub member_count: u32,
-    pub add_from_invite_link: i32,
-    pub revision: u32,
-    pub pending_admin_approval: bool,
-    pub description: String,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -276,8 +103,7 @@ impl GroupOperations {
         Ok(Member {
             uuid,
             profile_key,
-            role: Role::from_i32(member.role)
-                .ok_or(GroupDecryptionError::WrongBlob)?,
+            role: member.role.try_into()?,
             joined_at_revision: member.joined_at_revision,
         })
     }
@@ -294,8 +120,7 @@ impl GroupOperations {
 
         Ok(PendingMember {
             uuid,
-            role: Role::from_i32(inner_member.role)
-                .ok_or(GroupDecryptionError::WrongBlob)?,
+            role: inner_member.role.try_into()?,
             added_by_uuid,
             timestamp: member.timestamp,
         })
@@ -411,7 +236,10 @@ impl GroupOperations {
             title,
             avatar: group.avatar,
             disappearing_messages_timer,
-            access_control: group.access_control,
+            access_control: group
+                .access_control
+                .map(TryInto::try_into)
+                .transpose()?,
             revision: group.revision,
             members,
             pending_members,
@@ -445,8 +273,7 @@ impl GroupOperations {
             actions.modify_member_roles.into_iter().map(|m| {
                 Ok(GroupChange::ModifyMemberRole {
                     uuid: self.decrypt_uuid(&m.user_id)?,
-                    role: Role::from_i32(m.role)
-                        .ok_or(GroupDecryptionError::WrongEnumValue)?,
+                    role: m.role.try_into()?,
                 })
             });
 
@@ -510,17 +337,13 @@ impl GroupOperations {
         let modify_attributes_access =
             actions.modify_attributes_access.into_iter().map(|m| {
                 Ok(GroupChange::AttributeAccess(
-                    AccessRequired::from_i32(m.attributes_access)
-                        .ok_or(GroupDecryptionError::WrongEnumValue)?,
+                    m.attributes_access.try_into()?,
                 ))
             });
 
         let modify_member_access =
             actions.modify_member_access.into_iter().map(|m| {
-                Ok(GroupChange::MemberAccess(
-                    AccessRequired::from_i32(m.members_access)
-                        .ok_or(GroupDecryptionError::WrongEnumValue)?,
-                ))
+                Ok(GroupChange::MemberAccess(m.members_access.try_into()?))
             });
 
         let modify_add_from_invite_link_access = actions
@@ -528,8 +351,7 @@ impl GroupOperations {
             .into_iter()
             .map(|m| {
                 Ok(GroupChange::InviteLinkAccess(
-                    AccessRequired::from_i32(m.add_from_invite_link_access)
-                        .ok_or(GroupDecryptionError::WrongEnumValue)?,
+                    m.add_from_invite_link_access.try_into()?,
                 ))
             });
 
@@ -554,8 +376,7 @@ impl GroupOperations {
             actions.promote_requesting_members.into_iter().map(|m| {
                 Ok(GroupChange::PromoteRequestingMember {
                     uuid: self.decrypt_uuid(&m.user_id)?,
-                    role: Role::from_i32(m.role)
-                        .ok_or(GroupDecryptionError::WrongEnumValue)?,
+                    role: m.role.try_into()?,
                 })
             });
 

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-
+use derivative::Derivative;
 use futures::{channel::mpsc::Sender, pin_mut, SinkExt, StreamExt};
 use libsignal_protocol::{PrivateKey, PublicKey};
 use phonenumber::PhoneNumber;
@@ -61,6 +60,8 @@ pub struct ProvisioningManager<'a, P: PushService + 'a> {
     password: String,
 }
 
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub enum SecondaryDeviceProvisioning {
     Url(Url),
     NewDeviceRegistration {
@@ -68,35 +69,12 @@ pub enum SecondaryDeviceProvisioning {
         device_id: DeviceId,
         registration_id: u32,
         uuid: Uuid,
+        #[derivative(Debug = "ignore")]
         private_key: PrivateKey,
         public_key: PublicKey,
+        #[derivative(Debug = "ignore")]
         profile_key: Vec<u8>,
     },
-}
-
-impl fmt::Debug for SecondaryDeviceProvisioning {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Url(url) => f.debug_tuple("Url").field(url).finish(),
-            Self::NewDeviceRegistration {
-                phone_number,
-                device_id,
-                registration_id,
-                uuid,
-                public_key,
-                profile_key,
-                ..
-            } => f
-                .debug_struct("NewDeviceRegistration")
-                .field("phone_number", phone_number)
-                .field("device_id", device_id)
-                .field("registration_id", registration_id)
-                .field("uuid", uuid)
-                .field("public_key", public_key)
-                .field("profile_key", profile_key)
-                .finish(),
-        }
-    }
 }
 
 impl<'a, P: PushService + 'a> ProvisioningManager<'a, P> {

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use crate::{
     configuration::{Endpoint, ServiceCredentials},
     envelope::*,
-    groups_v2::GroupDecryptionError,
+    groups_v2::GroupDecodingError,
     pre_keys::{PreKeyEntity, PreKeyState, SignedPreKeyEntity},
     profile_cipher::ProfileCipherError,
     proto::{attachment_pointer::AttachmentIdentifier, AttachmentPointer},
@@ -380,7 +380,7 @@ pub enum ServiceError {
     GroupsV2Error,
 
     #[error(transparent)]
-    GroupsV2DecryptionError(#[from] GroupDecryptionError),
+    GroupsV2DecryptionError(#[from] GroupDecodingError),
 
     #[error("unsupported content")]
     UnsupportedContent,

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -1,4 +1,4 @@
-use std::{fmt, time::Duration};
+use std::time::Duration;
 
 use crate::{
     configuration::{Endpoint, ServiceCredentials},
@@ -18,6 +18,7 @@ use aes_gcm::{
     Aes256Gcm, NewAead,
 };
 use chrono::prelude::*;
+use derivative::Derivative;
 use libsignal_protocol::{
     error::SignalProtocolError, IdentityKey, PreKeyBundle, PublicKey,
     SenderCertificate,
@@ -142,9 +143,11 @@ pub struct PreKeyStatus {
     pub count: u32,
 }
 
-#[derive(Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct HttpAuth {
     pub username: String,
+    #[derivative(Debug = "ignore")]
     pub password: String,
 }
 
@@ -167,12 +170,6 @@ pub enum AvatarWrite<C> {
 struct SenderCertificateJson {
     #[serde(with = "serde_base64")]
     certificate: Vec<u8>,
-}
-
-impl fmt::Debug for HttpAuth {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "HTTP auth with username {}", self.username)
-    }
 }
 
 pub trait ProfileKeyExt {


### PR DESCRIPTION
This is a remake of #192 which makes we use 100% internal types when dealing with group decryption. Before this change, we had a mix of own types and protobuf enums. The main advantage of using our own types is to be able to control derives as well as immediately catch issues when the protobuf schema changes.

- Move all group structs and enums into its own `model.rs` file
- Add 3 very small converters for `Role`, `AccessRequired` and `AccessControl`.