### PR TITLE
Add support for versioned expire timers

### DIFF
--- a/libsignal-service/protobuf/SignalService.proto
+++ b/libsignal-service/protobuf/SignalService.proto
@@ -331,6 +331,7 @@ message DataMessage {
   optional GroupContextV2     groupV2                 = 15;
   optional uint32             flags                   = 4;
   optional uint32             expireTimer             = 5;
+  optional uint32             expireTimerVersion      = 23;
   optional bytes              profileKey              = 6;
   optional uint64             timestamp               = 7;
   optional Quote              quote                   = 8;
@@ -792,17 +793,18 @@ message ContactDetails {
     optional uint32 length      = 2;
   }
 
-  optional string   number        = 1;
-  optional string   aci           = 9;
-  optional string   name          = 2;
-  optional Avatar   avatar        = 3;
-  optional string   color         = 4;
-  optional Verified verified      = 5;
-  optional bytes    profileKey    = 6;
-  reserved          /*blocked*/     7;
-  optional uint32   expireTimer   = 8;
-  optional uint32   inboxPosition = 10;
-  optional bool     archived      = 11;
+  optional string   number             = 1;
+  optional string   aci                = 9;
+  optional string   name               = 2;
+  optional Avatar   avatar             = 3;
+  optional string   color              = 4;
+  optional Verified verified           = 5;
+  optional bytes    profileKey         = 6;
+  reserved          /*blocked*/          7;
+  optional uint32   expireTimer        = 8;
+  optional uint32   expireTimerVersion = 12;
+  optional uint32   inboxPosition      = 10;
+  optional bool     archived           = 11;
 }
 
 message GroupDetails {

--- a/libsignal-service/src/models.rs
+++ b/libsignal-service/src/models.rs
@@ -29,6 +29,7 @@ pub struct Contact {
     pub verified: Verified,
     pub profile_key: Vec<u8>,
     pub expire_timer: u32,
+    pub expire_timer_version: u32,
     pub inbox_position: u32,
     pub archived: bool,
     #[serde(skip)]
@@ -69,6 +70,7 @@ impl Contact {
             verified: contact_details.verified.clone().unwrap_or_default(),
             profile_key: contact_details.profile_key().to_vec(),
             expire_timer: contact_details.expire_timer(),
+            expire_timer_version: contact_details.expire_timer_version(),
             inbox_position: contact_details.inbox_position(),
             archived: contact_details.archived(),
             avatar: contact_details.avatar.and_then(|avatar| {

--- a/libsignal-service/src/push_service.rs
+++ b/libsignal-service/src/push_service.rs
@@ -435,12 +435,16 @@ pub struct LinkAccountAttributes {
 #[serde(rename_all = "camelCase")]
 pub struct LinkCapabilities {
     pub delete_sync: bool,
+    pub versioned_expiration_timer: bool,
 }
 
 // https://github.com/signalapp/Signal-Desktop/blob/1e57db6aa4786dcddc944349e4894333ac2ffc9e/ts/textsecure/WebAPI.ts#L1287
 impl Default for LinkCapabilities {
     fn default() -> Self {
-        Self { delete_sync: true }
+        Self {
+            delete_sync: true,
+            versioned_expiration_timer: true,
+        }
     }
 }
 


### PR DESCRIPTION
Signal introduced a mechanism in which the disappearing message timer is versioned to avoid conflicts where two users attempt to change it simultaneously. This unit test from the diff explains it way better than I will be able to:

https://github.com/signalapp/Signal-Desktop/commit/2fb50df0afb23e4944f44dd282f238fbc8197ee7#diff-bbee704f3a58f941935376ab98cc2f7f301445f1db90c89b5bd6ca3c449b46c8

This commit adds support for that and declares the capacity. This fixes device linking failing with 409 Conflict.