### PR TITLE
Post-quantum E2E sessions

### DIFF
--- a/libsignal-service-hyper/examples/registering.rs
+++ b/libsignal-service-hyper/examples/registering.rs
@@ -8,8 +8,7 @@ use libsignal_service::provisioning::{
     VerifyAccountResponse,
 };
 use libsignal_service::push_service::{
-    AccountAttributes, DeviceCapabilities, ProfileKeyExt, PushService,
-    ServiceError,
+    AccountAttributes, DeviceCapabilities, PushService, ServiceError,
 };
 use libsignal_service::USER_AGENT;
 
@@ -97,7 +96,9 @@ async fn confirm_registration<'a, T: PushService>(
                 fetches_messages: true,
                 pin: None,
                 registration_lock: None,
-                unidentified_access_key: Some(profile_key.derive_access_key()),
+                unidentified_access_key: Some(
+                    profile_key.derive_access_key().to_vec(),
+                ),
                 unrestricted_unidentified_access: false, // TODO: make this configurable?
                 discoverable_by_phone_number: true,
                 name: Some("libsignal-service-hyper test".into()),

--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -7,8 +7,8 @@ license = "GPLv3"
 readme = "../README.md"
 
 [dependencies]
-libsignal-protocol = { git = "https://github.com/signalapp/libsignal", tag = "v0.22.2" }
-zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.22.2" }
+libsignal-protocol = { git = "https://github.com/signalapp/libsignal", tag = "v0.28.1" }
+zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.28.1" }
 
 aes = { version = "0.7", features = ["ctr"] }
 aes-gcm = "0.9"

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -207,6 +207,12 @@ impl<Service: PushService> AccountManager<Service> {
             pq_pre_keys: pq_pre_key_entities,
             pq_last_resort_key: if use_last_resort_key {
                 log::warn!("Last resort Kyber key unimplemented");
+                // Note about the last-resort key:
+                // mark_kyber_pre_key_used() should retain the last-resort key, but can safely
+                // remove the ephemeral pre keys.  This implies that generating the last-resort key
+                // should notify the pre-key store, when saving the key, that it concerns a
+                // last-resort key.  I don't see how this can be communicated to the store, and I
+                // fear that we need to reengineer the whole prekeystore system as a whole.
                 None
                 // Some(KyberPreKeyEntity {
                 //     key_id: 0x7fffffff,

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -7,8 +7,8 @@ use aes::cipher::{NewCipher, StreamCipher};
 use aes::Aes256Ctr;
 use hmac::{Hmac, Mac};
 use libsignal_protocol::{
-    IdentityKeyStore, KeyPair, PreKeyRecord, PrivateKey, ProtocolStore,
-    PublicKey, SignalProtocolError, SignedPreKeyRecord,
+    GenericSignedPreKey, IdentityKeyStore, KeyPair, PreKeyRecord, PrivateKey,
+    ProtocolStore, PublicKey, SignalProtocolError, SignedPreKeyRecord,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -7,13 +7,15 @@ use aes::cipher::{NewCipher, StreamCipher};
 use aes::Aes256Ctr;
 use hmac::{Hmac, Mac};
 use libsignal_protocol::{
-    GenericSignedPreKey, IdentityKeyStore, KeyPair, PreKeyRecord, PrivateKey,
-    ProtocolStore, PublicKey, SignalProtocolError, SignedPreKeyRecord,
+    kem, GenericSignedPreKey, IdentityKeyStore, KeyPair, KyberPreKeyRecord,
+    PreKeyRecord, PrivateKey, ProtocolStore, PublicKey, SignalProtocolError,
+    SignedPreKeyRecord,
 };
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use zkgroup::profiles::ProfileKey;
 
+use crate::pre_keys::KyberPreKeyEntity;
 use crate::push_service::{AvatarWrite, RecaptchaAttributes, ServiceIdType};
 use crate::ServiceAddress;
 use crate::{
@@ -82,7 +84,7 @@ impl<Service: PushService> AccountManager<Service> {
     ///
     /// Equivalent to Java's RefreshPreKeysJob
     ///
-    /// Returns the next pre-key offset and next signed pre-key offset as a tuple.
+    /// Returns the next pre-key offset, pq pre-key offset, and next signed pre-key offset as a tuple.
     #[allow(clippy::too_many_arguments)]
     pub async fn update_pre_key_bundle<
         R: rand::Rng + rand::CryptoRng,
@@ -93,30 +95,46 @@ impl<Service: PushService> AccountManager<Service> {
         csprng: &mut R,
         pre_keys_offset_id: u32,
         next_signed_pre_key_id: u32,
+        pq_pre_keys_offset_id: u32,
         use_last_resort_key: bool,
-    ) -> Result<(u32, u32), ServiceError> {
-        let prekey_count = match self
+    ) -> Result<(u32, u32, u32), ServiceError> {
+        let prekey_status = match self
             .service
             .get_pre_key_status(ServiceIdType::AccountIdentity)
             .await
         {
-            Ok(status) => status.count,
+            Ok(status) => status,
             Err(ServiceError::Unauthorized) => {
                 log::info!("Got Unauthorized when fetching pre-key status. Assuming first installment.");
                 // Additionally, the second PUT request will fail if this really comes down to an
                 // authorization failure.
-                0
+                crate::push_service::PreKeyStatus {
+                    count: 0,
+                    pq_count: 0,
+                }
             },
             Err(e) => return Err(e),
         };
-        log::trace!("Remaining pre-keys on server: {}", prekey_count);
+        log::trace!("Remaining pre-keys on server: {:?}", prekey_status);
 
-        if prekey_count >= PRE_KEY_MINIMUM {
+        if prekey_status.count >= PRE_KEY_MINIMUM
+            && prekey_status.pq_count >= PRE_KEY_MINIMUM
+        {
             log::info!("Available keys sufficient");
-            return Ok((pre_keys_offset_id, next_signed_pre_key_id));
+            return Ok((
+                pre_keys_offset_id,
+                pq_pre_keys_offset_id,
+                next_signed_pre_key_id,
+            ));
         }
 
+        let identity_key_pair =
+            protocol_store.get_identity_key_pair(None).await?;
+
         let mut pre_key_entities = vec![];
+        let mut pq_pre_key_entities = vec![];
+
+        // EC keys
         for i in 0..PRE_KEY_BATCH_SIZE {
             let key_pair = KeyPair::generate(csprng);
             let pre_key_id = (((pre_keys_offset_id + i)
@@ -127,13 +145,36 @@ impl<Service: PushService> AccountManager<Service> {
             protocol_store
                 .save_pre_key(pre_key_id, &pre_key_record, None)
                 .await?;
+            // TODO: Shouldn't this also remove the previous pre-keys from storage?
+            //       I think we might want to update the storage, and then sync the storage to the
+            //       server.
 
             pre_key_entities.push(PreKeyEntity::try_from(pre_key_record)?);
         }
 
+        // Kyber keys
+        for i in 0..PRE_KEY_BATCH_SIZE {
+            let pre_key_id = (((pq_pre_keys_offset_id + i)
+                % (PRE_KEY_MEDIUM_MAX_VALUE - 1))
+                + 1)
+            .into();
+            let pre_key_record = KyberPreKeyRecord::generate(
+                kem::KeyType::Kyber1024,
+                pre_key_id,
+                identity_key_pair.private_key(),
+            )?;
+            protocol_store
+                .save_kyber_pre_key(pre_key_id, &pre_key_record, None)
+                .await?;
+            // TODO: Shouldn't this also remove the previous pre-keys from storage?
+            //       I think we might want to update the storage, and then sync the storage to the
+            //       server.
+
+            pq_pre_key_entities
+                .push(KyberPreKeyEntity::try_from(pre_key_record)?);
+        }
+
         // Generate and store the next signed prekey
-        let identity_key_pair =
-            protocol_store.get_identity_key_pair(None).await?;
         let signed_pre_key_pair = KeyPair::generate(csprng);
         let signed_pre_key_public = signed_pre_key_pair.public_key;
         let signed_pre_key_signature = identity_key_pair
@@ -163,11 +204,14 @@ impl<Service: PushService> AccountManager<Service> {
             pre_keys: pre_key_entities,
             signed_pre_key: signed_prekey_record.try_into()?,
             identity_key: *identity_key_pair.public_key(),
-            last_resort_key: if use_last_resort_key {
-                Some(PreKeyEntity {
-                    key_id: 0x7fffffff,
-                    public_key: "NDI=".into(),
-                })
+            pq_pre_keys: pq_pre_key_entities,
+            pq_last_resort_key: if use_last_resort_key {
+                log::warn!("Last resort Kyber key unimplemented");
+                None
+                // Some(KyberPreKeyEntity {
+                //     key_id: 0x7fffffff,
+                //     public_key: "NDI=".into(),
+                // })
             } else {
                 None
             },
@@ -180,6 +224,7 @@ impl<Service: PushService> AccountManager<Service> {
         log::trace!("Successfully refreshed prekeys");
         Ok((
             pre_keys_offset_id + PRE_KEY_BATCH_SIZE,
+            pq_pre_keys_offset_id + PRE_KEY_BATCH_SIZE,
             next_signed_pre_key_id + 1,
         ))
     }

--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -6,8 +6,8 @@ use libsignal_protocol::{
     message_encrypt, process_sender_key_distribution_message,
     sealed_sender_decrypt_to_usmc, sealed_sender_encrypt,
     CiphertextMessageType, Context, DeviceId, IdentityKeyStore,
-    PreKeySignalMessage, PreKeyStore, ProtocolAddress, ProtocolStore,
-    PublicKey, SealedSenderDecryptionResult, SenderCertificate,
+    KyberPreKeyStore, PreKeySignalMessage, PreKeyStore, ProtocolAddress,
+    ProtocolStore, PublicKey, SealedSenderDecryptionResult, SenderCertificate,
     SenderKeyDistributionMessage, SenderKeyStore, SessionStore, SignalMessage,
     SignalProtocolError, SignedPreKeyStore,
 };
@@ -36,7 +36,7 @@ pub struct ServiceCipher<S, R> {
 
 impl<S, R> ServiceCipher<S, R>
 where
-    S: ProtocolStore + SenderKeyStore + Clone,
+    S: ProtocolStore + KyberPreKeyStore + SenderKeyStore + Clone,
     R: Rng + CryptoRng + Clone,
 {
     pub fn new(
@@ -128,6 +128,7 @@ where
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
+                    &mut self.protocol_store.clone(),
                     &mut self.csprng,
                     None,
                 )
@@ -213,6 +214,7 @@ where
                     None,
                     self.local_uuid.to_string(),
                     self.local_device_id.into(),
+                    &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
@@ -431,6 +433,7 @@ async fn sealed_sender_decrypt(
     pre_key_store: &mut dyn PreKeyStore,
     signed_pre_key_store: &mut dyn SignedPreKeyStore,
     sender_key_store: &mut dyn SenderKeyStore,
+    kyber_pre_key_store: &mut dyn KyberPreKeyStore,
     ctx: Context,
 ) -> Result<SealedSenderDecryptionResult, SignalProtocolError> {
     let usmc =
@@ -484,6 +487,7 @@ async fn sealed_sender_decrypt(
                 identity_store,
                 pre_key_store,
                 signed_pre_key_store,
+                kyber_pre_key_store,
                 &mut rng,
                 ctx,
             )

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -98,11 +98,12 @@ pub mod prelude {
         pub use crate::session_store::SessionStoreExt;
         pub use libsignal_protocol::{
             Context, DeviceId, Direction, IdentityKey, IdentityKeyPair,
-            IdentityKeyStore, KeyPair, PreKeyId, PreKeyRecord, PreKeyStore,
-            PrivateKey, ProtocolAddress, ProtocolStore, PublicKey,
-            SenderCertificate, SenderKeyRecord, SenderKeyStore, SessionRecord,
-            SessionStore, SignalProtocolError, SignedPreKeyId,
-            SignedPreKeyRecord, SignedPreKeyStore,
+            IdentityKeyStore, KeyPair, KyberPreKeyId, KyberPreKeyRecord,
+            KyberPreKeyStore, PreKeyId, PreKeyRecord, PreKeyStore, PrivateKey,
+            ProtocolAddress, ProtocolStore, PublicKey, SenderCertificate,
+            SenderKeyRecord, SenderKeyStore, SessionRecord, SessionStore,
+            SignalProtocolError, SignedPreKeyId, SignedPreKeyRecord,
+            SignedPreKeyStore,
         };
     }
 }

--- a/libsignal-service/src/pre_keys.rs
+++ b/libsignal-service/src/pre_keys.rs
@@ -2,7 +2,8 @@ use std::convert::TryFrom;
 
 use crate::utils::{serde_base64, serde_public_key};
 use libsignal_protocol::{
-    error::SignalProtocolError, PreKeyRecord, PublicKey, SignedPreKeyRecord,
+    error::SignalProtocolError, GenericSignedPreKey, PreKeyRecord, PublicKey,
+    SignedPreKeyRecord,
 };
 
 use serde::{Deserialize, Serialize};

--- a/libsignal-service/src/pre_keys.rs
+++ b/libsignal-service/src/pre_keys.rs
@@ -2,8 +2,8 @@ use std::convert::TryFrom;
 
 use crate::utils::{serde_base64, serde_public_key};
 use libsignal_protocol::{
-    error::SignalProtocolError, GenericSignedPreKey, PreKeyRecord, PublicKey,
-    SignedPreKeyRecord,
+    error::SignalProtocolError, GenericSignedPreKey, KyberPreKeyRecord,
+    PreKeyRecord, PublicKey, SignedPreKeyRecord,
 };
 
 use serde::{Deserialize, Serialize};
@@ -59,6 +59,28 @@ impl TryFrom<SignedPreKeyRecord> for SignedPreKey {
     }
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KyberPreKeyEntity {
+    pub key_id: u32,
+    #[serde(with = "serde_base64")]
+    pub public_key: Vec<u8>,
+    #[serde(with = "serde_base64")]
+    pub signature: Vec<u8>,
+}
+
+impl TryFrom<KyberPreKeyRecord> for KyberPreKeyEntity {
+    type Error = SignalProtocolError;
+
+    fn try_from(key: KyberPreKeyRecord) -> Result<Self, Self::Error> {
+        Ok(KyberPreKeyEntity {
+            key_id: key.id()?.into(),
+            public_key: key.key_pair()?.public_key.serialize().to_vec(),
+            signature: key.signature()?,
+        })
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PreKeyState {
@@ -67,5 +89,6 @@ pub struct PreKeyState {
     #[serde(with = "serde_public_key")]
     pub identity_key: PublicKey,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_resort_key: Option<PreKeyEntity>,
+    pub pq_last_resort_key: Option<KyberPreKeyEntity>,
+    pub pq_pre_keys: Vec<KyberPreKeyEntity>,
 }

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -15,10 +15,6 @@ use crate::{
     MaybeSend, ParseServiceAddressError, Profile, ServiceAddress,
 };
 
-use aes_gcm::{
-    aead::{generic_array::GenericArray, Aead},
-    Aes256Gcm, NewAead,
-};
 use chrono::prelude::*;
 use derivative::Derivative;
 use libsignal_protocol::{
@@ -30,7 +26,7 @@ use phonenumber::PhoneNumber;
 use prost::Message as ProtobufMessage;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use zkgroup::profiles::{ProfileKey, ProfileKeyCommitment, ProfileKeyVersion};
+use zkgroup::profiles::{ProfileKeyCommitment, ProfileKeyVersion};
 
 /**
 Since we can't use format!() with constants, the URLs here are just for reference purposes
@@ -211,22 +207,6 @@ pub enum AvatarWrite<C> {
 struct SenderCertificateJson {
     #[serde(with = "serde_base64")]
     certificate: Vec<u8>,
-}
-
-pub trait ProfileKeyExt {
-    fn derive_access_key(&self) -> Vec<u8>;
-}
-
-impl ProfileKeyExt for ProfileKey {
-    fn derive_access_key(&self) -> Vec<u8> {
-        let key = GenericArray::from_slice(&self.bytes);
-        let cipher = Aes256Gcm::new(key);
-        let nonce = GenericArray::from_slice(&[0u8; 12]);
-        let buf = [0u8; 16];
-        let mut ciphertext = cipher.encrypt(nonce, &buf[..]).unwrap();
-        ciphertext.truncate(16);
-        ciphertext
-    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -728,7 +728,8 @@ pub trait PushService: MaybeSend {
         destination: &ServiceAddress,
         device_id: u32,
     ) -> Result<PreKeyBundle, ServiceError> {
-        let path = format!("/v2/keys/{}/{}", destination.uuid, device_id);
+        let path =
+            format!("/v2/keys/{}/{}?pq=true", destination.uuid, device_id);
 
         let mut pre_key_response: PreKeyResponse = self
             .get_json(Endpoint::Service, &path, HttpAuthOverride::NoOverride)
@@ -746,9 +747,9 @@ pub trait PushService: MaybeSend {
         device_id: u32,
     ) -> Result<Vec<PreKeyBundle>, ServiceError> {
         let path = if device_id == 1 {
-            format!("/v2/keys/{}/*", destination.uuid)
+            format!("/v2/keys/{}/*?pq=true", destination.uuid)
         } else {
-            format!("/v2/keys/{}/{}", destination.uuid, device_id)
+            format!("/v2/keys/{}/{}?pq=true", destination.uuid, device_id)
         };
         let pre_key_response: PreKeyResponse = self
             .get_json(Endpoint::Service, &path, HttpAuthOverride::NoOverride)


### PR DESCRIPTION
Since two months, Signal supports PQ E2E sessions. This PR adds this support to libsignal-service-rs.