### PR TITLE
Switch to attachments v4

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -225,8 +225,7 @@ impl AccountManager {
             .service
             .request(
                 Method::GET,
-                Endpoint::Service,
-                "/v1/devices/provisioning/code",
+                Endpoint::service("/v1/devices/provisioning/code"),
                 HttpAuthOverride::NoOverride,
             )?
             .send()
@@ -254,8 +253,7 @@ impl AccountManager {
         self.service
             .request(
                 Method::PUT,
-                Endpoint::Service,
-                format!("/v1/provisioning/{}", destination),
+                Endpoint::service(format!("/v1/provisioning/{}", destination)),
                 HttpAuthOverride::NoOverride,
             )?
             .json(&ProvisioningMessage {
@@ -594,8 +592,7 @@ impl AccountManager {
         self.service
             .request(
                 Method::PUT,
-                Endpoint::Service,
-                "/v1/accounts/name",
+                Endpoint::service("/v1/accounts/name"),
                 HttpAuthOverride::NoOverride,
             )?
             .json(&Data {
@@ -623,8 +620,7 @@ impl AccountManager {
         self.service
             .request(
                 Method::PUT,
-                Endpoint::Service,
-                "/v1/challenge",
+                Endpoint::service("/v1/challenge"),
                 HttpAuthOverride::NoOverride,
             )?
             .json(&RecaptchaAttributes {

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -253,7 +253,7 @@ impl AccountManager {
         self.service
             .request(
                 Method::PUT,
-                Endpoint::service(format!("/v1/provisioning/{}", destination)),
+                Endpoint::service(format!("/v1/provisioning/{destination}")),
                 HttpAuthOverride::NoOverride,
             )?
             .json(&ProvisioningMessage {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -92,6 +92,26 @@ pub enum Endpoint<'a> {
     },
 }
 
+impl fmt::Display for Endpoint<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Endpoint::Absolute(url) => write!(f, "absolute URL {url}"),
+            Endpoint::Service { path } => {
+                write!(f, "service API call to {path}")
+            },
+            Endpoint::Storage { path } => {
+                write!(f, "storage API call to {path}")
+            },
+            Endpoint::Cdn { cdn_id, path, .. } => {
+                write!(f, "CDN{cdn_id} call to {path}")
+            },
+            Endpoint::ContactDiscovery { path } => {
+                write!(f, "Contact discovery API call to {path}")
+            },
+        }
+    }
+}
+
 impl<'a> Endpoint<'a> {
     pub fn service(path: impl Into<Cow<'a, str>>) -> Self {
         Self::Service { path: path.into() }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -190,6 +190,7 @@ impl From<&SignalServers> for ServiceConfiguration {
                     let mut map = HashMap::new();
                     map.insert(0, "https://cdn-staging.signal.org".parse().unwrap());
                     map.insert(2, "https://cdn2-staging.signal.org".parse().unwrap());
+                    map.insert(3, "https://cdn3-staging.signal.org".parse().unwrap());
                     map
                 },
                 contact_discovery_url:

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use std::{collections::HashMap, str::FromStr};
+use std::{borrow::Cow, collections::HashMap, str::FromStr};
 
 use crate::utils::BASE64_RELAXED;
 use base64::prelude::*;
@@ -74,11 +74,50 @@ pub enum SignalServers {
 }
 
 #[derive(Debug)]
-pub enum Endpoint {
-    Service,
-    Storage,
-    Cdn(u32),
-    ContactDiscovery,
+pub enum Endpoint<'a> {
+    Absolute(Url),
+    Service { path: Cow<'a, str> },
+    Storage { path: Cow<'a, str> },
+    Cdn { path: Cow<'a, str>, cdn_id: u32 },
+    ContactDiscovery { path: Cow<'a, str> },
+}
+
+impl<'a> Endpoint<'a> {
+    pub fn service(path: impl Into<Cow<'a, str>>) -> Self {
+        Self::Service { path: path.into() }
+    }
+
+    pub fn cdn(cdn_id: u32, path: impl Into<Cow<'a, str>>) -> Self {
+        Self::Cdn {
+            path: path.into(),
+            cdn_id,
+        }
+    }
+
+    pub fn storage(path: impl Into<Cow<'a, str>>) -> Self {
+        Self::Storage { path: path.into() }
+    }
+
+    pub fn into_url(
+        self,
+        service_configuration: &ServiceConfiguration,
+    ) -> Result<Url, url::ParseError> {
+        match self {
+            Endpoint::Service { path } => {
+                service_configuration.service_url.join(&path)
+            },
+            Endpoint::Storage { path } => {
+                service_configuration.storage_url.join(&path)
+            },
+            Endpoint::Cdn { path, ref cdn_id } => {
+                service_configuration.cdn_urls[cdn_id].join(&path)
+            },
+            Endpoint::ContactDiscovery { path } => {
+                service_configuration.contact_discovery_url.join(&path)
+            },
+            Endpoint::Absolute(url) => Ok(url),
+        }
+    }
 }
 
 impl FromStr for SignalServers {
@@ -144,6 +183,7 @@ impl From<&SignalServers> for ServiceConfiguration {
                     let mut map = HashMap::new();
                     map.insert(0, "https://cdn.signal.org".parse().unwrap());
                     map.insert(2, "https://cdn2.signal.org".parse().unwrap());
+                    map.insert(3, "https://cdn3.signal.org".parse().unwrap());
                     map
                 },
                 contact_discovery_url: "https://api.directory.signal.org".parse().unwrap(),
@@ -153,17 +193,6 @@ impl From<&SignalServers> for ServiceConfiguration {
                 zkgroup_server_public_params: bincode::deserialize(
                     &BASE64_RELAXED.decode("AMhf5ywVwITZMsff/eCyudZx9JDmkkkbV6PInzG4p8x3VqVJSFiMvnvlEKWuRob/1eaIetR31IYeAbm0NdOuHH8Qi+Rexi1wLlpzIo1gstHWBfZzy1+qHRV5A4TqPp15YzBPm0WSggW6PbSn+F4lf57VCnHF7p8SvzAA2ZZJPYJURt8X7bbg+H3i+PEjH9DXItNEqs2sNcug37xZQDLm7X36nOoGPs54XsEGzPdEV+itQNGUFEjY6X9Uv+Acuks7NpyGvCoKxGwgKgE5XyJ+nNKlyHHOLb6N1NuHyBrZrgtY/JYJHRooo5CEqYKBqdFnmbTVGEkCvJKxLnjwKWf+fEPoWeQFj5ObDjcKMZf2Jm2Ae69x+ikU5gBXsRmoF94GXTLfN0/vLt98KDPnxwAQL9j5V1jGOY8jQl6MLxEs56cwXN0dqCnImzVH3TZT1cJ8SW1BRX6qIVxEzjsSGx3yxF3suAilPMqGRp4ffyopjMD1JXiKR2RwLKzizUe5e8XyGOy9fplzhw3jVzTRyUZTRSZKkMLWcQ/gv0E4aONNqs4P+NameAZYOD12qRkxosQQP5uux6B2nRyZ7sAV54DgFyLiRcq1FvwKw2EPQdk4HDoePrO/RNUbyNddnM/mMgj4FW65xCoT1LmjrIjsv/Ggdlx46ueczhMgtBunx1/w8k8V+l8LVZ8gAT6wkU5J+DPQalQguMg12Jzug3q4TbdHiGCmD9EunCwOmsLuLJkz6EcSYXtrlDEnAM+hicw7iergYLLlMXpfTdGxJCWJmP4zqUFeTTmsmhsjGBt7NiEB/9pFFEB3pSbf4iiUukw63Eo8Aqnf4iwob6X1QviCWuc8t0LUlT9vALgh/f2DPVOOmR0RW6bgRvc7DSF20V/omg+YBw==").unwrap()).unwrap(),
             },
-        }
-    }
-}
-
-impl ServiceConfiguration {
-    pub fn base_url(&self, endpoint: Endpoint) -> &Url {
-        match endpoint {
-            Endpoint::Service => &self.service_url,
-            Endpoint::Storage => &self.storage_url,
-            Endpoint::Cdn(ref n) => &self.cdn_urls[n],
-            Endpoint::ContactDiscovery => &self.contact_discovery_url,
         }
     }
 }

--- a/src/groups_v2/manager.rs
+++ b/src/groups_v2/manager.rs
@@ -170,8 +170,7 @@ impl<C: CredentialsCache> GroupsManager<C> {
                 .push_service
                 .request(
                     Method::GET,
-                    Endpoint::Service,
-                    &path,
+                    Endpoint::service(path),
                     HttpAuthOverride::NoOverride,
                 )?
                 .send()

--- a/src/profile_service.rs
+++ b/src/profile_service.rs
@@ -41,8 +41,7 @@ impl ProfileService {
         self.push_service
             .request(
                 Method::GET,
-                Endpoint::Service,
-                path,
+                Endpoint::service(path),
                 HttpAuthOverride::NoOverride,
             )?
             .send()

--- a/src/push_service/account.rs
+++ b/src/push_service/account.rs
@@ -132,8 +132,7 @@ impl PushService {
     pub async fn whoami(&mut self) -> Result<WhoAmIResponse, ServiceError> {
         self.request(
             Method::GET,
-            Endpoint::Service,
-            "/v1/accounts/whoami",
+            Endpoint::service("/v1/accounts/whoami"),
             HttpAuthOverride::NoOverride,
         )?
         .send()
@@ -157,8 +156,7 @@ impl PushService {
         let devices: DeviceInfoList = self
             .request(
                 Method::GET,
-                Endpoint::Service,
-                "/v1/devices/",
+                Endpoint::service("/v1/devices/"),
                 HttpAuthOverride::NoOverride,
             )?
             .send()
@@ -182,8 +180,7 @@ impl PushService {
 
         self.request(
             Method::PUT,
-            Endpoint::Service,
-            "/v1/accounts/attributes/",
+            Endpoint::service("/v1/accounts/attributes/"),
             HttpAuthOverride::NoOverride,
         )?
         .json(&attributes)

--- a/src/push_service/cdn.rs
+++ b/src/push_service/cdn.rs
@@ -343,6 +343,7 @@ impl PushService {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, content))]
     async fn upload_to_cdn2(
         &mut self,
         resumable_url: &Url,
@@ -380,6 +381,7 @@ impl PushService {
         })
     }
 
+    #[tracing::instrument(skip(self, content))]
     async fn upload_to_cdn3(
         &mut self,
         resumable_url: &Url,
@@ -389,7 +391,7 @@ impl PushService {
         mut content: impl std::io::Read + std::io::Seek + Send,
     ) -> Result<AttachmentDigest, ServiceError> {
         let resume_info = self
-            .get_attachment_resume_info_cdn3(resumable_url, &headers)
+            .get_attachment_resume_info_cdn3(resumable_url, headers)
             .await?;
 
         trace!(?resume_info, "got resume info");

--- a/src/push_service/error.rs
+++ b/src/push_service/error.rs
@@ -93,6 +93,9 @@ pub enum ServiceError {
     #[error("invalid device name")]
     InvalidDeviceName,
 
+    #[error("Unknown CDN version {0}")]
+    UnknownCdnVersion(u32),
+
     #[error("HTTP reqwest error: {0}")]
     Http(#[from] reqwest::Error),
 }

--- a/src/push_service/keys.rs
+++ b/src/push_service/keys.rs
@@ -32,8 +32,7 @@ impl PushService {
     ) -> Result<PreKeyStatus, ServiceError> {
         self.request(
             Method::GET,
-            Endpoint::Service,
-            format!("/v2/keys?identity={}", service_id_type),
+            Endpoint::service(format!("/v2/keys?identity={}", service_id_type)),
             HttpAuthOverride::NoOverride,
         )?
         .send()
@@ -52,8 +51,7 @@ impl PushService {
     ) -> Result<(), ServiceError> {
         self.request(
             Method::PUT,
-            Endpoint::Service,
-            format!("/v2/keys?identity={}", service_id_type),
+            Endpoint::service(format!("/v2/keys?identity={}", service_id_type)),
             HttpAuthOverride::NoOverride,
         )?
         .json(&pre_key_state)
@@ -76,8 +74,7 @@ impl PushService {
         let mut pre_key_response: PreKeyResponse = self
             .request(
                 Method::GET,
-                Endpoint::Service,
-                &path,
+                Endpoint::service(path),
                 HttpAuthOverride::NoOverride,
             )?
             .send()
@@ -107,8 +104,7 @@ impl PushService {
         let pre_key_response: PreKeyResponse = self
             .request(
                 Method::GET,
-                Endpoint::Service,
-                &path,
+                Endpoint::service(path),
                 HttpAuthOverride::NoOverride,
             )?
             .send()
@@ -131,8 +127,7 @@ impl PushService {
         let cert: SenderCertificateJson = self
             .request(
                 Method::GET,
-                Endpoint::Service,
-                "/v1/certificate/delivery",
+                Endpoint::service("/v1/certificate/delivery"),
                 HttpAuthOverride::NoOverride,
             )?
             .send()
@@ -150,8 +145,7 @@ impl PushService {
         let cert: SenderCertificateJson = self
             .request(
                 Method::GET,
-                Endpoint::Service,
-                "/v1/certificate/delivery?includeE164=false",
+                Endpoint::service("/v1/certificate/delivery?includeE164=false"),
                 HttpAuthOverride::NoOverride,
             )?
             .send()
@@ -190,8 +184,9 @@ impl PushService {
         }
         self.request(
             Method::PUT,
-            Endpoint::Service,
-            "/v2/accounts/phone_number_identity_key_distribution",
+            Endpoint::service(
+                "/v2/accounts/phone_number_identity_key_distribution",
+            ),
             HttpAuthOverride::NoOverride,
         )?
         .json(&PniKeyDistributionRequest {

--- a/src/push_service/linking.rs
+++ b/src/push_service/linking.rs
@@ -62,8 +62,7 @@ impl PushService {
     ) -> Result<LinkResponse, ServiceError> {
         self.request(
             Method::PUT,
-            Endpoint::Service,
-            "/v1/devices/link",
+            Endpoint::service("/v1/devices/link"),
             HttpAuthOverride::Identified(http_auth),
         )?
         .json(&link_request)
@@ -79,8 +78,7 @@ impl PushService {
     pub async fn unlink_device(&mut self, id: i64) -> Result<(), ServiceError> {
         self.request(
             Method::DELETE,
-            Endpoint::Service,
-            format!("/v1/devices/{}", id),
+            Endpoint::service(format!("/v1/devices/{}", id)),
             HttpAuthOverride::NoOverride,
         )?
         .send()

--- a/src/push_service/mod.rs
+++ b/src/push_service/mod.rs
@@ -177,7 +177,7 @@ impl PushService {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self), fields(endpoint = %endpoint))]
     pub fn request(
         &self,
         method: Method,

--- a/src/push_service/profile.rs
+++ b/src/push_service/profile.rs
@@ -92,7 +92,7 @@ impl PushService {
         address: ServiceAddress,
         profile_key: Option<zkgroup::profiles::ProfileKey>,
     ) -> Result<SignalServiceProfile, ServiceError> {
-        let endpoint = if let Some(key) = profile_key {
+        let path = if let Some(key) = profile_key {
             let version = bincode::serialize(&key.get_profile_key_version(
                 address.aci().expect("profile by ACI ProtocolAddress"),
             ))?;
@@ -105,8 +105,7 @@ impl PushService {
         // TODO: set locale to en_US
         self.request(
             Method::GET,
-            Endpoint::Service,
-            &endpoint,
+            Endpoint::service(path),
             HttpAuthOverride::NoOverride,
         )?
         .send()
@@ -171,8 +170,7 @@ impl PushService {
         let upload_url: Result<String, _> = self
             .request(
                 Method::PUT,
-                Endpoint::Service,
-                "/v1/profile",
+                Endpoint::service("/v1/profile"),
                 HttpAuthOverride::NoOverride,
             )?
             .json(&command)

--- a/src/push_service/registration.rs
+++ b/src/push_service/registration.rs
@@ -154,8 +154,7 @@ impl PushService {
 
         self.request(
             Method::POST,
-            Endpoint::Service,
-            "/v1/registration",
+            Endpoint::service("/v1/registration"),
             HttpAuthOverride::NoOverride,
         )?
         .json(&RegistrationSessionRequestBody {
@@ -198,8 +197,7 @@ impl PushService {
 
         self.request(
             Method::POST,
-            Endpoint::Service,
-            "/v1/verification/session",
+            Endpoint::service("/v1/verification/session"),
             HttpAuthOverride::Unidentified,
         )?
         .json(&VerificationSessionMetadataRequestBody {
@@ -240,8 +238,10 @@ impl PushService {
 
         self.request(
             Method::PATCH,
-            Endpoint::Service,
-            format!("/v1/verification/session/{}", session_id),
+            Endpoint::service(format!(
+                "/v1/verification/session/{}",
+                session_id
+            )),
             HttpAuthOverride::Unidentified,
         )?
         .json(&UpdateVerificationSessionRequestBody {
@@ -289,8 +289,10 @@ impl PushService {
 
         self.request(
             Method::POST,
-            Endpoint::Service,
-            format!("/v1/verification/session/{}/code", session_id),
+            Endpoint::service(format!(
+                "/v1/verification/session/{}/code",
+                session_id
+            )),
             HttpAuthOverride::Unidentified,
         )?
         .json(&VerificationCodeRequest { transport, client })
@@ -315,8 +317,10 @@ impl PushService {
 
         self.request(
             Method::PUT,
-            Endpoint::Service,
-            format!("/v1/verification/session/{}/code", session_id),
+            Endpoint::service(format!(
+                "/v1/verification/session/{}/code",
+                session_id
+            )),
             HttpAuthOverride::Unidentified,
         )?
         .json(&VerificationCode {

--- a/src/push_service/response.rs
+++ b/src/push_service/response.rs
@@ -10,8 +10,10 @@ where
     ServiceError: From<<R as SignalServiceResponse>::Error>,
 {
     match response.status_code() {
-        StatusCode::OK => Ok(response),
-        StatusCode::NO_CONTENT => Ok(response),
+        StatusCode::OK
+        | StatusCode::CREATED
+        | StatusCode::ACCEPTED
+        | StatusCode::NO_CONTENT => Ok(response),
         StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
             Err(ServiceError::Unauthorized)
         },

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -244,7 +244,6 @@ where
                 attachment_upload_form.headers,
                 &mut std::io::Cursor::new(&contents),
             )
-            .instrument(tracing::trace_span!("Uploading attachment"))
             .await?;
 
         Ok(AttachmentPointer {


### PR DESCRIPTION
which means dropping CDN0 which was AWS CloudFront and use CDN2 or CDN3 depending on what the server tells us to do.

TODO:
- [x] Make sure we still have `post_to_cdn0` functional, even though I'm not sure whether it is used or not.
- [x] Add logic for CDN2 (we cannot know whether it is still in use or not, the server tells us to use it).

In general, I'd like to ditch `libsignal-service-actix` since it is not used anymore, which in turn will let us remove the `PushService` trait and let us have a _much nicer_ direct access to the HTTP API.

Closes #320