### PR TITLE
Refactoring ACI/PNI storage types

### DIFF
--- a/libsignal-service-actix/examples/registering.rs
+++ b/libsignal-service-actix/examples/registering.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Error> {
     let mut push_service = AwcPushService::new(
         servers,
         Some(ServiceCredentials {
-            uuid: None,
+            aci: None,
             phonenumber: phonenumber.clone(),
             password,
             signaling_key: None,

--- a/libsignal-service-actix/examples/registering.rs
+++ b/libsignal-service-actix/examples/registering.rs
@@ -59,6 +59,7 @@ async fn main() -> Result<(), Error> {
         servers,
         Some(ServiceCredentials {
             aci: None,
+            pni: None,
             phonenumber: phonenumber.clone(),
             password,
             signaling_key: None,

--- a/libsignal-service-hyper/examples/registering.rs
+++ b/libsignal-service-hyper/examples/registering.rs
@@ -148,7 +148,7 @@ fn create_push_service(
     HyperPushService::new(
         SignalServers::Staging, // You might want to switch to Production servers
         Some(ServiceCredentials {
-            uuid: None,
+            aci: None,
             phonenumber,
             password: Some(password),
             signaling_key: None,

--- a/libsignal-service-hyper/examples/registering.rs
+++ b/libsignal-service-hyper/examples/registering.rs
@@ -149,6 +149,7 @@ fn create_push_service(
         SignalServers::Staging, // You might want to switch to Production servers
         Some(ServiceCredentials {
             aci: None,
+            pni: None,
             phonenumber,
             password: Some(password),
             signaling_key: None,

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -336,14 +336,14 @@ impl<Service: PushService> AccountManager<Service> {
         let pni_identity_key_pair =
             pni_identity_store.get_identity_key_pair().await?;
 
-        if credentials.uuid.is_none() {
-            tracing::warn!("No local UUID set");
+        if credentials.aci.is_none() {
+            tracing::warn!("No local ACI set");
         }
 
         let provisioning_code = self.new_device_provisioning_code().await?;
 
         let msg = ProvisionMessage {
-            aci: credentials.uuid.as_ref().map(|u| u.to_string()),
+            aci: credentials.aci.as_ref().map(|u| u.to_string()),
             aci_identity_key_public: Some(
                 aci_identity_key_pair.public_key().serialize().into_vec(),
             ),

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -339,6 +339,9 @@ impl<Service: PushService> AccountManager<Service> {
         if credentials.aci.is_none() {
             tracing::warn!("No local ACI set");
         }
+        if credentials.pni.is_none() {
+            tracing::warn!("No local PNI set");
+        }
 
         let provisioning_code = self.new_device_provisioning_code().await?;
 

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -103,7 +103,7 @@ impl<Service: PushService> AccountManager<Service> {
         csprng: &mut R,
         use_last_resort_key: bool,
     ) -> Result<(u32, u32, u32), ServiceError> {
-        let pre_keys_offset_id = pre_key_store.pre_keys_offset_id().await?;
+        let pre_keys_offset_id = pre_key_store.next_pre_key_id().await?;
         let next_signed_pre_key_id =
             pre_key_store.next_signed_pre_key_id().await?;
         let pq_pre_keys_offset_id = pre_key_store.next_pq_pre_key_id().await?;

--- a/libsignal-service/src/configuration.rs
+++ b/libsignal-service/src/configuration.rs
@@ -25,7 +25,7 @@ pub type SignalingKey = [u8; CIPHER_KEY_SIZE + MAC_KEY_SIZE];
 
 #[derive(Clone)]
 pub struct ServiceCredentials {
-    pub uuid: Option<uuid::Uuid>,
+    pub aci: Option<uuid::Uuid>,
     pub pni: Option<uuid::Uuid>,
     pub phonenumber: phonenumber::PhoneNumber,
     pub password: Option<String>,
@@ -50,7 +50,7 @@ impl ServiceCredentials {
 
     pub fn login(&self) -> String {
         let identifier = {
-            if let Some(uuid) = self.uuid.as_ref() {
+            if let Some(uuid) = self.aci.as_ref() {
                 uuid.to_string()
             } else {
                 self.e164()

--- a/libsignal-service/src/configuration.rs
+++ b/libsignal-service/src/configuration.rs
@@ -26,6 +26,7 @@ pub type SignalingKey = [u8; CIPHER_KEY_SIZE + MAC_KEY_SIZE];
 #[derive(Clone)]
 pub struct ServiceCredentials {
     pub uuid: Option<uuid::Uuid>,
+    pub pni: Option<uuid::Uuid>,
     pub phonenumber: phonenumber::PhoneNumber,
     pub password: Option<String>,
     pub signaling_key: Option<SignalingKey>,

--- a/libsignal-service/src/pre_keys.rs
+++ b/libsignal-service/src/pre_keys.rs
@@ -18,7 +18,7 @@ pub trait PreKeysStore:
     PreKeyStore + SignedPreKeyStore + KyberPreKeyStore
 {
     /// ID of the next pre key
-    async fn pre_keys_offset_id(&self) -> Result<u32, SignalProtocolError>;
+    async fn next_pre_key_id(&self) -> Result<u32, SignalProtocolError>;
 
     /// ID of the next signed pre key
     async fn next_signed_pre_key_id(&self) -> Result<u32, SignalProtocolError>;

--- a/libsignal-service/src/pre_keys.rs
+++ b/libsignal-service/src/pre_keys.rs
@@ -3,9 +3,9 @@ use std::{convert::TryFrom, time::SystemTime};
 use crate::utils::{serde_base64, serde_public_key};
 use async_trait::async_trait;
 use libsignal_protocol::{
-    error::SignalProtocolError, kem, GenericSignedPreKey, KeyPair,
-    KyberPreKeyRecord, KyberPreKeyStore, PreKeyRecord, PreKeyStore, PublicKey,
-    SignedPreKeyRecord, SignedPreKeyStore,
+    error::SignalProtocolError, kem, GenericSignedPreKey, IdentityKeyStore,
+    KeyPair, KyberPreKeyRecord, KyberPreKeyStore, PreKeyRecord, PreKeyStore,
+    PublicKey, SignedPreKeyRecord, SignedPreKeyStore,
 };
 
 use serde::{Deserialize, Serialize};
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// <https://signal.org/docs/specifications/x3dh/>
 #[async_trait(?Send)]
 pub trait PreKeysStore:
-    PreKeyStore + SignedPreKeyStore + KyberPreKeyStore
+    PreKeyStore + IdentityKeyStore + SignedPreKeyStore + KyberPreKeyStore
 {
     /// ID of the next pre key
     async fn next_pre_key_id(&self) -> Result<u32, SignalProtocolError>;

--- a/libsignal-service/src/pre_keys.rs
+++ b/libsignal-service/src/pre_keys.rs
@@ -1,6 +1,7 @@
 use std::{convert::TryFrom, time::SystemTime};
 
 use crate::utils::{serde_base64, serde_public_key};
+use async_trait::async_trait;
 use libsignal_protocol::{
     error::SignalProtocolError, kem, GenericSignedPreKey, KeyPair,
     KyberPreKeyRecord, KyberPreKeyStore, PreKeyRecord, PreKeyStore, PublicKey,
@@ -12,32 +13,33 @@ use serde::{Deserialize, Serialize};
 /// Stores the ID of keys published ahead of time
 ///
 /// <https://signal.org/docs/specifications/x3dh/>
+#[async_trait(?Send)]
 pub trait PreKeysStore:
     PreKeyStore + SignedPreKeyStore + KyberPreKeyStore
 {
     /// ID of the next pre key
-    fn pre_keys_offset_id(&self) -> Result<u32, SignalProtocolError>;
+    async fn pre_keys_offset_id(&self) -> Result<u32, SignalProtocolError>;
 
     /// ID of the next signed pre key
-    fn next_signed_pre_key_id(&self) -> Result<u32, SignalProtocolError>;
+    async fn next_signed_pre_key_id(&self) -> Result<u32, SignalProtocolError>;
 
     /// ID of the next PQ pre key
-    fn next_pq_pre_key_id(&self) -> Result<u32, SignalProtocolError>;
+    async fn next_pq_pre_key_id(&self) -> Result<u32, SignalProtocolError>;
 
     /// set the ID of the next pre key
-    fn set_pre_keys_offset_id(
+    async fn set_pre_keys_offset_id(
         &mut self,
         id: u32,
     ) -> Result<(), SignalProtocolError>;
 
     /// set the ID of the next signed pre key
-    fn set_next_signed_pre_key_id(
+    async fn set_next_signed_pre_key_id(
         &mut self,
         id: u32,
     ) -> Result<(), SignalProtocolError>;
 
     /// set the ID of the next PQ pre key
-    fn set_next_pq_pre_key_id(
+    async fn set_next_pq_pre_key_id(
         &mut self,
         id: u32,
     ) -> Result<(), SignalProtocolError>;
@@ -132,7 +134,7 @@ pub(crate) async fn generate_last_resort_kyber_key<S: PreKeysStore>(
     store: &mut S,
     identity_key: &KeyPair,
 ) -> Result<KyberPreKeyRecord, SignalProtocolError> {
-    let id = store.next_pq_pre_key_id()?;
+    let id = store.next_pq_pre_key_id().await?;
     let id = id.max(1); // TODO: Hack, keys start with 1
 
     let record = KyberPreKeyRecord::generate(
@@ -142,7 +144,7 @@ pub(crate) async fn generate_last_resort_kyber_key<S: PreKeysStore>(
     )?;
 
     store.save_kyber_pre_key(id.into(), &record).await?;
-    store.set_next_pq_pre_key_id(id + 1)?;
+    store.set_next_pq_pre_key_id(id + 1).await?;
 
     Ok(record)
 }
@@ -155,7 +157,7 @@ pub(crate) async fn generate_signed_pre_key<
     csprng: &mut R,
     identity_key: &KeyPair,
 ) -> Result<SignedPreKeyRecord, SignalProtocolError> {
-    let id = store.next_signed_pre_key_id()?;
+    let id = store.next_signed_pre_key_id().await?;
     let id = id.max(1); // TODO: Hack, keys start with 1
 
     let key_pair = KeyPair::generate(csprng);
@@ -171,7 +173,7 @@ pub(crate) async fn generate_signed_pre_key<
         SignedPreKeyRecord::new(id.into(), unix_time, &key_pair, &signature);
 
     store.save_signed_pre_key(id.into(), &record).await?;
-    store.set_next_signed_pre_key_id(id + 1)?;
+    store.set_next_signed_pre_key_id(id + 1).await?;
 
     Ok(record)
 }

--- a/libsignal-service/src/pre_keys.rs
+++ b/libsignal-service/src/pre_keys.rs
@@ -27,7 +27,7 @@ pub trait PreKeysStore:
     async fn next_pq_pre_key_id(&self) -> Result<u32, SignalProtocolError>;
 
     /// set the ID of the next pre key
-    async fn set_pre_keys_offset_id(
+    async fn set_next_pre_key_id(
         &mut self,
         id: u32,
     ) -> Result<(), SignalProtocolError>;

--- a/libsignal-service/src/provisioning/mod.rs
+++ b/libsignal-service/src/provisioning/mod.rs
@@ -108,11 +108,12 @@ pub struct NewDeviceRegistration {
 
 pub async fn link_device<
     R: rand::Rng + rand::CryptoRng,
-    S: PreKeysStore,
+    Aci: PreKeysStore,
+    Pni: PreKeysStore,
     P: PushService,
 >(
-    aci_store: &mut S,
-    pni_store: &mut S,
+    aci_store: &mut Aci,
+    pni_store: &mut Pni,
     csprng: &mut R,
     mut push_service: P,
     password: &str,

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -73,7 +73,7 @@ pub const STICKER_PATH: &str = "stickers/%s/full/%d";
 pub const KEEPALIVE_TIMEOUT_SECONDS: Duration = Duration::from_secs(55);
 pub const DEFAULT_DEVICE_ID: u32 = 1;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ServiceIdType {
     /// Account Identity (ACI)
     ///

--- a/libsignal-service/src/service_address.rs
+++ b/libsignal-service/src/service_address.rs
@@ -29,6 +29,10 @@ impl ServiceAddress {
     pub fn aci(&self) -> libsignal_protocol::Aci {
         libsignal_protocol::Aci::from_uuid_bytes(self.uuid.into_bytes())
     }
+
+    pub fn pni(&self) -> libsignal_protocol::Pni {
+        libsignal_protocol::Pni::from_uuid_bytes(self.uuid.into_bytes())
+    }
 }
 
 impl From<Uuid> for ServiceAddress {


### PR DESCRIPTION
Branch as I go along, with things that I disagree with :'-)

- Allow ACI/PNI store to be distinct types
- Make PreKeysStore async
- AccountManager can update prekey bundles for either PreKeyStore

One thing I disagree with, but don't necessarily want to fix here: `set_next_prekey_id` sounds like a great source of confusion. In RDBMS-based implementations, the `next_prekey_id`-family is expected to just query the database and return max+1. Setting a value doesn't make any sense, but the naming of the method implies it should need to be a method with a side effect.