### PR TITLE
Correct license specifiers

### DIFF
--- a/libsignal-service-actix/Cargo.toml
+++ b/libsignal-service-actix/Cargo.toml
@@ -3,6 +3,7 @@ name = "libsignal-service-actix"
 version = "0.1.0"
 authors = ["Ruben De Smet <ruben.de.smet@rubdos.be>"]
 edition = "2018"
+license = "AGPL-3.0"
 
 [dependencies]
 # Contrary to hyper, actix does not have Send compatible futures, which means

--- a/libsignal-service-hyper/Cargo.toml
+++ b/libsignal-service-hyper/Cargo.toml
@@ -3,6 +3,7 @@ name = "libsignal-service-hyper"
 version = "0.1.0"
 authors = ["Gabriel Féron <g@leirbag.net>"]
 edition = "2018"
+license = "AGPL-3.0"
 
 [dependencies]
 libsignal-service = { path = "../libsignal-service" }

--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -3,7 +3,7 @@ name = "libsignal-service"
 version = "0.1.0"
 authors = ["Ruben De Smet <ruben.de.smet@rubdos.be>", "Gabriel Féron <g@leirbag.net>", "Michael Bryan <michaelfbryan@gmail.com>", "Shady Khalifa <shekohex@gmail.com>"]
 edition = "2018"
-license = "GPLv3"
+license = "AGPL-3.0"
 readme = "../README.md"
 
 [dependencies]


### PR DESCRIPTION
I'm messing around with `cargo deny`, and noticed that the licenses were unspecified in Cargo.toml for the implementation crates, and it was plain wrong in the main crate. License should be AGPL-3.0 for all.

We may want to start using `cargo deny` in CI here too, but I'll toy around in Whisperfish first.