### PR TITLE
MSRV 1.61

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           args: --manifest-path ${{ matrix.project }}/Cargo.toml
 
   build:
-    name: Build
+    name: Build ${{ matrix.project }} / Rust ${{ matrix.toolchain }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,10 +50,7 @@ jobs:
             coverage: false
         include:
           - project: "libsignal-service-actix"
-            # toolchain: "1.52.1"
-            toolchain: "nightly-2021-05-06"
-            features: "rust-1-52"
-            can-fail: true
+            toolchain: "1.61"
             coverage: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           args: --manifest-path ${{ matrix.project }}/Cargo.toml
 
   build:
-    name: Build ${{ matrix.project }} / Rust ${{ matrix.toolchain }}
+    name: Build (${{ matrix.project }}, Rust ${{ matrix.toolchain }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,18 +33,14 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.can-fail }}
     strategy:
       fail-fast: false
       matrix:
         project: ["libsignal-service-actix", "libsignal-service-hyper"]
         toolchain: ["stable", "nightly"]
-        can-fail: [false]
         coverage: [false, true]
         exclude:
           - toolchain: stable
-            coverage: true
-          - toolchain: beta
             coverage: true
           - toolchain: nightly
             coverage: false
@@ -64,20 +60,20 @@ jobs:
         if: ${{ !matrix.coverage }}
         with:
           command: test
-          args: --all-targets --no-fail-fast --manifest-path ${{ matrix.project }}/Cargo.toml --features "${{ matrix.features }}"
+          args: --all-targets --no-fail-fast --manifest-path ${{ matrix.project }}/Cargo.toml
 
       - name: Build
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-targets --manifest-path ${{ matrix.project }}/Cargo.toml --features "${{ matrix.features }}"
+          args: --all-targets --manifest-path ${{ matrix.project }}/Cargo.toml
 
       - name: Run tests
         uses: actions-rs/cargo@v1
         if: ${{ matrix.coverage }}
         with:
           command: test
-          args: --all-targets --no-fail-fast --manifest-path ${{ matrix.project }}/Cargo.toml --features "${{ matrix.features }}"
+          args: --all-targets --no-fail-fast --manifest-path ${{ matrix.project }}/Cargo.toml
         env:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you're using a Cargo workspace, you should add the `[patch.crates.io]` sectio
 
 ### Note on supported Rust versions
 
-`libsignal-service-rs` is the at the core of [Whisperfish][whisperfish], a SailfishOS application. The SailfishOS Rust compiler is relatively old, and therefore the MSRV for `libsignal-service-actix` maps on the compiler for that operating system, including some lag. At moment of writing, this is **Rust 1.52.1** (soon to be updated to 1.61).
+`libsignal-service-rs` is the at the core of [Whisperfish][whisperfish], a SailfishOS application. The SailfishOS Rust compiler is relatively old, and therefore the MSRV for `libsignal-service-actix` maps on the compiler for that operating system, including some lag. At moment of writing, this is **Rust 1.61**.
 
 For other platforms, we don't mandate MSRV.
 

--- a/libsignal-service-actix/Cargo.toml
+++ b/libsignal-service-actix/Cargo.toml
@@ -31,9 +31,6 @@ base64 = "0.13"
 
 phonenumber = "0.3"
 
-proc-macro2 = { version = "1.0.66", optional = true }
-quote = { version = "1.0.33", optional = true }
-
 [dev-dependencies]
 env_logger = "0.9"
 image = { version = "0.23", default-features = false, features = ["png"] }
@@ -42,6 +39,3 @@ qrcode = "0.12"
 structopt = "0.3"
 tokio = { version = "1", features = ["macros"] }
 anyhow = "1.0"
-
-[features]
-rust-1-52 = ["proc-macro2", "quote"]


### PR DESCRIPTION
Supersedes #149. Whisperfish will not be able to update libsignal-service for a while since libsignal-client 0.32, but we'll take that hit internally. You folks don't have to suffer anymore under 1.52 :-)