### PR TITLE
Ensure self-sending is unidentified

### DIFF
--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -339,7 +339,7 @@ where
                     );
                 self.try_send_message(
                     self.local_address,
-                    None,
+                    unidentified_access.as_ref(),
                     &sync_message,
                     timestamp,
                     false,
@@ -415,7 +415,7 @@ where
                 let result = self
                     .try_send_message(
                         self.local_address,
-                        None,
+                        unidentified_access.as_ref(),
                         &sync_message,
                         timestamp,
                         false,


### PR DESCRIPTION
I previously thought this was incorrect, but I'm coming back from that. Untested. If someone else could test, that would be really neat :D