### PR TITLE
Expose SignalWebSocket::is_closed

### DIFF
--- a/libsignal-service/src/websocket.rs
+++ b/libsignal-service/src/websocket.rs
@@ -309,6 +309,10 @@ impl SignalWebSocket {
         )
     }
 
+    pub fn is_closed(&self) -> bool {
+        self.request_sink.is_closed()
+    }
+
     pub(crate) fn take_request_stream(
         &mut self,
     ) -> Option<SignalRequestStream> {


### PR DESCRIPTION
This is useful to check is the websocket is closed (e.g. after a connectivity loss) and reconnect it in that case.