### PR TITLE
Add `Keys` sync message

### DIFF
--- a/libsignal-service/src/sender.rs
+++ b/libsignal-service/src/sender.rs
@@ -677,6 +677,25 @@ where
         Ok(())
     }
 
+    /// Send `Keys` synchronization message
+    #[tracing::instrument(skip(self))]
+    pub async fn send_keys(
+        &mut self,
+        recipient: &ServiceAddress,
+        keys: sync_message::Keys,
+    ) -> Result<(), MessageSenderError> {
+        let msg = SyncMessage {
+            keys: Some(keys),
+            ..SyncMessage::with_padding()
+        };
+
+        let ts = Utc::now().timestamp_millis() as u64;
+        self.send_message(recipient, None, msg, ts, false, false)
+            .await?;
+
+        Ok(())
+    }
+
     #[tracing::instrument(level = "trace", skip(self))]
     fn create_pni_signature(
         &mut self,


### PR DESCRIPTION
Untested, but should work.

I tried to remove passing self-recipient, but couldn't figure out a way to get it in the method. I think that would require setting self service address to sender, which would break API, so I'm not delving into that currently.