### PR TITLE
Registration fixes for 2023

### DIFF
--- a/libsignal-service-actix/examples/registering.rs
+++ b/libsignal-service-actix/examples/registering.rs
@@ -18,36 +18,165 @@
 //! ```
 
 use anyhow::Error;
-use libsignal_service::{
-    configuration::*, provisioning::ProvisioningManager, USER_AGENT,
+use libsignal_service::configuration::SignalServers;
+use libsignal_service::prelude::{ProfileKey, ServiceCredentials};
+use libsignal_service::provisioning::generate_registration_id;
+use libsignal_service::push_service::{
+    AccountAttributes, DeviceCapabilities, PushService, RegistrationMethod,
+    VerificationTransport,
 };
+use libsignal_service::USER_AGENT;
 use libsignal_service_actix::prelude::AwcPushService;
+use rand::RngCore;
 use structopt::StructOpt;
 
 #[actix_rt::main]
 async fn main() -> Result<(), Error> {
     env_logger::init();
+    let client = "libsignal-service-hyper-example";
+    let use_voice = false;
 
-    let args = Args::from_args();
+    let Args {
+        servers,
+        phonenumber,
+        password,
+        captcha,
+    } = Args::from_args();
+
+    let push_token = None;
+    // Mobile country code and mobile network code can in theory be extracted from the phone
+    // number, but it's not necessary for the API to function correctly.
+    // XXX: We could internalize this if statement to create_verification_session
+    let (mcc, mnc) = if let Some(carrier) = phonenumber.carrier() {
+        (Some(&carrier[0..3]), Some(&carrier[3..]))
+    } else {
+        (None, None)
+    };
 
     // Only used with MessageSender and MessageReceiver
     // let password = args.get_password()?;
 
-    let mut push_service =
-        AwcPushService::new(args.servers, None, USER_AGENT.into());
-    let mut provision_manager: ProvisioningManager<AwcPushService> =
-        ProvisioningManager::new(
-            &mut push_service,
-            args.username,
-            args.password.unwrap(),
-        );
+    let mut push_service = AwcPushService::new(
+        servers,
+        Some(ServiceCredentials {
+            uuid: None,
+            phonenumber: phonenumber.clone(),
+            password,
+            signaling_key: None,
+            device_id: None,
+        }),
+        USER_AGENT.into(),
+    );
 
-    provision_manager
-        // You probably want to generate a reCAPTCHA though!
-        .request_sms_verification_code(None, None)
-        .await?;
+    let mut session = push_service
+        .create_verification_session(
+            &phonenumber.to_string(),
+            push_token,
+            mcc,
+            mnc,
+        )
+        .await
+        .expect("create a registration verification session");
+    println!("Sending registration request...");
+
+    if session.captcha_required() {
+        session = push_service
+            .patch_verification_session(
+                &session.id,
+                None,
+                None,
+                None,
+                captcha.as_deref(),
+                None,
+            )
+            .await
+            .expect("submit captcha");
+    }
+
+    if session.push_challenge_required() {
+        anyhow::bail!("Push challenge required, but not implemented.");
+    }
+
+    if !session.allowed_to_request_code {
+        anyhow::bail!(
+            "Not allowed to request verification code, reason unknown: {session:?}",
+        );
+    }
+
+    session = push_service
+        .request_verification_code(
+            &session.id,
+            client,
+            if use_voice {
+                VerificationTransport::Voice
+            } else {
+                VerificationTransport::Sms
+            },
+        )
+        .await
+        .expect("request verification code");
+
+    let confirmation_code = let_user_enter_confirmation_code();
+
+    println!("Submitting confirmation code...");
+
+    session = push_service
+        .submit_verification_code(&session.id, confirmation_code)
+        .await
+        .expect("Sending confirmation code failed.");
+
+    if !session.verified {
+        anyhow::bail!("Session is not verified");
+    }
+
+    let registration_id = generate_registration_id(&mut rand::thread_rng());
+    let pni_registration_id = generate_registration_id(&mut rand::thread_rng());
+    let signaling_key = generate_signaling_key();
+    let mut profile_key = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut profile_key);
+    let profile_key = ProfileKey::create(profile_key);
+    let skip_device_transfer = false;
+    let _registration_data = push_service
+        .submit_registration_request(
+            RegistrationMethod::SessionId(&session.id),
+            AccountAttributes {
+                signaling_key: Some(signaling_key.to_vec()),
+                registration_id,
+                pni_registration_id,
+                voice: false,
+                video: false,
+                fetches_messages: true,
+                pin: None,
+                registration_lock: None,
+                unidentified_access_key: Some(
+                    profile_key.derive_access_key().to_vec(),
+                ),
+                unrestricted_unidentified_access: false, // TODO: make this configurable?
+                discoverable_by_phone_number: true,
+                name: Some("libsignal-service-hyper test".into()),
+                capabilities: DeviceCapabilities::default(),
+            },
+            skip_device_transfer,
+        )
+        .await;
+
+    // You would want to store the registration data
+
+    println!("Registration completed!");
 
     Ok(())
+}
+
+fn let_user_enter_confirmation_code() -> &'static str {
+    "12345"
+}
+
+fn generate_signaling_key() -> [u8; 52] {
+    // Signaling key that decrypts the incoming Signal messages
+    let mut rng = rand::thread_rng();
+    let mut signaling_key = [0u8; 52];
+    rng.fill_bytes(&mut signaling_key);
+    signaling_key
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, StructOpt)]
@@ -65,11 +194,17 @@ pub struct Args {
         help = "Your username or other identifier",
         default_value = "+14151231234"
     )]
