### PR TITLE
Add support for PNI fields and fix fetching (encrypted groups)

### DIFF
--- a/libsignal-service-actix/examples/link.rs
+++ b/libsignal-service-actix/examples/link.rs
@@ -67,12 +67,17 @@ async fn main() -> Result<(), Error> {
                         phone_number: _,
                         device_id: _,
                         registration_id: _,
-                        uuid,
-                        private_key: _,
-                        public_key: _,
+                        service_ids,
                         profile_key: _,
+                        aci_private_key: _,
+                        aci_public_key: _,
+                        pni_private_key: _,
+                        pni_public_key: _,
                     } => {
-                        log::info!("successfully registered device {}", &uuid);
+                        log::info!(
+                            "successfully registered device {}",
+                            &service_ids
+                        );
                         // here you would store all of this data somehow to use it later!
                     },
                 }

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -7,8 +7,8 @@ use aes::cipher::{NewCipher, StreamCipher};
 use aes::Aes256Ctr;
 use hmac::{Hmac, Mac};
 use libsignal_protocol::{
-    IdentityKeyStore, KeyPair, PreKeyRecord, PrivateKey,
-    PublicKey, SignalProtocolError, SignedPreKeyRecord, ProtocolStore,
+    IdentityKeyStore, KeyPair, PreKeyRecord, PrivateKey, ProtocolStore,
+    PublicKey, SignalProtocolError, SignedPreKeyRecord,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -84,7 +84,10 @@ impl<Service: PushService> AccountManager<Service> {
     ///
     /// Returns the next pre-key offset and next signed pre-key offset as a tuple.
     #[allow(clippy::too_many_arguments)]
-    pub async fn update_pre_key_bundle<R: rand::Rng + rand::CryptoRng, P: ProtocolStore>(
+    pub async fn update_pre_key_bundle<
+        R: rand::Rng + rand::CryptoRng,
+        P: ProtocolStore,
+    >(
         &mut self,
         protocol_store: &mut P,
         csprng: &mut R,

--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -26,25 +26,21 @@ use crate::{
 ///
 /// Equivalent of SignalServiceCipher in Java.
 #[derive(Clone)]
-pub struct ServiceCipher<S, SK, R> {
+pub struct ServiceCipher<S, R> {
     protocol_store: S,
-    sender_key_store: SK,
     csprng: R,
     trust_root: PublicKey,
     local_uuid: Uuid,
     local_device_id: u32,
 }
 
-impl<S, SK, R> ServiceCipher<S, SK, R>
+impl<S, R> ServiceCipher<S, R>
 where
-    S: ProtocolStore + Clone,
-    SK: SenderKeyStore + Clone,
+    S: ProtocolStore + SenderKeyStore + Clone,
     R: Rng + CryptoRng + Clone,
 {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         protocol_store: S,
-        sender_key_store: SK,
         csprng: R,
         trust_root: PublicKey,
         local_uuid: Uuid,
@@ -52,7 +48,6 @@ where
     ) -> Self {
         Self {
             protocol_store,
-            sender_key_store,
             csprng,
             trust_root,
             local_uuid,
@@ -76,7 +71,7 @@ where
                 process_sender_key_distribution_message(
                     &plaintext.metadata.protocol_address(),
                     &skdm,
-                    &mut self.sender_key_store,
+                    &mut self.protocol_store,
                     None,
                 )
                 .await?;
@@ -221,8 +216,8 @@ where
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
+                    &mut self.protocol_store.clone(),
                     &mut self.protocol_store,
-                    &mut self.sender_key_store,
                     None,
                 )
                 .await?;

--- a/libsignal-service/src/groups_v2/manager.rs
+++ b/libsignal-service/src/groups_v2/manager.rs
@@ -99,7 +99,6 @@ impl CredentialsCache for InMemoryCredentialsCache {
         &mut self,
         map: HashMap<u64, AuthCredentialWithPniResponse>,
     ) -> Result<(), CredentialsCacheError> {
-        dbg!(map.keys());
         self.map = map;
         Ok(())
     }
@@ -260,7 +259,6 @@ impl<S: PushService, C: CredentialsCache> GroupsManager<S, C> {
         let authorization = self
             .get_authorization_for_today(group_secret_params)
             .await?;
-        dbg!(&authorization);
         self.push_service.get_group(authorization).await
     }
 

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -98,10 +98,10 @@ pub mod prelude {
         pub use libsignal_protocol::{
             Context, DeviceId, Direction, IdentityKey, IdentityKeyPair,
             IdentityKeyStore, KeyPair, PreKeyId, PreKeyRecord, PreKeyStore,
-            PrivateKey, ProtocolAddress, PublicKey, SenderCertificate,
-            SenderKeyRecord, SenderKeyStore, SessionRecord, SessionStore,
-            SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord,
-            SignedPreKeyStore,
+            PrivateKey, ProtocolAddress, ProtocolStore, PublicKey,
+            SenderCertificate, SenderKeyRecord, SenderKeyStore, SessionRecord,
+            SessionStore, SignalProtocolError, SignedPreKeyId,
+            SignedPreKeyRecord, SignedPreKeyStore,
         };
     }
 }

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{fmt, time::Duration};
 
 use crate::{
     configuration::{Endpoint, ServiceCredentials},
@@ -66,6 +66,18 @@ pub const STICKER_PATH: &str = "stickers/%s/full/%d";
 
 pub const KEEPALIVE_TIMEOUT_SECONDS: Duration = Duration::from_secs(55);
 pub const DEFAULT_DEVICE_ID: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ServiceIds {
+    pub aci: Uuid,
+    pub pni: Uuid,
+}
+
+impl fmt::Display for ServiceIds {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "aci={} pni={}", self.aci, self.pni)
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -67,7 +67,7 @@ pub const STICKER_PATH: &str = "stickers/%s/full/%d";
 pub const KEEPALIVE_TIMEOUT_SECONDS: Duration = Duration::from_secs(55);
 pub const DEFAULT_DEVICE_ID: u32 = 1;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum ServiceIdType {
     /// Account Identity (an account UUID without an associated phone number, probably in the future to a username)
     AccountIdentity,
@@ -525,10 +525,11 @@ pub trait PushService: MaybeSend {
 
     async fn get_pre_key_status(
         &mut self,
+        service_id_type: ServiceIdType,
     ) -> Result<PreKeyStatus, ServiceError> {
         self.get_json(
             Endpoint::Service,
-            "/v2/keys/",
+            &format!("/v2/keys?identity={}", service_id_type),
             HttpAuthOverride::NoOverride,
         )
         .await
@@ -536,12 +537,13 @@ pub trait PushService: MaybeSend {
 
     async fn register_pre_keys(
         &mut self,
+        service_id_type: ServiceIdType,
         pre_key_state: PreKeyState,
     ) -> Result<(), ServiceError> {
         match self
             .put_json(
                 Endpoint::Service,
-                "/v2/keys/",
+                &format!("/v2/keys?identity={}", service_id_type),
                 HttpAuthOverride::NoOverride,
                 pre_key_state,
             )

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -69,9 +69,13 @@ pub const DEFAULT_DEVICE_ID: u32 = 1;
 
 #[derive(Debug, Clone, Copy)]
 pub enum ServiceIdType {
-    /// Account Identity (an account UUID without an associated phone number, probably in the future to a username)
+    /// Account Identity (ACI)
+    ///
+    /// An account UUID without an associated phone number, probably in the future to a username
     AccountIdentity,
-    /// Phone number identity (a UUID associated with a phone number)
+    /// Phone number identity (PNI)
+    ///
+    /// A UUID associated with a phone number
     PhoneNumberIdentity,
 }
 

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -69,17 +69,17 @@ pub const DEFAULT_DEVICE_ID: u32 = 1;
 
 #[derive(Debug)]
 pub enum ServiceIdType {
-    // Account Identity
-    ACI,
-    // Phone number identity
-    PNI,
+    /// Account Identity (an account UUID without an associated phone number, probably in the future to a username)
+    AccountIdentity,
+    /// Phone number identity (a UUID associated with a phone number)
+    PhoneNumberIdentity,
 }
 
 impl fmt::Display for ServiceIdType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ServiceIdType::ACI => f.write_str("aci"),
-            ServiceIdType::PNI => f.write_str("pni"),
+            ServiceIdType::AccountIdentity => f.write_str("aci"),
+            ServiceIdType::PhoneNumberIdentity => f.write_str("pni"),
         }
     }
 }

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -67,6 +67,23 @@ pub const STICKER_PATH: &str = "stickers/%s/full/%d";
 pub const KEEPALIVE_TIMEOUT_SECONDS: Duration = Duration::from_secs(55);
 pub const DEFAULT_DEVICE_ID: u32 = 1;
 
+#[derive(Debug)]
+pub enum ServiceIdType {
+    // Account Identity
+    ACI,
+    // Phone number identity
+    PNI,
+}
+
+impl fmt::Display for ServiceIdType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ServiceIdType::ACI => f.write_str("aci"),
+            ServiceIdType::PNI => f.write_str("pni"),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ServiceIds {
     pub aci: Uuid,

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -86,6 +86,7 @@ impl fmt::Display for ServiceIdType {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ServiceIds {
+    #[serde(rename = "uuid")]
     pub aci: Uuid,
     pub pni: Uuid,
 }

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -76,11 +76,11 @@ pub struct AttachmentSpec {
 
 /// Equivalent of Java's `SignalServiceMessageSender`.
 #[derive(Clone)]
-pub struct MessageSender<Service, S, SK, R> {
+pub struct MessageSender<Service, S, R> {
     ws: SignalWebSocket,
     unidentified_ws: SignalWebSocket,
     service: Service,
-    cipher: ServiceCipher<S, SK, R>,
+    cipher: ServiceCipher<S, R>,
     csprng: R,
     protocol_store: S,
     local_address: ServiceAddress,
@@ -118,11 +118,10 @@ pub enum MessageSenderError {
     NotFound { uuid: Uuid },
 }
 
-impl<Service, S, SK, R> MessageSender<Service, S, SK, R>
+impl<Service, S, R> MessageSender<Service, S, R>
 where
     Service: PushService + Clone,
-    S: ProtocolStore + SessionStoreExt + Sync + Clone,
-    SK: SenderKeyStore + Clone,
+    S: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone,
     R: Rng + CryptoRng + Clone,
 {
     #[allow(clippy::too_many_arguments)]
@@ -130,7 +129,7 @@ where
         ws: SignalWebSocket,
         unidentified_ws: SignalWebSocket,
         service: Service,
-        cipher: ServiceCipher<S, SK, R>,
+        cipher: ServiceCipher<S, R>,
         csprng: R,
         protocol_store: S,
         local_address: ServiceAddress,


### PR DESCRIPTION
Tested in `presage` which should get us started with #206 and fix #223.

This requires to be able to provide two separate store implementations to the underlying `libsignal`. See https://github.com/signalapp/Signal-Android/blob/b4f6177e873cfd23cbce8fdbea8b573af8faf45d/app/src/main/java/org/thoughtcrime/securesms/crypto/storage/SignalServiceAccountDataStoreImpl.java#L26 for the requirements in `Signal-Android`.