### PR TITLE
Add api for retrieving stickerpacks from the cdn

### DIFF
--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -592,6 +592,23 @@ pub trait PushService: MaybeSend {
         }
     }
 
+    async fn get_sticker_pack_manifest(
+        &mut self,
+        id: &str,
+    ) -> Result<Self::ByteStream, ServiceError> {
+        let path = format!("/stickers/{}/manifest.proto", id);
+        self.get_from_cdn(0, &path).await
+    }
+
+    async fn get_sticker(
+        &mut self,
+        pack_id: &str,
+        sticker_id: u32,
+    ) -> Result<Self::ByteStream, ServiceError> {
+        let path = format!("/stickers/{}/full/{}", pack_id, sticker_id);
+        self.get_from_cdn(0, &path).await
+    }
+
     async fn send_messages(
         &mut self,
         messages: OutgoingPushMessages,


### PR DESCRIPTION
While mostly untested, this should allow for retrieval of stickerpack data by requesting from the correct endpoints using the preexisting cdn retrieval functions.