### PR TITLE
Publish group operation structs

### DIFF
--- a/libsignal-service/src/groups_v2/mod.rs
+++ b/libsignal-service/src/groups_v2/mod.rs
@@ -7,4 +7,7 @@ pub use manager::{
     decrypt_group, CredentialsCache, CredentialsCacheError, GroupsManager,
     InMemoryCredentialsCache,
 };
-pub use operations::{Group, GroupChange, GroupChanges, GroupDecryptionError};
+pub use operations::{
+    Group, GroupChange, GroupChanges, GroupDecryptionError, Member,
+    PendingMember, RequestingMember, Timer,
+};


### PR DESCRIPTION
Needed for <https://github.com/whisperfish/presage/pull/149>. Note that the base-branch is quite outdated as presage was not yet updated to latest commit.