### PR TITLE
Derive mcc/mnc inside of registration methods

### DIFF
--- a/libsignal-service-actix/examples/registering.rs
+++ b/libsignal-service-actix/examples/registering.rs
@@ -82,9 +82,8 @@ async fn main() -> Result<(), Error> {
     if session.captcha_required() {
         session = push_service
             .patch_verification_session(
+                &phonenumber,
                 &session.id,
-                None,
-                None,
                 None,
                 captcha.as_deref(),
                 None,

--- a/libsignal-service-hyper/examples/registering.rs
+++ b/libsignal-service-hyper/examples/registering.rs
@@ -26,10 +26,7 @@ async fn main() {
     let mut push_service =
         create_push_service(phonenumber.clone(), password.clone());
     let mut session = push_service
-        .create_verification_session(
-            &phonenumber,
-            push_token,
-        )
+        .create_verification_session(&phonenumber, push_token)
         .await
         .expect("create a registration verification session");
     println!("Sending registration request...");
@@ -115,7 +112,8 @@ async fn main() {
             },
             skip_device_transfer,
         )
-        .await.expect("failed to register");
+        .await
+        .expect("failed to register");
 
     // You would want to store the registration data
 

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -1186,7 +1186,7 @@ pub trait PushService: MaybeSend {
 
 trait PhoneNumberExt {
     fn mcc(&self) -> Option<&str>;
-    fn mnc(&self) -> Option<&str>; 
+    fn mnc(&self) -> Option<&str>;
 }
 
 impl PhoneNumberExt for PhoneNumber {


### PR DESCRIPTION
This was a sort of TODO in https://github.com/whisperfish/libsignal-service-rs/pull/238 but when adapting `presage` I felt like this would be better like suggested in the comment.