### PR TITLE
Don't send messages to self device

### DIFF
--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -630,8 +630,8 @@ where
         // always send to the primary device no matter what
         devices.insert(DEFAULT_DEVICE_ID.into());
 
-        // when sending an identified message, remove ourselves from the list of recipients
-        if unidentified_access.is_none() {
+        // never try to send messages to the sender device
+        if recipient.aci() == self.local_address.aci() {
             devices.remove(&self.device_id);
         }
 


### PR DESCRIPTION
If we're sending a message to self, _always_ exclude the sending device itself.

Fixes #266 according to a quick test with Whisperfish running on Sailfish Emulator. I'm unable to link other devices, nor testing this with any other client, however.
