### PR TITLE
Fix some new Clippy lints

### DIFF
--- a/libsignal-service-actix/src/websocket.rs
+++ b/libsignal-service-actix/src/websocket.rs
@@ -66,7 +66,7 @@ impl From<AwcWebSocketError> for ServiceError {
 }
 
 /// Process the WebSocket, until it times out.
-async fn process<S: Stream>(
+async fn process<S>(
     socket_stream: S,
     mut incoming_sink: Sender<WebSocketStreamItem>,
 ) -> Result<(), AwcWebSocketError>

--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -580,7 +580,7 @@ impl<Service: PushService> AccountManager<Service> {
         }
 
         self.service
-            .put_json(
+            .put_json::<(), _>(
                 Endpoint::Service,
                 "/v1/accounts/name",
                 &[],


### PR DESCRIPTION
Not entirely sure about this (cca447a69):

```diff
commit cca447a69d9a5cb1b86714dc1d88856e96b5d9cd
Author: Ruben De Smet <ruben.de.smet@rubdos.be>
Date:   Fri Jul 5 16:05:16 2024 +0200

    Fix fallback to never type clippy warning

diff --git a/libsignal-service/src/account_manager.rs b/libsignal-service/src/account_manager.rs
index 14c6242c2..0ca2abad9 100644
--- a/libsignal-service/src/account_manager.rs
+++ b/libsignal-service/src/account_manager.rs
@@ -580,7 +580,7 @@ impl<Service: PushService> AccountManager<Service> {
         }
 
         self.service
-            .put_json(
+            .put_json::<(), _>(
                 Endpoint::Service,
                 "/v1/accounts/name",
                 &[],

```

The return value is inferred by Rust Analyzer to be `!`, but that's obviously skipping over the happy-path. I'm 99% sure that the type system infers the Ok-type to be `()` in Rust 2018 (which is what we're running), but from the clippy warning, it seems that it'll change to `!` (as RA says too), so we have to make this type explicit.