### PR TITLE
fix: RUSTSEC-2023-0065 (part 2)

### DIFF
--- a/libsignal-service-actix/Cargo.toml
+++ b/libsignal-service-actix/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Ruben De Smet <ruben.de.smet@rubdos.be>"]
 edition = "2018"
 license = "AGPL-3.0"
+rust-version = "1.70.0"
 
 [dependencies]
 # Contrary to hyper, actix does not have Send compatible futures, which means

--- a/libsignal-service-hyper/Cargo.toml
+++ b/libsignal-service-hyper/Cargo.toml
@@ -20,15 +20,15 @@ thiserror = "1.0"
 url = "2.1"
 
 hyper = { version = "0.14", features = ["client", "stream"] }
-hyper-rustls = "0.23"
+hyper-rustls = "0.24"
 hyper-timeout = "0.4"
 headers = "0.3"
 
 # for websocket support
-async-tungstenite = { version = "0.21", features = ["tokio-rustls-native-certs"] }
+async-tungstenite = { version = "0.23", features = ["tokio-rustls-native-certs"] }
 
 tokio = { version = "1.0", features = ["macros"] }
-tokio-rustls = "0.23"
+tokio-rustls = "0.24"
 
 rustls-pemfile = "0.3"
 


### PR DESCRIPTION
Fix security issue by upgrading tungstenite v0.19.0 -> v0.20.1.

Also specify MSRV in libsignal-service-hyper as 1.70.