-    pub username: phonenumber::PhoneNumber,
+    pub phonenumber: phonenumber::PhoneNumber,
     #[structopt(
         short = "p",
         long = "password",
         help = "The password to use. Read from stdin if not provided"
     )]
     pub password: Option<String>,
+    #[structopt(
+        short = "c",
+        long = "captcha",
+        help = "Captcha for registration"
+    )]
+    pub captcha: Option<String>,
 }

--- a/libsignal-service-actix/src/push_service.rs
+++ b/libsignal-service-actix/src/push_service.rs
@@ -310,6 +310,52 @@ impl PushService for AwcPushService {
         Self::json(&text)
     }
 
+    async fn post_json<D, S>(
+        &mut self,
+        endpoint: Endpoint,
+        path: &str,
+        credentials_override: HttpAuthOverride,
+        value: S,
+    ) -> Result<D, ServiceError>
+    where
+        for<'de> D: Deserialize<'de>,
+        S: Serialize,
+    {
+        let mut response = self
+            .request(Method::POST, endpoint, path, credentials_override)?
+            .send_json(&value)
+            .await
+            .map_err(|e| ServiceError::SendError {
+                reason: e.to_string(),
+            })?;
+
+        log::debug!("AwcPushService::post response: {:?}", response);
+
+        Self::from_response(&mut response).await?;
+
+        // In order to catch the zero-length output, we have to collect
+        // the whole response. The actix-web api is meant to used as a
+        // streaming deserializer, so we have this little awkward match.
+        //
+        // This is also the reason we depend directly on serde_json, however
+        // actix already imports that anyway.
+        let text = match response.body().await {
+            Ok(text) => {
+                log::debug!(
+                    "GET response: {:?}",
+                    String::from_utf8_lossy(&text)
+                );
+                text
+            },
+            Err(e) => {
+                return Err(ServiceError::ResponseError {
+                    reason: e.to_string(),
+                })
+            },
+        };
+        Self::json(&text)
+    }
+
     async fn get_protobuf<T>(
         &mut self,
         endpoint: Endpoint,

--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -345,6 +345,39 @@ impl PushService for HyperPushService {
         Self::json(&mut response).await
     }
 
+    async fn patch_json<D, S>(
+        &mut self,
+        service: Endpoint,
+        path: &str,
+        credentials_override: HttpAuthOverride,
+        value: S,
+    ) -> Result<D, ServiceError>
+    where
+        for<'de> D: Deserialize<'de>,
+        S: MaybeSend + Serialize,
+    {
+        let json = serde_json::to_vec(&value).map_err(|e| {
+            ServiceError::JsonDecodeError {
+                reason: e.to_string(),
+            }
+        })?;
+
+        let mut response = self
+            .request(
+                Method::PATCH,
+                service,
+                path,
+                credentials_override,
+                Some(RequestBody {
+                    contents: json,
+                    content_type: "application/json".into(),
+                }),
+            )
+            .await?;
+
+        Self::json(&mut response).await
+    }
+
     async fn post_json<D, S>(
         &mut self,
         service: Endpoint,

--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -345,6 +345,39 @@ impl PushService for HyperPushService {
         Self::json(&mut response).await
     }
 
+    async fn post_json<D, S>(
+        &mut self,
+        service: Endpoint,
+        path: &str,
+        credentials_override: HttpAuthOverride,
+        value: S,
+    ) -> Result<D, ServiceError>
+    where
+        for<'de> D: Deserialize<'de>,
+        S: MaybeSend + Serialize,
+    {
+        let json = serde_json::to_vec(&value).map_err(|e| {
+            ServiceError::JsonDecodeError {
+                reason: e.to_string(),
+            }
+        })?;
+
+        let mut response = self
+            .request(
+                Method::POST,
+                service,
+                path,
+                credentials_override,
+                Some(RequestBody {
+                    contents: json,
+                    content_type: "application/json".into(),
+                }),
+            )
+            .await?;
+
+        Self::json(&mut response).await
+    }
+
     async fn get_protobuf<T>(
         &mut self,
         service: Endpoint,

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -41,12 +41,6 @@ pub struct ConfirmCodeResponse {
     pub storage_capable: bool,
 }
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum VerificationCodeResponse {
-    CaptchaRequired,
-    Issued,
-}
-
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VerifyAccountResponse {

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -82,7 +82,7 @@ impl<'a, P: PushService + 'a> ProvisioningManager<'a, P> {
 
     pub(crate) async fn confirm_device(
         &mut self,
-        confirm_code: u32,
+        confirm_code: &str,
         confirm_code_message: ConfirmDeviceMessage,
     ) -> Result<DeviceId, ServiceError> {
         self.push_service
@@ -235,16 +235,15 @@ impl<P: PushService> LinkingManager<P> {
                         self.password.clone(),
                     );
 
+                    let provisioning_code = message.provisioning_code.ok_or(
+                        ProvisioningError::InvalidData {
+                            reason: "no provisioning confirmation code".into(),
+                        },
+                    )?;
+
                     let device_id = provisioning_manager
                         .confirm_device(
-                            message
-                                .provisioning_code
-                                .ok_or(ProvisioningError::InvalidData {
-                                    reason: "no provisioning confirmation code"
-                                        .into(),
-                                })?
-                                .parse()
-                                .unwrap(),
+                            &provisioning_code,
                             ConfirmDeviceMessage {
                                 signaling_key: signaling_key.to_vec(),
                                 supports_sms: false,

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -14,8 +14,7 @@ use super::{
 use crate::{
     configuration::{Endpoint, ServiceCredentials, SignalingKey},
     push_service::{
-        AccountAttributes, DeviceId, HttpAuthOverride, PushService,
-        ServiceError, ServiceIds,
+        DeviceId, HttpAuthOverride, PushService, ServiceError, ServiceIds,
     },
     utils::serde_base64,
 };
@@ -38,14 +37,6 @@ pub(crate) struct ConfirmDeviceMessage {
 #[serde(rename_all = "camelCase")]
 pub struct ConfirmCodeResponse {
     pub uuid: Uuid,
-    pub storage_capable: bool,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct VerifyAccountResponse {
-    pub uuid: Uuid,
-    pub pni: Uuid,
     pub storage_capable: bool,
 }
 
@@ -87,21 +78,6 @@ impl<'a, P: PushService + 'a> ProvisioningManager<'a, P> {
             phone_number,
             password,
         }
-    }
-
-    pub async fn confirm_verification_code(
-        &mut self,
-        confirm_code: impl AsRef<str>,
-        account_attributes: AccountAttributes,
-    ) -> Result<VerifyAccountResponse, ServiceError> {
-        self.push_service
-            .put_json(
-                Endpoint::Service,
-                &format!("/v1/accounts/code/{}", confirm_code.as_ref()),
-                self.auth_override(),
-                account_attributes,
-            )
-            .await
     }
 
     pub(crate) async fn confirm_device(

--- a/libsignal-service/src/provisioning/mod.rs
+++ b/libsignal-service/src/provisioning/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod pipe;
 pub use cipher::ProvisioningCipher;
 pub use manager::{
     ConfirmCodeResponse, LinkingManager, ProvisioningManager,
-    SecondaryDeviceProvisioning, VerifyAccountResponse,
+    SecondaryDeviceProvisioning,
 };
 
 use crate::prelude::ServiceError;

--- a/libsignal-service/src/provisioning/mod.rs
+++ b/libsignal-service/src/provisioning/mod.rs
@@ -5,8 +5,7 @@ pub(crate) mod pipe;
 pub use cipher::ProvisioningCipher;
 pub use manager::{
     ConfirmCodeResponse, LinkingManager, ProvisioningManager,
-    SecondaryDeviceProvisioning, VerificationCodeResponse,
-    VerifyAccountResponse,
+    SecondaryDeviceProvisioning, VerifyAccountResponse,
 };
 
 use crate::prelude::ServiceError;

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -1177,7 +1177,7 @@ pub trait PushService: MaybeSend {
             .post_json(
                 Endpoint::Service,
                 "/v1/registration",
-                HttpAuthOverride::Unidentified,
+                HttpAuthOverride::NoOverride,
                 req,
             )
             .await?;

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -536,6 +536,17 @@ pub trait PushService: MaybeSend {
         for<'de> D: Deserialize<'de>,
         S: MaybeSend + Serialize;
 
+    async fn patch_json<D, S>(
+        &mut self,
+        service: Endpoint,
+        path: &str,
+        credentials_override: HttpAuthOverride,
+        value: S,
+    ) -> Result<D, ServiceError>
+    where
+        for<'de> D: Deserialize<'de>,
+        S: MaybeSend + Serialize;
+
     async fn post_json<D, S>(
         &mut self,
         service: Endpoint,

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -1046,6 +1046,48 @@ pub trait PushService: MaybeSend {
     }
 
     // Equivalent of Java's
+    // RegistrationSessionMetadataResponse patchVerificationSession(String sessionId, @Nullable String pushToken, @Nullable String mcc, @Nullable String mnc, @Nullable String captchaToken, @Nullable String pushChallengeToken)
+    async fn patch_verification_session<'a>(
+        &mut self,
+        session_id: &'a str,
+        push_token: Option<&'a str>,
+        mcc: Option<&'a str>,
+        mnc: Option<&'a str>,
+        captcha: Option<&'a str>,
+        push_challenge: Option<&'a str>,
+    ) -> Result<RegistrationSessionMetadataResponse, ServiceError> {
+        #[derive(serde::Serialize, Debug)]
+        #[serde(rename_all = "camelCase")]
+        struct UpdateVerificationSessionRequestBody<'a> {
+            captcha: Option<&'a str>,
+            push_token: Option<&'a str>,
+            push_challenge: Option<&'a str>,
+            mcc: Option<&'a str>,
+            mnc: Option<&'a str>,
+            push_token_type: Option<&'a str>,
+        }
+
+        let req = UpdateVerificationSessionRequestBody {
+            captcha,
+            push_token_type: push_token.as_ref().map(|_| "fcm"),
+            push_token,
+            mcc,
+            mnc,
+            push_challenge,
+        };
+
+        let res: RegistrationSessionMetadataResponse = self
+            .patch_json(
+                Endpoint::Service,
+                &format!("/v1/verification/session/{}", session_id),
+                HttpAuthOverride::Unidentified,
+                req,
+            )
+            .await?;
+        Ok(res)
+    }
+
+    // Equivalent of Java's
     // RegistrationSessionMetadataResponse requestVerificationCode(String sessionId, Locale locale, boolean androidSmsRetriever, VerificationCodeTransport transport)
     /// Request a verification code.
     ///

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     profile_cipher::ProfileCipherError,
     proto::{attachment_pointer::AttachmentIdentifier, AttachmentPointer},
-    provisioning::VerifyAccountResponse,
     sender::{OutgoingPushMessages, SendMessageResponse},
     utils::{serde_base64, serde_optional_base64, serde_phone_number},
     websocket::SignalWebSocket,
@@ -263,6 +262,16 @@ impl RegistrationSessionMetadataResponse {
             .iter()
             .any(|x| x.as_str() == "captcha")
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyAccountResponse {
+    pub uuid: Uuid,
+    pub pni: Uuid,
+    pub storage_capable: bool,
+    #[serde(default)]
+    pub number: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -461,6 +461,17 @@ pub trait PushService: MaybeSend {
         for<'de> D: Deserialize<'de>,
         S: MaybeSend + Serialize;
 
+    async fn post_json<D, S>(
+        &mut self,
+        service: Endpoint,
+        path: &str,
+        credentials_override: HttpAuthOverride,
+        value: S,
+    ) -> Result<D, ServiceError>
+    where
+        for<'de> D: Deserialize<'de>,
+        S: MaybeSend + Serialize;
+
     async fn get_protobuf<T>(
         &mut self,
         service: Endpoint,

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -1044,4 +1044,23 @@ pub trait PushService: MaybeSend {
             .await?;
         Ok(res)
     }
+
+    async fn submit_verification_code(
+        &mut self,
+        session_id: &str,
+        verification_code: &str,
+    ) -> Result<RegistrationSessionMetadataResponse, ServiceError> {
+        let mut req = std::collections::HashMap::new();
+        req.insert("code", verification_code);
+
+        let res: RegistrationSessionMetadataResponse = self
+            .put_json(
+                Endpoint::Service,
+                &format!("/v1/verification/session/{}/code", session_id),
+                HttpAuthOverride::Unidentified,
+                req,
+            )
+            .await?;
+        Ok(res)
+    }
 }


### PR DESCRIPTION
The registration procedure has changed a few months ago, and the old API has been terminated. This is an attempt to expose the new registration API surface for Whisperfish. All the other clients I know are secondary-only, so this shouldn't affect anyone but Whisperfish.