### PR TITLE
Allow PNI in PendingMember

### DIFF
--- a/src/groups_v2/model.rs
+++ b/src/groups_v2/model.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use zkgroup::profiles::ProfileKey;
 
+use crate::ServiceAddress;
+
 use super::GroupDecodingError;
 
 #[derive(Copy, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -30,15 +32,15 @@ impl PartialEq for Member {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PendingMember {
-    pub uuid: Uuid,
+    pub address: ServiceAddress,
     pub role: Role,
     pub added_by_uuid: Uuid,
     pub timestamp: u64,
 }
 
-#[derive(Derivative, Clone, Deserialize, Serialize)]
+#[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub struct RequestingMember {
     pub uuid: Uuid,
@@ -69,7 +71,7 @@ pub struct AccessControl {
     pub add_from_invite_link: AccessRequired,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Group {
     pub title: String,
     pub avatar: String,

--- a/src/service_address.rs
+++ b/src/service_address.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use libsignal_protocol::{DeviceId, ProtocolAddress};
+use libsignal_protocol::{DeviceId, ProtocolAddress, ServiceId};
 use uuid::Uuid;
 
 pub use crate::push_service::ServiceIdType;
@@ -48,14 +48,24 @@ impl ServiceAddress {
         }
     }
 
+    #[deprecated]
     pub fn new_aci(uuid: Uuid) -> Self {
+        Self::from_aci(uuid)
+    }
+
+    pub fn from_aci(uuid: Uuid) -> Self {
         Self {
             uuid,
             identity: ServiceIdType::AccountIdentity,
         }
     }
 
+    #[deprecated]
     pub fn new_pni(uuid: Uuid) -> Self {
+        Self::from_pni(uuid)
+    }
+
+    pub fn from_pni(uuid: Uuid) -> Self {
         Self {
             uuid,
             identity: ServiceIdType::PhoneNumberIdentity,
@@ -106,9 +116,9 @@ impl TryFrom<&ProtocolAddress> for ServiceAddress {
     fn try_from(addr: &ProtocolAddress) -> Result<Self, Self::Error> {
         let value = addr.name();
         if let Some(pni) = value.strip_prefix("PNI:") {
-            Ok(ServiceAddress::new_pni(Uuid::parse_str(pni)?))
+            Ok(ServiceAddress::from_pni(Uuid::parse_str(pni)?))
         } else {
-            Ok(ServiceAddress::new_aci(Uuid::parse_str(value)?))
+            Ok(ServiceAddress::from_aci(Uuid::parse_str(value)?))
         }
         .map_err(|e| {
             tracing::error!("Parsing ServiceAddress from {:?}", addr);
@@ -122,9 +132,9 @@ impl TryFrom<&str> for ServiceAddress {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         if let Some(pni) = value.strip_prefix("PNI:") {
-            Ok(ServiceAddress::new_pni(Uuid::parse_str(pni)?))
+            Ok(ServiceAddress::from_pni(Uuid::parse_str(pni)?))
         } else {
-            Ok(ServiceAddress::new_aci(Uuid::parse_str(value)?))
+            Ok(ServiceAddress::from_aci(Uuid::parse_str(value)?))
         }
         .map_err(|e| {
             tracing::error!("Parsing ServiceAddress from '{}'", value);
@@ -138,9 +148,9 @@ impl TryFrom<&[u8]> for ServiceAddress {
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         if let Some(pni) = value.strip_prefix(b"PNI:") {
-            Ok(ServiceAddress::new_pni(Uuid::from_slice(pni)?))
+            Ok(ServiceAddress::from_pni(Uuid::from_slice(pni)?))
         } else {
-            Ok(ServiceAddress::new_aci(Uuid::from_slice(value)?))
+            Ok(ServiceAddress::from_aci(Uuid::from_slice(value)?))
         }
         .map_err(|e| {
             tracing::error!("Parsing ServiceAddress from {:?}", value);

--- a/src/service_address.rs
+++ b/src/service_address.rs
@@ -87,6 +87,19 @@ impl ServiceAddress {
     }
 }
 
+impl From<ServiceId> for ServiceAddress {
+    fn from(service_id: ServiceId) -> Self {
+        match service_id {
+            ServiceId::Aci(service_id) => {
+                ServiceAddress::from_aci(service_id.into())
+            },
+            ServiceId::Pni(service_id) => {
+                ServiceAddress::from_pni(service_id.into())
+            },
+        }
+    }
+}
+
 impl TryFrom<&ProtocolAddress> for ServiceAddress {
     type Error = ParseServiceAddressError;
 


### PR DESCRIPTION
Should fix #328 

The other member decryption functions are ACI-only (which makes sense). I double-checked this.

@gferon, @boxdot, I have removed `Serialize` and `Deserialize` bounds on some structs. These were in place because Presage stores those structs directly in its database, but I don't think that is correct behavior. `libsignal-service` exposes those structs without any forward or backward compatibility guarantees, as illustrated in here: the `uuid` field is dropped in favor of the service_id field. Migration should be handled by the storage backend. Same reasoning goes for #324.