### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: ["libsignal-service-actix", "libsignal-service-hyper"]
+        project: ["libsignal-service-actix", "libsignal-service-hyper", "libsignal-service"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/clippy-check@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: ["libsignal-service-actix", "libsignal-service-hyper"]
+        project: ["libsignal-service-actix", "libsignal-service-hyper", "libsignal-service"]
         toolchain: ["stable", "beta", "nightly"]
         coverage: [false, true]
         exclude:

--- a/libsignal-service/src/provisioning/pipe.rs
+++ b/libsignal-service/src/provisioning/pipe.rs
@@ -8,9 +8,7 @@ use futures::{
 };
 use url::Url;
 
-pub use crate::proto::{
-    ProvisionEnvelope, ProvisionMessage, ProvisioningVersion,
-};
+pub use crate::proto::{ProvisionEnvelope, ProvisionMessage};
 
 use crate::{
     proto::{


### PR DESCRIPTION
Adds libsignal-service to the projects to test (only had the impl crates before), fixes an unused import. I'm splitting this off from #280 because this is trivially mergable.