### PR TITLE
Fix sending SyncMessage to self

### DIFF
--- a/libsignal-service/src/proto.rs
+++ b/libsignal-service/src/proto.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::all)]
+
+use rand::{Rng, RngCore};
 include!(concat!(env!("OUT_DIR"), "/signalservice.rs"));
 include!(concat!(env!("OUT_DIR"), "/signal.rs"));
 
@@ -62,6 +64,20 @@ impl WebSocketResponseMessage {
                 message: Some("Unknown".to_string()),
                 ..Default::default()
             }
+        }
+    }
+}
+
+impl SyncMessage {
+    pub fn with_padding() -> Self {
+        let mut rng = rand::thread_rng();
+        let random_size = rng.gen_range(1..=512);
+        let mut padding: Vec<u8> = vec![0; random_size];
+        rng.fill_bytes(&mut padding);
+
+        Self {
+            padding: Some(padding),
+            ..Default::default()
         }
     }
 }

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -126,7 +126,7 @@ where
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        ws: SignalWebSocket,
+        identified_ws: SignalWebSocket,
         unidentified_ws: SignalWebSocket,
         service: Service,
         cipher: ServiceCipher<S, R>,
@@ -137,7 +137,7 @@ where
     ) -> Self {
         MessageSender {
             service,
-            identified_ws: ws,
+            identified_ws,
             unidentified_ws,
             cipher,
             csprng,

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -641,7 +641,7 @@ where
                 self.create_encrypted_message(
                     recipient,
                     unidentified_access,
-                    device_id.into(),
+                    device_id,
                     content,
                 )
                 .await?,

--- a/libsignal-service/src/websocket.rs
+++ b/libsignal-service/src/websocket.rs
@@ -95,7 +95,7 @@ impl<WS: WebSocketService> SignalWebSocketProcess<WS> {
         frame: Bytes,
     ) -> Result<(), ServiceError> {
         let msg = WebSocketMessage::decode(frame)?;
-        log::trace!("Decoded {:?}", msg);
+        log::trace!("decoded {:?}", msg);
 
         use web_socket_message::Type;
         match (msg.r#type(), msg.request, msg.response) {
@@ -184,7 +184,7 @@ impl<WS: WebSocketService> SignalWebSocketProcess<WS> {
                                     .filter(|x| !self.outgoing_request_map.contains_key(x))
                                     .unwrap_or_else(|| self.next_request_id()),
                             );
-                            log::trace!("Sending request {:?}", request);
+                            log::trace!("sending request {:?}", request);
 
                             self.outgoing_request_map.insert(request.id.unwrap(), responder);
                             let msg = WebSocketMessage {
@@ -227,7 +227,8 @@ impl<WS: WebSocketService> SignalWebSocketProcess<WS> {
                             self.ws.send_message(buffer.into()).await?
                         }
                         Some(WebSocketStreamItem::KeepAliveRequest) => {
-                            log::debug!("keep alive is disabled: ignoring request");
+                            log::trace!("keep-alive is disabled");
+                            continue;
                         }
                         None => {
                             return Err(ServiceError::WsError {
@@ -239,7 +240,7 @@ impl<WS: WebSocketService> SignalWebSocketProcess<WS> {
                 response = self.outgoing_responses.next() => {
                     match response {
                         Some(Ok(response)) => {
-                            log::trace!("Sending response {:?}", response);
+                            log::trace!("sending response {:?}", response);
 
                             let msg = WebSocketMessage {
                                 r#type: Some(web_socket_message::Type::Response.into()),

--- a/libsignal-service/src/websocket.rs
+++ b/libsignal-service/src/websocket.rs
@@ -227,8 +227,7 @@ impl<WS: WebSocketService> SignalWebSocketProcess<WS> {
                             self.ws.send_message(buffer.into()).await?
                         }
                         Some(WebSocketStreamItem::KeepAliveRequest) => {
-                            log::trace!("keep-alive is disabled");
-                            continue;
+                            log::trace!("keep alive is disabled: ignoring request");
                         }
                         None => {
                             return Err(ServiceError::WsError {


### PR DESCRIPTION
Fixes sending `SyncMessage` and to self.

- After looking at both Signal-Android and Signal-Desktop, we need to make sure any message sent to self is _never_ send unidentified
- Make sure we add padding to all `SyncMessage`
- Remove some redundant session loading before creating encrypted messages