### PR TITLE
Remove prelude::{zkgroup,protocol} in favour of direct reexports

### DIFF
--- a/libsignal-service-actix/src/push_service.rs
+++ b/libsignal-service-actix/src/push_service.rs
@@ -551,10 +551,4 @@ mod tests {
             );
         }
     }
-
-    #[test]
-    fn serde_json_from_null() {
-        // We are using this to generate empty JSON from empty responses
-        assert_eq!("{}", serde_json::from_slice::<&str>(b"null").unwrap());
-    }
 }

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -89,21 +89,7 @@ pub mod prelude {
     pub use phonenumber;
     pub use prost::Message as ProtobufMessage;
     pub use uuid::{Error as UuidError, Uuid};
-    pub use zkgroup::{
-        groups::{GroupMasterKey, GroupSecretParams},
-        profiles::ProfileKey,
-    };
-
-    pub mod protocol {
-        pub use crate::session_store::SessionStoreExt;
-        pub use libsignal_protocol::{
-            Context, DeviceId, Direction, GenericSignedPreKey, IdentityKey,
-            IdentityKeyPair, IdentityKeyStore, KeyPair, KyberPreKeyId,
-            KyberPreKeyRecord, KyberPreKeyStore, PreKeyId, PreKeyRecord,
-            PreKeyStore, PrivateKey, ProtocolAddress, ProtocolStore, PublicKey,
-            SenderCertificate, SenderKeyRecord, SenderKeyStore, SessionRecord,
-            SessionStore, SignalProtocolError, SignedPreKeyId,
-            SignedPreKeyRecord, SignedPreKeyStore,
-        };
-    }
 }
+
+pub use libsignal_protocol as protocol;
+pub use zkgroup;

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -93,6 +93,8 @@ pub mod prelude {
         groups::{GroupMasterKey, GroupSecretParams},
         profiles::ProfileKey,
     };
+
+    pub use libsignal_protocol::DeviceId;
 }
 
 pub use libsignal_protocol as protocol;

--- a/libsignal-service/src/lib.rs
+++ b/libsignal-service/src/lib.rs
@@ -89,6 +89,10 @@ pub mod prelude {
     pub use phonenumber;
     pub use prost::Message as ProtobufMessage;
     pub use uuid::{Error as UuidError, Uuid};
+    pub use zkgroup::{
+        groups::{GroupMasterKey, GroupSecretParams},
+        profiles::ProfileKey,
+    };
 }
 
 pub use libsignal_protocol as protocol;


### PR DESCRIPTION
This removes a maintenance and development burden, and feels more logical and consistent to me. Dependees on libsignal-service can now drop the direct dep on libsignal-protocol/zkgroup/...