### PR TITLE
Fix panic for fetching group avatar

### DIFF
--- a/libsignal-service/src/groups_v2/manager.rs
+++ b/libsignal-service/src/groups_v2/manager.rs
@@ -267,7 +267,7 @@ impl<S: PushService, C: CredentialsCache> GroupsManager<S, C> {
 
     #[tracing::instrument(
         skip(self, group_secret_params),
-        fields(path = %path[..4]),
+        fields(path = %path[..4.min(path.len())]),
     )]
     pub async fn retrieve_avatar(
         &mut self,


### PR DESCRIPTION
Tracing assumed the path was always at least 4 characters long. This would panic with the empty path which can be the value of a group avatar path if no avatar is set for the group.

While this panic is easy to prevent in presage (which I also did [here](https://github.com/whisperfish/presage/pull/234/commits/1852f52c5b076bdb0a2dc0e6972e5096e7ab6fa6#diff-99551c60a775f81baa1c0f5ba314ab329a8b187a979ece33826b3f98a02c3fa3R502)), this panic should still be removed from libsignal-service-rs.

(CI failure is again in nightly and most likely not my fault)