### PR TITLE
Accept raw string confirmation code on confirm device

### DIFF
--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -346,12 +346,11 @@ impl<P: PushService> LinkingManager<P> {
                         self.password.clone(),
                     );
 
-                    let provisioning_code = message
-                        .provisioning_code
-                        .ok_or(ProvisioningError::InvalidData {
-                            reason: "no provisioning confirmation code"
-                                .into(),
-                        })?;
+                    let provisioning_code = message.provisioning_code.ok_or(
+                        ProvisioningError::InvalidData {
+                            reason: "no provisioning confirmation code".into(),
+                        },
+                    )?;
 
                     let device_id = provisioning_manager
                         .confirm_device(

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -170,7 +170,7 @@ impl<'a, P: PushService + 'a> ProvisioningManager<'a, P> {
 
     pub(crate) async fn confirm_device(
         &mut self,
-        confirm_code: u32,
+        confirm_code: &str,
         confirm_code_message: ConfirmDeviceMessage,
     ) -> Result<DeviceId, ServiceError> {
         self.push_service
@@ -346,16 +346,16 @@ impl<P: PushService> LinkingManager<P> {
                         self.password.clone(),
                     );
 
+                    let provisioning_code = message
+                        .provisioning_code
+                        .ok_or(ProvisioningError::InvalidData {
+                            reason: "no provisioning confirmation code"
+                                .into(),
+                        })?;
+
                     let device_id = provisioning_manager
                         .confirm_device(
-                            message
-                                .provisioning_code
-                                .ok_or(ProvisioningError::InvalidData {
-                                    reason: "no provisioning confirmation code"
-                                        .into(),
-                                })?
-                                .parse()
-                                .unwrap(),
+                            &provisioning_code,
                             ConfirmDeviceMessage {
                                 signaling_key: signaling_key.to_vec(),
                                 supports_sms: false,


### PR DESCRIPTION
Got a panic here today, seems to have been changed recently.

Removes u32 validation, since it seems signal isn't sticking to u32 codes. Besides, it's just converting to a u32 to then converting back to a string on the url. Backwards compatible.