### PR TITLE
Add destination ServiceAddress to Metadata

### DIFF
--- a/libsignal-service/src/cipher.rs
+++ b/libsignal-service/src/cipher.rs
@@ -164,6 +164,7 @@ where
                 )
                 .await?;
                 let metadata = Metadata {
+                    destination: envelope.destination_address(),
                     sender: envelope.source_address(),
                     sender_device: envelope.source_device(),
                     timestamp: envelope.server_timestamp(),
@@ -201,6 +202,7 @@ where
             Type::PlaintextContent => {
                 tracing::warn!(?envelope, "Envelope with plaintext content.  This usually indicates a decryption retry.");
                 let metadata = Metadata {
+                    destination: envelope.destination_address(),
                     sender: envelope.source_address(),
                     sender_device: envelope.source_device(),
                     timestamp: envelope.server_timestamp(),
@@ -221,6 +223,7 @@ where
                 )
                 .await?;
                 let metadata = Metadata {
+                    destination: envelope.destination_address(),
                     sender: envelope.source_address(),
                     sender_device: envelope.source_device(),
                     timestamp: envelope.timestamp(),
@@ -290,6 +293,7 @@ where
                 };
 
                 let metadata = Metadata {
+                    destination: envelope.destination_address(),
                     sender,
                     sender_device: device_id.into(),
                     timestamp: envelope.timestamp(),

--- a/libsignal-service/src/content.rs
+++ b/libsignal-service/src/content.rs
@@ -19,6 +19,7 @@ mod story_message;
 #[derive(Clone, Debug)]
 pub struct Metadata {
     pub sender: crate::ServiceAddress,
+    pub destination: crate::ServiceAddress,
     pub sender_device: u32,
     pub timestamp: u64,
     pub needs_receipt: bool,

--- a/libsignal-service/src/envelope.rs
+++ b/libsignal-service/src/envelope.rs
@@ -136,8 +136,16 @@ impl Envelope {
     pub fn source_address(&self) -> ServiceAddress {
         match self.source_service_id.as_deref() {
             Some(service_id) => ServiceAddress::try_from(service_id)
-                .expect("invalid ProtocolAddress UUID or prefix"),
+                .expect("invalid source ProtocolAddress UUID or prefix"),
             None => panic!("source_service_id is set"),
+        }
+    }
+
+    pub fn destination_address(&self) -> ServiceAddress {
+        match self.destination_service_id.as_deref() {
+            Some(service_id) => ServiceAddress::try_from(service_id)
+                .expect("invalid destination ProtocolAddress UUID or prefix"),
+            None => panic!("destination_address is set"),
         }
     }
 }

--- a/libsignal-service/src/receiver.rs
+++ b/libsignal-service/src/receiver.rs
@@ -32,8 +32,6 @@ impl<Service: PushService> MessageReceiver<Service> {
         &mut self,
         allow_stories: bool,
     ) -> Result<Vec<Envelope>, ServiceError> {
-        use std::convert::TryFrom;
-
         let entities = self.service.get_messages(allow_stories).await?;
         let entities = entities
             .into_iter()


### PR DESCRIPTION
What it says on the tin!

This is currently required only for delivering the destination ServiceAddress to the host application for determining our identity which the message was sent to in order to pick the correct protocol store when deleting all sessions.