### PR TITLE
Remove last remaining part of signaling key

### DIFF
--- a/libsignal-service/src/configuration.rs
+++ b/libsignal-service/src/configuration.rs
@@ -28,7 +28,6 @@ pub struct ServiceCredentials {
     pub uuid: Option<uuid::Uuid>,
     pub phonenumber: phonenumber::PhoneNumber,
     pub password: Option<String>,
-    pub signaling_key: Option<SignalingKey>,
     pub device_id: Option<u32>,
 }
 


### PR DESCRIPTION
Came across this while cleaning up Whisperfish at https://gitlab.com/whisperfish/whisperfish/-/merge_requests/534