### PR TITLE
Bump libsignal to v0.37.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,10 @@ jobs:
         project: ["libsignal-service-actix", "libsignal-service-hyper"]
     steps:
       - uses: actions/checkout@v3
+      - name: Install protobuf
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-dev
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,6 +56,10 @@ jobs:
             coverage: false
     steps:
       - uses: actions/checkout@v3
+      - name: Install protobuf
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-dev
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = ["libsignal-service", "libsignal-service-actix", "libsignal-service-hy
 default-members = ["libsignal-service", "libsignal-service-hyper"]
 
 [patch.crates-io]
-curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', tag = 'signal-curve25519-4.0.0' }
+curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', tag = 'signal-curve25519-4.1.1' }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ libsignal-protocol = { git = "https://github.com/signalapp/libsignal-client", br
 zkgroup = { version = "0.9.0", git = "https://github.com/signalapp/libsignal-client", branch = "main" }
 
 [patch.crates-io]
-"curve25519-dalek" = { git = "https://github.com/signalapp/curve25519-dalek", tag = "signal-curve25519-4.0.0" }
+"curve25519-dalek" = { git = "https://github.com/signalapp/curve25519-dalek", tag = "signal-curve25519-4.1.1" }
 ```
 
 If you're using a Cargo workspace, you should add the `[patch.crates.io]` section in the root `Cargo.toml` file instead.

--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -7,8 +7,8 @@ license = "AGPL-3.0"
 readme = "../README.md"
 
 [dependencies]
-libsignal-protocol = { git = "https://github.com/signalapp/libsignal", tag = "v0.32.0" }
-zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.32.0" }
+libsignal-protocol = { git = "https://github.com/signalapp/libsignal", tag = "v0.37.0" }
+zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.37.0" }
 
 aes = { version = "0.7", features = ["ctr"] }
 aes-gcm = "0.9"


### PR DESCRIPTION
It just compiles ™️ 

It is required for downstream users to adjust the patched version of `curve25519-dalek`:

```toml
[patch.crates-io]
"curve25519-dalek" = { git = "https://github.com/signalapp/curve25519-dalek", tag = "signal-curve25519-4.1.1" }
```