### PR TITLE
Add Configuration sync message sending

### DIFF
--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -657,6 +657,25 @@ where
         Ok(())
     }
 
+    /// Send `Configuration` synchronization message
+    #[tracing::instrument(skip(self))]
+    pub async fn send_configuration(
+        &mut self,
+        recipient: &ServiceAddress,
+        configuration: sync_message::Configuration,
+    ) -> Result<(), MessageSenderError> {
+        let msg = SyncMessage {
+            configuration: Some(configuration),
+            ..SyncMessage::with_padding()
+        };
+
+        let ts = Utc::now().timestamp_millis() as u64;
+        self.send_message(recipient, None, msg, ts, false, false)
+            .await?;
+
+        Ok(())
+    }
+
     #[tracing::instrument(level = "trace", skip(self))]
     fn create_pni_signature(
         &mut self,


### PR DESCRIPTION
Support sending messages with `SyncMessage { configuration: Option<Configuration> }` payload.

Tested on Whisperfish -- changing typing indicators setting synchronizes to Molly (which in turn is then able to send or not send typing indicator messages too).