### PR TITLE
1.64 MSRV

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
             coverage: false
         include:
           - project: "libsignal-service-actix"
-            toolchain: "1.61"
+            toolchain: "1.64"
             coverage: false
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you're using a Cargo workspace, you should add the `[patch.crates.io]` sectio
 
 ### Note on supported Rust versions
 
-`libsignal-service-rs` is the at the core of [Whisperfish][whisperfish], a SailfishOS application. The SailfishOS Rust compiler is relatively old, and therefore the MSRV for `libsignal-service-actix` maps on the compiler for that operating system, including some lag. At moment of writing, this is **Rust 1.61**.
+`libsignal-service-rs` is the at the core of [Whisperfish][whisperfish], a SailfishOS application. The SailfishOS Rust compiler is relatively old, and therefore the MSRV for `libsignal-service-actix` maps on the compiler for that operating system, including some lag. At moment of writing, this is **Rust 1.64**.
 
 For other platforms, we don't mandate MSRV.
 


### PR DESCRIPTION
It seems like we will have [Rust 1.64](https://github.com/sailfishos/rust/pull/19) on Sailfish OS soon™, so this makes our lives here a bit easier.

I'm still trying to get 1.72.1 through too, but I can't promise that yet.