### PR TITLE
Bump protobufs

### DIFF
--- a/libsignal-service/protobuf/SignalService.proto
+++ b/libsignal-service/protobuf/SignalService.proto
@@ -439,9 +439,11 @@ message Verified {
 message SyncMessage {
   message Sent {
     message UnidentifiedDeliveryStatus {
-      reserved      /*destinationE164*/ 1;
-      optional string destinationServiceId = 3;
-      optional bool   unidentified         = 2;
+      reserved        /*destinationE164*/      1;
+      optional string destinationServiceId   = 3;
+      optional bool   unidentified           = 2;
+      reserved        /*destinationPni*/       4;
+      optional bytes  destinationIdentityKey = 5;
     }
 
     message StoryMessageRecipient {
@@ -460,6 +462,8 @@ message SyncMessage {
     optional StoryMessage               storyMessage             = 8;
     repeated StoryMessageRecipient      storyMessageRecipients   = 9;
     optional EditMessage                editMessage              = 10;
+    reserved                            /*destinationPni*/         11;
+    // NEXT ID: 12
   }
 
   message Contacts {
@@ -610,6 +614,7 @@ message SyncMessage {
       ACCEPTED       = 1;
       NOT_ACCEPTED   = 2;
       DELETE         = 3;
+      OBSERVED       = 4;
     }
 
     optional bytes     conversationId = 1;
@@ -621,17 +626,79 @@ message SyncMessage {
   }
 
   message CallLinkUpdate {
+    enum Type {
+      UPDATE = 0;
+      DELETE = 1;
+    }
+
     optional bytes rootKey      = 1;
     optional bytes adminPassKey = 2;
+    optional Type  type         = 3;
   }
 
   message CallLogEvent {
     enum Type {
-      CLEAR = 0;
+      CLEAR                          = 0;
+      MARKED_AS_READ                 = 1;
+      MARKED_AS_READ_IN_CONVERSATION = 2;
     }
 
-    optional Type   type      = 1;
-    optional uint64 timestamp = 2;
+    optional Type   type          = 1;
+    optional uint64 timestamp     = 2;
+    /* Data identifying a conversation. The service ID for 1:1, the group ID for
+     * group, or the room ID for an ad-hoc call. See also
+     * `CallEvent/conversationId`. */
+    optional bytes conversationId = 3;
+    /* An identifier for a call. Generated directly for 1:1, or derived from
+     * the era ID for group and ad-hoc calls. See also `CallEvent/callId`. */
+    optional uint64 callId        = 4;
+  }
+
+  message DeleteForMe {
+    message ConversationIdentifier {
+      oneof identifier {
+        string threadServiceId = 1;
+        bytes threadGroupId = 2;
+        string threadE164 = 3;
+      }
+    }
+
+    message AddressableMessage {
+      oneof author {
+        string authorServiceId = 1;
+        string authorE164 = 2;
+      }
+      optional uint64 sentTimestamp = 3;
+    }
+
+    message MessageDeletes {
+      optional ConversationIdentifier conversation = 1;
+      repeated AddressableMessage messages = 2;
+    }
+
+    message AttachmentDelete {
+      optional ConversationIdentifier conversation = 1;
+      optional AddressableMessage targetMessage = 2;
+      optional bytes uuid = 3; // The `uuid` from the `Attachment`.
+      optional bytes fallbackDigest = 4;
+      optional bytes fallbackPlaintextHash = 5;
+    }
+
+    message ConversationDelete {
+      optional ConversationIdentifier conversation = 1;
+      repeated AddressableMessage mostRecentMessages = 2;
+      repeated AddressableMessage mostRecentNonExpiringMessages = 4;
+      optional bool isFullDelete = 3;
+    }
+
+    message LocalOnlyConversationDelete {
+      optional ConversationIdentifier conversation = 1;
+    }
+
+    repeated MessageDeletes messageDeletes = 1;
+    repeated ConversationDelete conversationDeletes = 2;
+    repeated LocalOnlyConversationDelete localOnlyConversationDeletes = 3;
+    repeated AttachmentDelete attachmentDeletes = 4;
   }
 
   optional Sent                   sent                   = 1;
@@ -655,6 +722,7 @@ message SyncMessage {
   optional CallEvent              callEvent              = 19;
   optional CallLinkUpdate         callLinkUpdate         = 20;
   optional CallLogEvent           callLogEvent           = 21;
+  optional DeleteForMe            deleteForMe            = 22;
 }
 
 message AttachmentPointer {
@@ -686,7 +754,8 @@ message AttachmentPointer {
   optional string  blurHash                = 12;
   optional uint64  uploadTimestamp         = 13;
   optional uint32  cdnNumber               = 14;
-  // Next ID: 19
+  optional bytes   uuid                    = 20;
+  // Next ID: 21
 }
 
 message GroupContext {
@@ -730,7 +799,7 @@ message ContactDetails {
   optional string   color         = 4;
   optional Verified verified      = 5;
   optional bytes    profileKey    = 6;
-  optional bool     blocked       = 7;
+  reserved          /*blocked*/     7;
   optional uint32   expireTimer   = 8;
   optional uint32   inboxPosition = 10;
   optional bool     archived      = 11;

--- a/libsignal-service/protobuf/update-protos.sh
+++ b/libsignal-service/protobuf/update-protos.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 update_proto() {
 	case "$1" in
 	  Signal-Android) 
-	  	git_revision="940cee0f30d6a2873ae08c65bb821c34302ccf5d"
+	  	git_revision="251cec5dee06d8d36f0177967d675e8eac2ba32f"
 		prefix="libsignal-service/src/main/protowire/";;
 	  Signal-Desktop)
-	  	git_revision="70858d9063446b07b19c03ae7d0c01075a2849e3"
+	  	git_revision="f46872b6e980132e8045b3288eb88d803f365a10"
 		prefix="protos/";;
 	esac
 	curl -LOf https://raw.githubusercontent.com/signalapp/${1}/${git_revision}/${prefix}${2}

--- a/libsignal-service/protobuf/update-protos.sh
+++ b/libsignal-service/protobuf/update-protos.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 update_proto() {
 	case "$1" in
-	  Signal-Android) 
+	  Signal-Android)
 	  	git_revision="251cec5dee06d8d36f0177967d675e8eac2ba32f"
 		prefix="libsignal-service/src/main/protowire/";;
 	  Signal-Desktop)

--- a/libsignal-service/src/models.rs
+++ b/libsignal-service/src/models.rs
@@ -28,7 +28,6 @@ pub struct Contact {
     #[serde(skip)]
     pub verified: Verified,
     pub profile_key: Vec<u8>,
-    pub blocked: bool,
     pub expire_timer: u32,
     pub inbox_position: u32,
     pub archived: bool,
@@ -69,7 +68,6 @@ impl Contact {
             color: contact_details.color.clone(),
             verified: contact_details.verified.clone().unwrap_or_default(),
             profile_key: contact_details.profile_key().to_vec(),
-            blocked: contact_details.blocked(),
             expire_timer: contact_details.expire_timer(),
             inbox_position: contact_details.inbox_position(),
             archived: contact_details.archived(),

--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -890,6 +890,8 @@ where
                             recipient.uuid.to_string(),
                         ),
                         unidentified: Some(*unidentified),
+                        // XXX: actually set this.
+                        destination_identity_key: None,
                     }
                 })
                 .collect();


### PR DESCRIPTION
    Update protobuf revision version

    Signal Android 7.10.2
    Signal Desktop 7.17.0-alpha.1

This part is potentially relevant for PNI (cc @direc85)

```diff
diff --git a/libsignal-service/protobuf/SignalService.proto b/libsignal-service/protobuf/SignalService.proto
index 2de3e6ac7..37506c78a 100644
--- a/libsignal-service/protobuf/SignalService.proto
+++ b/libsignal-service/protobuf/SignalService.proto
@@ -439,9 +439,11 @@ message Verified {
 message SyncMessage {
   message Sent {
     message UnidentifiedDeliveryStatus {
-      reserved      /*destinationE164*/ 1;
-      optional string destinationServiceId = 3;
-      optional bool   unidentified         = 2;
+      reserved        /*destinationE164*/      1;
+      optional string destinationServiceId   = 3;
+      optional bool   unidentified           = 2;
+      reserved        /*destinationPni*/       4;
+      optional bytes  destinationIdentityKey = 5;
     }

     message StoryMessageRecipient {
```