### PR TITLE
Don't send every DataMessage unsealed

### DIFF
--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -301,16 +301,13 @@ where
 
         let end_session = match &content_body {
             ContentBody::DataMessage(message) => {
-                unidentified_access.take(); // don't send end session as sealed sender
                 message.flags == Some(Flags::EndSession as u32)
             },
             _ => false,
         };
 
-        // we never send sync messages or to our own account as sealed sender
-        if recipient == &self.local_address
-            || matches!(&content_body, ContentBody::SynchronizeMessage(_))
-        {
+        // don't send anything to self nor session enders to others as sealed sender
+        if recipient == &self.local_address || end_session {
             unidentified_access.take();
         }
 


### PR DESCRIPTION
@Schmiddiii writes in Whisperfish Matrix channel:

> I have a question to https://github.com/whisperfish/libsignal-service-rs/pull/263: If I understand your code correctly, you take the `unidentified_access` on every single `DataMessage` [here](https://github.com/whisperfish/libsignal-service-rs/pull/263/files#diff-9ae521e6fffe43a399d2d3007bbccc81a73e245f5aa5663b007af1fa97dbcc26R304), which means [try_send_message](https://github.com/whisperfish/libsignal-service-rs/pull/263/files#diff-9ae521e6fffe43a399d2d3007bbccc81a73e245f5aa5663b007af1fa97dbcc26R311) always gets `None` as unidentified access. Am I misunderstanding something? Shouldn't it be something like `if end_session { unidentified_access.take() }`?

I took a look at the code, and I arrived at the same conclusion, and developed a fix for the logic. So: the code previously made every `DataMessage` be sent identified/unsealed, whereas the intention is to use identified/unsealed sending for 1) `EndSession` messages and 2) messages to other own devices.

This has already received some real-world testing, and seems to work fine. As such, I was asked to make it a PR, so here it is!