### PR TITLE
Attempt to reestablish a session when it's found to be corrupt.

### DIFF
--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -663,6 +663,9 @@ where
 
         for device_id in devices {
             trace!("sending message to device {}", device_id);
+            // `create_encrypted_message` may fail with `SessionNotFound` if the session is corrupted;
+            // see https://github.com/whisperfish/libsignal-client/commit/601454d20.
+            // If this happens, delete the session and retry.
             for _attempt in 0..2 {
                 match self
                     .create_encrypted_message(

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -663,15 +663,52 @@ where
 
         for device_id in devices {
             trace!("sending message to device {}", device_id);
-            messages.push(
-                self.create_encrypted_message(
-                    recipient,
-                    unidentified_access,
-                    device_id,
-                    content,
-                )
-                .await?,
-            )
+            for _attempt in 0..2 {
+                match self
+                    .create_encrypted_message(
+                        recipient,
+                        unidentified_access,
+                        device_id,
+                        content,
+                    )
+                    .await
+                {
+                    Ok(message) => {
+                        messages.push(message);
+                        break;
+                    },
+                    Err(
+                        e @ MessageSenderError::ServiceError(
+                            ServiceError::SignalProtocolError(
+                                SignalProtocolError::SessionNotFound(_),
+                            ),
+                        ),
+                    ) => {
+                        let MessageSenderError::ServiceError(
+                            ServiceError::SignalProtocolError(
+                                SignalProtocolError::SessionNotFound(addr),
+                            ),
+                        ) = &e
+                        else {
+                            // We can't bind to addr above, because we move into `e`.
+                            unreachable!()
+                        };
+                        // SessionNotFound is returned on certain session corruption.
+                        // Since delete_session *creates* a session if it doesn't exist,
+                        // the NotFound error is an indicator of session corruption.
+                        // Try to delete this session, if it gets succesfully deleted, retry.  Otherwise, fail.
+                        tracing::warn!("Potential session corruption for {}, deleting session", addr);
+                        match self.protocol_store.delete_session(addr).await {
+                            Ok(()) => continue,
+                            Err(_e) => {
+                                tracing::warn!("Failed to delete session for {}, failing message. {}", addr, _e);
+                                return Err(e);
+                            },
+                        }
+                    },
+                    Err(e) => return Err(e),
+                }
+            }
         }
 
         Ok(messages)


### PR DESCRIPTION
@direc85 and me found some corrupt sessions in the database. Since https://github.com/whisperfish/libsignal-client/commit/601454d20, libsignal-protocol forwards corruption as `SessionNotFound` errors, which makes me believe we're allowed to recreate said session. This patch implements exactly that.

This deviates from the behaviour at the Android side, as far as I can tell, so needs caution. I tested this in the Whisperfishers group, seems to behave as intended.

FWIW, I blame said session corruption on going back-and-forth between the Kyber and pre-Kyber code a few times. I recall doing that and not turning off my network by accident.