### PR TITLE
Propagate registration lock

### DIFF
--- a/libsignal-service-actix/src/push_service.rs
+++ b/libsignal-service-actix/src/push_service.rs
@@ -136,6 +136,19 @@ impl AwcPushService {
                 })?;
                 Err(ServiceError::StaleDevices(stale_devices))
             },
+            StatusCode::LOCKED => {
+                let locked = response.json().await.map_err(|e| {
+                    tracing::error!(
+                        ?response,
+                        "Failed to decode HTTP 423 response: {}",
+                        e
+                    );
+                    ServiceError::UnhandledResponseCode {
+                        http_code: StatusCode::LOCKED.as_u16(),
+                    }
+                })?;
+                Err(ServiceError::Locked(locked))
+            },
             StatusCode::PRECONDITION_REQUIRED => {
                 let proof_required = response.json().await.map_err(|e| {
                     tracing::error!(

--- a/libsignal-service/src/provisioning/cipher.rs
+++ b/libsignal-service/src/provisioning/cipher.rs
@@ -10,9 +10,7 @@ use prost::Message;
 use rand::Rng;
 use sha2::Sha256;
 
-pub use crate::proto::{
-    ProvisionEnvelope, ProvisionMessage, ProvisioningVersion,
-};
+pub use crate::proto::{ProvisionEnvelope, ProvisionMessage};
 
 use crate::{
     envelope::{CIPHER_KEY_SIZE, IV_LENGTH, IV_OFFSET},

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -206,6 +206,16 @@ pub struct HttpAuth {
     pub password: String,
 }
 
+/// This type is used in registration lock handling.
+/// It's identical with HttpAuth, but used to avoid type confusion.
+#[derive(Derivative, Clone, Serialize, Deserialize)]
+#[derivative(Debug)]
+pub struct AuthCredentials {
+    pub username: String,
+    #[derivative(Debug = "ignore")]
+    pub password: String,
+}
+
 #[derive(Debug, Clone)]
 pub enum HttpAuthOverride {
     NoOverride,
@@ -282,8 +292,9 @@ impl RegistrationSessionMetadataResponse {
 pub struct RegistrationLockFailure {
     pub length: u32,
     pub time_remaining: u64,
-    pub svr1_credentials: HttpAuth,
-    pub svr2_credentials: HttpAuth,
+    #[serde(rename = "backup_credentials")]
+    pub svr1_credentials: Option<AuthCredentials>,
+    pub svr2_credentials: Option<AuthCredentials>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -198,7 +198,7 @@ pub struct PreKeyStatus {
     pub pq_count: u32,
 }
 
-#[derive(Derivative, Clone)]
+#[derive(Derivative, Clone, Serialize, Deserialize)]
 #[derivative(Debug)]
 pub struct HttpAuth {
     pub username: String,
@@ -275,6 +275,15 @@ impl RegistrationSessionMetadataResponse {
             .iter()
             .any(|x| x.as_str() == "captcha")
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegistrationLockFailure {
+    pub length: u32,
+    pub time_remaining: u64,
+    pub svr1_credentials: HttpAuth,
+    pub svr2_credentials: HttpAuth,
 }
 
 #[derive(Debug, Deserialize)]
@@ -516,6 +525,8 @@ pub enum ServiceError {
     RateLimitExceeded,
     #[error("Authorization failed")]
     Unauthorized,
+    #[error("Registration lock is set: {0:?}")]
+    Locked(RegistrationLockFailure),
     #[error("Unexpected response: HTTP {http_code}")]
     UnhandledResponseCode { http_code: u16 },
 

--- a/libsignal-service/src/websocket.rs
+++ b/libsignal-service/src/websocket.rs
@@ -462,6 +462,15 @@ impl SignalWebSocket {
                     })?;
                 Err(ServiceError::StaleDevices(stale_devices))
             },
+            423 /* LOCKED */ => {
+                let locked = json(response.body()).map_err(|e| {
+                    tracing::error!("Failed to decode HTTP 423 response: {}", e);
+                    ServiceError::UnhandledResponseCode {
+                        http_code: 423,
+                    }
+                })?;
+                Err(ServiceError::Locked(locked))
+            },
             428 /* PRECONDITION_REQUIRED */ => {
                 let proof_required = json(response.body()).map_err(|e| {
                     tracing::error!("Failed to decode HTTP 428 response: {}", e);


### PR DESCRIPTION
Add handler for `HTTP 423 Locked` to catch and pass registration lock error message during primary registration.

Contributes to #54  