### PR TITLE
chore: make ByteStream in PushService MaybeSend

### DIFF
--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -590,7 +590,7 @@ pub enum ServiceError {
 #[cfg_attr(feature = "unsend-futures", async_trait::async_trait(?Send))]
 #[cfg_attr(not(feature = "unsend-futures"), async_trait::async_trait)]
 pub trait PushService: MaybeSend {
-    type ByteStream: futures::io::AsyncRead + Unpin;
+    type ByteStream: futures::io::AsyncRead + MaybeSend + Unpin;
 
     async fn get_json<T>(
         &mut self,


### PR DESCRIPTION
Rationale: even when the service is send, the bytes are not, so it is hard to use them with work-stealing executors.