### PR TITLE
Expose SignalWebSocket::is_used

### DIFF
--- a/libsignal-service/src/websocket.rs
+++ b/libsignal-service/src/websocket.rs
@@ -313,6 +313,10 @@ impl SignalWebSocket {
         self.request_sink.is_closed()
     }
 
+    pub fn is_used(&self) -> bool {
+        self.inner_locked().stream.is_none()
+    }
+
     pub(crate) fn take_request_stream(
         &mut self,
     ) -> Option<SignalRequestStream> {


### PR DESCRIPTION
This is required to fix a panic `web socket request handler not in use` due to reuse of the same websocket between different `receive_messages` calls.

Downstream PR: https://github.com/whisperfish/presage/pull/226