### PR TITLE
Enable keep-alive for provisioning socket

### DIFF
--- a/libsignal-service-actix/src/push_service.rs
+++ b/libsignal-service-actix/src/push_service.rs
@@ -625,9 +625,9 @@ impl PushService for AwcPushService {
     async fn ws(
         &mut self,
         path: &str,
+        keep_alive_path: &str,
         additional_headers: &[(&str, &str)],
         credentials: Option<ServiceCredentials>,
-        keep_alive: bool,
     ) -> Result<SignalWebSocket, ServiceError> {
         let (ws, stream) = AwcWebSocket::with_client(
             &mut self.client,
@@ -637,7 +637,11 @@ impl PushService for AwcPushService {
             credentials.as_ref(),
         )
         .await?;
-        let (ws, task) = SignalWebSocket::from_socket(ws, stream, keep_alive);
+        let (ws, task) = SignalWebSocket::from_socket(
+            ws,
+            stream,
+            keep_alive_path.to_owned(),
+        );
         actix_rt::spawn(task);
         Ok(ws)
     }

--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -582,9 +582,9 @@ impl PushService for HyperPushService {
     async fn ws(
         &mut self,
         path: &str,
+        keepalive_path: &str,
         additional_headers: &[(&str, &str)],
         credentials: Option<ServiceCredentials>,
-        keep_alive: bool,
     ) -> Result<SignalWebSocket, ServiceError> {
         let (ws, stream) = TungsteniteWebSocket::with_tls_config(
             Self::tls_config(&self.cfg),
@@ -594,7 +594,8 @@ impl PushService for HyperPushService {
             credentials.as_ref(),
         )
         .await?;
-        let (ws, task) = SignalWebSocket::from_socket(ws, stream, keep_alive);
+        let (ws, task) =
+            SignalWebSocket::from_socket(ws, stream, keepalive_path.into());
         tokio::task::spawn(task);
         Ok(ws)
     }

--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -595,7 +595,7 @@ impl PushService for HyperPushService {
         )
         .await?;
         let (ws, task) =
-            SignalWebSocket::from_socket(ws, stream, keepalive_path.into());
+            SignalWebSocket::from_socket(ws, stream, keepalive_path.to_owned());
         tokio::task::spawn(task);
         Ok(ws)
     }

--- a/libsignal-service/src/provisioning/manager.rs
+++ b/libsignal-service/src/provisioning/manager.rs
@@ -136,7 +136,12 @@ impl<P: PushService> LinkingManager<P> {
         // open a websocket without authentication, to receive a tsurl://
         let ws = self
             .push_service
-            .ws("/v1/websocket/provisioning/", &[], None, false)
+            .ws(
+                "/v1/websocket/provisioning/",
+                "/v1/keepalive/provisioning",
+                &[],
+                None,
+            )
             .await?;
 
         let registration_id = csprng.gen_range(1..256);

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -625,9 +625,9 @@ pub trait PushService: MaybeSend {
     async fn ws(
         &mut self,
         path: &str,
+        keepalive_path: &str,
         additional_headers: &[(&str, &str)],
         credentials: Option<ServiceCredentials>,
-        keep_alive: bool,
     ) -> Result<SignalWebSocket, ServiceError>;
 
     /// Fetches a list of all devices tied to the authenticated account.

--- a/libsignal-service/src/receiver.rs
+++ b/libsignal-service/src/receiver.rs
@@ -53,7 +53,12 @@ impl<Service: PushService> MessageReceiver<Service> {
         )];
         let ws = self
             .service
-            .ws("/v1/websocket/", headers, Some(credentials.clone()), true)
+            .ws(
+                "/v1/websocket/",
+                "/v1/keepalive",
+                headers,
+                Some(credentials.clone()),
+            )
             .await?;
         Ok(MessagePipe::from_socket(ws, credentials))
     }


### PR DESCRIPTION
Just found this while starting to look into linking errors.

Reference: https://github.com/signalapp/Signal-Desktop/blob/c6c072319993fefd9fcfab55ca77dc75263bc875/ts/textsecure/SocketManager.ts#L273