### PR TITLE
Add HTTP 423 LOCKED handling

### DIFF
--- a/libsignal-service-hyper/src/push_service.rs
+++ b/libsignal-service-hyper/src/push_service.rs
@@ -182,6 +182,19 @@ impl HyperPushService {
                     })?;
                 Err(ServiceError::StaleDevices(stale_devices))
             },
+            StatusCode::LOCKED => {
+                let locked = Self::json(&mut response).await.map_err(|e| {
+                    tracing::error!(
+                        ?response,
+                        "Failed to decode HTTP 423 response: {}",
+                        e
+                    );
+                    ServiceError::UnhandledResponseCode {
+                        http_code: StatusCode::LOCKED.as_u16(),
+                    }
+                })?;
+                Err(ServiceError::Locked(locked))
+            },
             StatusCode::PRECONDITION_REQUIRED => {
                 let proof_required =
                     Self::json(&mut response).await.map_err(|e| {

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -290,8 +290,8 @@ impl RegistrationSessionMetadataResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegistrationLockFailure {
-    pub length: u32,
-    pub time_remaining: u64,
+    pub length: Option<u32>,
+    pub time_remaining: Option<u64>,
     #[serde(rename = "backup_credentials")]
     pub svr1_credentials: Option<AuthCredentials>,
     pub svr2_credentials: Option<AuthCredentials>,


### PR DESCRIPTION
Add missed status code 423 handling for hyper. Completes https://github.com/whisperfish/libsignal-service-rs/pull/284 in that sense.