### PR TITLE
Set the expiration start timestamp if required

### DIFF
--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -843,6 +843,15 @@ where
             sent: Some(sync_message::Sent {
                 destination_uuid: recipient.map(|r| r.uuid.to_string()),
                 destination_e164: None,
+                expiration_start_timestamp: if data_message
+                    .as_ref()
+                    .and_then(|m| m.expire_timer)
+                    .is_some()
+                {
+                    Some(timestamp)
+                } else {
+                    None
+                },
                 message: data_message,
                 timestamp: Some(timestamp),
                 unidentified_status,


### PR DESCRIPTION
Currently when a message has sent an expire timer, it will be instantly deleted upon receipt on Signal Android as the expiration start timestamp has no value. This PR sets that value if required to the timestamp the message was sent at.

I don't think something similar is required for non-sync messages, but I have not yet tested this.

Somewhat related to https://github.com/whisperfish/presage/issues/93.