### PR TITLE
Add server_guid to Metadata

### DIFF
--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -103,6 +103,15 @@ where
             });
         };
 
+        let server_guid =
+            envelope.server_guid.as_ref().and_then(|g| match g.parse() {
+                Ok(uuid) => Some(uuid),
+                Err(e) => {
+                    log::error!("Unparseable server_guid ({})", e);
+                    None
+                },
+            });
+
         use crate::proto::envelope::Type;
         let plaintext = match envelope.r#type() {
             Type::PrekeyBundle => {
@@ -118,6 +127,7 @@ where
                     timestamp: envelope.server_timestamp(),
                     needs_receipt: false,
                     unidentified_sender: false,
+                    server_guid,
                 };
 
                 let mut data = message_decrypt_prekey(
@@ -154,6 +164,7 @@ where
                     timestamp: envelope.server_timestamp(),
                     needs_receipt: false,
                     unidentified_sender: false,
+                    server_guid,
                 };
                 Plaintext {
                     metadata,
@@ -173,6 +184,7 @@ where
                     timestamp: envelope.timestamp(),
                     needs_receipt: false,
                     unidentified_sender: false,
+                    server_guid,
                 };
 
                 let mut data = message_decrypt_signal(
@@ -241,6 +253,7 @@ where
                     timestamp: envelope.timestamp(),
                     unidentified_sender: true,
                     needs_receipt,
+                    server_guid,
                 };
 
                 strip_padding(&mut message)?;

--- a/libsignal-service/src/content.rs
+++ b/libsignal-service/src/content.rs
@@ -24,6 +24,9 @@ pub struct Metadata {
     pub needs_receipt: bool,
     pub unidentified_sender: bool,
 
+    /// A unique UUID for this specific message, produced by the Signal servers.
+    ///
+    /// The server GUID is used to report spam messages.
     pub server_guid: Option<Uuid>,
 }
 

--- a/libsignal-service/src/content.rs
+++ b/libsignal-service/src/content.rs
@@ -1,4 +1,5 @@
 use libsignal_protocol::ProtocolAddress;
+use uuid::Uuid;
 
 pub use crate::{
     proto::{
@@ -22,6 +23,8 @@ pub struct Metadata {
     pub timestamp: u64,
     pub needs_receipt: bool,
     pub unidentified_sender: bool,
+
+    pub server_guid: Option<Uuid>,
 }
 
 impl Metadata {


### PR DESCRIPTION
This is unlike Signal Android, where the Envelope is also continously passed while processing the already decrypted content.  In Rust, we logically would *consume* the envelope to yield the Metadata and Content, so I prefer the Metadata to contain this information.