### PR TITLE
Bump to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,7 @@
 members = ["libsignal-service", "libsignal-service-actix", "libsignal-service-hyper"]
 default-members = ["libsignal-service", "libsignal-service-hyper"]
 
+resolver = "2"
+
 [patch.crates-io]
 curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', tag = 'signal-curve25519-4.1.3' }

--- a/libsignal-service-actix/Cargo.toml
+++ b/libsignal-service-actix/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libsignal-service-actix"
 version = "0.1.0"
 authors = ["Ruben De Smet <ruben.de.smet@rubdos.be>"]
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0"
 rust-version = "1.70.0"
 

--- a/libsignal-service-hyper/Cargo.toml
+++ b/libsignal-service-hyper/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libsignal-service-hyper"
 version = "0.1.0"
 authors = ["Gabriel Féron <g@leirbag.net>"]
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0"
 rust-version = "1.70.0"
 

--- a/libsignal-service/Cargo.toml
+++ b/libsignal-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libsignal-service"
 version = "0.1.0"
 authors = ["Ruben De Smet <ruben.de.smet@rubdos.be>", "Gabriel Féron <g@leirbag.net>", "Michael Bryan <michaelfbryan@gmail.com>", "Shady Khalifa <shekohex@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "AGPL-3.0"
 readme = "../README.md"
 


### PR DESCRIPTION
Since we're on MSRV 1.75 anyway, we can bump to 2021 (which requires 1.56).