### PR TITLE
Fix sending note to self as primary without secondary devices

### DIFF
--- a/src/sender.rs
+++ b/src/sender.rs
@@ -354,6 +354,7 @@ where
     ) -> SendMessageResult {
         let content_body = message.into();
         let message_to_self = recipient == &self.local_aci;
+        let is_multi_device = self.is_multi_device().await;
 
         use crate::proto::data_message::Flags;
 
@@ -365,7 +366,7 @@ where
         };
 
         // only send a sync message when sending to self and skip the rest of the process
-        if message_to_self {
+        if message_to_self && is_multi_device {
             debug!("sending note to self");
             let sync_message =
                 Self::create_multi_device_sent_transcript_content(
@@ -408,7 +409,7 @@ where
             _ => false,
         };
 
-        if needs_sync || self.is_multi_device().await {
+        if needs_sync || is_multi_device {
             debug!("sending multi-device sync message");
             let sync_message =
                 Self::create_multi_device_sent_transcript_content(
@@ -544,7 +545,7 @@ where
             }) = self
                 .create_encrypted_messages(
                     &recipient,
-                    unidentified_access.map(|x| &x.certificate),
+                    uDnidentified_access.map(|x| &x.certificate),
                     &content_bytes,
                 )
                 .await?

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -545,7 +545,7 @@ where
             }) = self
                 .create_encrypted_messages(
                     &recipient,
-                    uDnidentified_access.map(|x| &x.certificate),
+                    unidentified_access.map(|x| &x.certificate),
                     &content_bytes,
                 )
                 .await?

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -6,7 +6,7 @@ use libsignal_protocol::{
     ProtocolStore, SenderCertificate, SenderKeyStore, SignalProtocolError,
 };
 use rand::{CryptoRng, Rng};
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 use tracing_futures::Instrument;
 use uuid::Uuid;
 use zkgroup::GROUP_IDENTIFIER_LEN;
@@ -553,7 +553,9 @@ where
                 // this can happen for example when a device is primary, without any secondaries
                 // and we send a message to ourselves (which is only a SyncMessage { sent: ... })
                 // addressed to self
-                debug!("no messages were encrypted: this should rarely happen");
+                warn!(
+                    "no messages were encrypted: this should not really happen and most likely implies a logic error."
+                );
                 break;
             };
 


### PR DESCRIPTION
There might be a better way to do this but... here's what happens:
1. Register a client as primary (no extra devices)
2. Try to send a message to `self` which will try to call `create_encrypted_message` but will never send any messages because we purposefully skip sending messages to ourselves (and own device) for good reasons
3. At the very end of the process, we fetch the `identity_key` (public key) we have for the recipient, which fails because we've never established a session with ourselves (this would only happen if we have other devices).

Here are two improvements:
- When the result of `create_encrypted_messages` return 0 messages, do nothing
- ...and check that we're `is_multi_device` before even attempting to craft and send a `SyncMessage` to self (that was missed when doing #338)