### PR TITLE
Send SyncMessages to self unidentified when possible

### DIFF
--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -388,7 +388,6 @@ where
         };
 
         let recipients = recipients.as_ref();
-        let mut needs_sync_in_results = false;
         for (recipient, unidentified_access) in recipients.iter() {
             let result = self
                 .try_send_message(
@@ -400,26 +399,12 @@ where
                 )
                 .await;
 
-            match result {
-                Ok(SentMessage { needs_sync, .. }) if needs_sync => {
-                    needs_sync_in_results = true;
-                },
-                _ => (),
-            };
-
             results.push(result);
-        }
-
-        if needs_sync_in_results && message.is_none() {
-            // XXX: does this happen?
-            tracing::warn!(
-                "Server claims need sync, but not sending datamessage."
-            );
         }
 
         // we only need to send a synchronization message once
         if let Some(message) = message {
-            if needs_sync_in_results || self.is_multi_device().await {
+            if self.is_multi_device().await {
                 let sync_message = self
                     .create_multi_device_sent_transcript_content(
                         None,

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -461,6 +461,15 @@ where
     ) -> SendMessageResult {
         use prost::Message;
 
+        // don't send messages to self but let the SyncMessage handle it instead
+        if recipient == self.local_address {
+            return Ok(SentMessage {
+                recipient,
+                unidentified: true,
+                needs_sync: true,
+            });
+        }
+
         let content = content_body.clone().into_proto();
 
         let content_bytes = content.encode_to_vec();


### PR DESCRIPTION
This changes the approach of sending `SyncMessage`s quite a lot, yet it shouldn't be _too_ invasive. This has received a brief test run in a device and it improves the situation quite a lot, if not fixes the core issue as-is! (knocks on wood)

- Add self-sync-message results to group and dm message sender results, and so...
- Return a `Vec<...>` from `send_message()`
- Accept the self recipient unidentified access when sending DMs
- Never send any "oridinary messages" to self, but only `SyncMessages`

I'll continue running this on my device for a while to see if there are any ill behaviors after this, and polish and fix as needed before un-drafting this.