### PR TITLE
[Partial revert] Make sure we use the provided CSPRNG everywhere.

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1,6 +1,5 @@
 use base64::prelude::*;
 use phonenumber::PhoneNumber;
-use rand::Rng;
 use reqwest::Method;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
@@ -642,7 +641,7 @@ impl AccountManager {
     /// Should be called as the primary device to migrate from pre-PNI to PNI.
     ///
     /// This is the equivalent of Android's PnpInitializeDevicesJob or iOS' PniHelloWorldManager.
-    #[tracing::instrument(skip(self, aci_protocol_store, pni_protocol_store, sender, local_aci), fields(local_aci = %local_aci))]
+    #[tracing::instrument(skip(self, aci_protocol_store, pni_protocol_store, sender, local_aci, csprng), fields(local_aci = %local_aci))]
     pub async fn pnp_initialize_devices<
         // XXX So many constraints here, all imposed by the MessageSender
         R: rand::Rng + rand::CryptoRng,
@@ -653,11 +652,11 @@ impl AccountManager {
         &mut self,
         aci_protocol_store: &mut Aci,
         pni_protocol_store: &mut Pni,
-        mut sender: MessageSender<AciOrPni>,
+        mut sender: MessageSender<AciOrPni, R>,
         local_aci: ServiceAddress,
         e164: PhoneNumber,
+        csprng: &mut R,
     ) -> Result<(), MessageSenderError> {
-        let mut csprng = rand::thread_rng();
         let pni_identity_key_pair =
             pni_protocol_store.get_identity_key_pair().await?;
 
@@ -714,7 +713,7 @@ impl AccountManager {
                 crate::pre_keys::replenish_pre_keys(
                     pni_protocol_store,
                     &pni_identity_key_pair,
-                    &mut csprng,
+                    csprng,
                     true,
                     0,
                     0,
@@ -722,12 +721,12 @@ impl AccountManager {
                 .await?
             } else {
                 // Generate a signed prekey
-                let signed_pre_key_pair = KeyPair::generate(&mut csprng);
+                let signed_pre_key_pair = KeyPair::generate(csprng);
                 let signed_pre_key_public = signed_pre_key_pair.public_key;
                 let signed_pre_key_signature =
                     pni_identity_key_pair.private_key().calculate_signature(
                         &signed_pre_key_public.serialize(),
-                        &mut csprng,
+                        csprng,
                     )?;
 
                 let signed_prekey_record = SignedPreKeyRecord::new(
@@ -755,7 +754,7 @@ impl AccountManager {
                 pni_protocol_store.get_local_registration_id().await?
             } else {
                 loop {
-                    let regid = generate_registration_id(&mut csprng);
+                    let regid = generate_registration_id(csprng);
                     if !pni_registration_ids.iter().any(|(_k, v)| *v == regid) {
                         break regid;
                     }
@@ -803,7 +802,7 @@ impl AccountManager {
                         e164.format().mode(phonenumber::Mode::E164).to_string(),
                     ),
                 }),
-                padding: Some(random_length_padding(&mut csprng, 512)),
+                padding: Some(random_length_padding(csprng, 512)),
                 ..SyncMessage::default()
             };
             let content: ContentBody = msg.into();

--- a/src/master_key.rs
+++ b/src/master_key.rs
@@ -1,3 +1,5 @@
+use rand::{CryptoRng, Rng};
+
 const MASTER_KEY_LEN: usize = 32;
 const STORAGE_KEY_LEN: usize = 32;
 
@@ -7,13 +9,10 @@ pub struct MasterKey {
 }
 
 impl MasterKey {
-    pub fn generate() -> Self {
-        use rand::Rng;
-
+    pub fn generate<R: Rng + CryptoRng>(csprng: &mut R) -> Self {
         // Create random bytes
-        let mut rng = rand::thread_rng();
         let mut inner = [0_u8; MASTER_KEY_LEN];
-        rng.fill(&mut inner);
+        csprng.fill(&mut inner);
         Self { inner }
     }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::all)]
 
-use rand::{Rng, RngCore};
+use rand::{CryptoRng, Rng};
 include!(concat!(env!("OUT_DIR"), "/signalservice.rs"));
 include!(concat!(env!("OUT_DIR"), "/signal.rs"));
 
@@ -69,11 +69,10 @@ impl WebSocketResponseMessage {
 }
 
 impl SyncMessage {
-    pub fn with_padding() -> Self {
-        let mut rng = rand::thread_rng();
-        let random_size = rng.gen_range(1..=512);
+    pub fn with_padding<R: Rng + CryptoRng>(csprng: &mut R) -> Self {
+        let random_size = csprng.gen_range(1..=512);
         let mut padding: Vec<u8> = vec![0; random_size];
-        rng.fill_bytes(&mut padding);
+        csprng.fill_bytes(&mut padding);
 
         Self {
             padding: Some(padding),

--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -158,7 +158,7 @@ pub async fn link_device<
     let registration_id = csprng.gen_range(1..256);
     let pni_registration_id = csprng.gen_range(1..256);
 
-    let provisioning_pipe = ProvisioningPipe::from_socket(ws)?;
+    let provisioning_pipe = ProvisioningPipe::from_socket(csprng, ws)?;
     let provision_stream = provisioning_pipe.stream();
     pin_mut!(provision_stream);
 

--- a/src/provisioning/pipe.rs
+++ b/src/provisioning/pipe.rs
@@ -7,6 +7,7 @@ use futures::{
     },
     prelude::*,
 };
+use rand::{CryptoRng, Rng};
 use url::Url;
 
 pub use crate::proto::{ProvisionEnvelope, ProvisionMessage};
@@ -34,12 +35,13 @@ pub enum ProvisioningStep {
 }
 
 impl ProvisioningPipe {
-    pub fn from_socket(ws: SignalWebSocket) -> Result<Self, ProvisioningError> {
+    pub fn from_socket<R: Rng + CryptoRng>(
+        csprng: &mut R,
+        ws: SignalWebSocket,
+    ) -> Result<Self, ProvisioningError> {
         Ok(ProvisioningPipe {
             ws,
-            provisioning_cipher: ProvisioningCipher::generate(
-                &mut rand::thread_rng(),
-            )?,
+            provisioning_cipher: ProvisioningCipher::generate(csprng)?,
         })
     }
 

--- a/src/push_service/profile.rs
+++ b/src/push_service/profile.rs
@@ -1,3 +1,4 @@
+use rand::{CryptoRng, Rng};
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use zkgroup::profiles::{ProfileKeyCommitment, ProfileKeyVersion};
@@ -38,9 +39,9 @@ pub struct SignalServiceProfile {
 }
 
 impl SignalServiceProfile {
-    pub fn decrypt(
+    pub fn decrypt<R: Rng + CryptoRng>(
         &self,
-        profile_cipher: crate::profile_cipher::ProfileCipher,
+        profile_cipher: crate::profile_cipher::ProfileCipher<R>,
     ) -> Result<Profile, ProfileCipherError> {
         // Profile decryption
         let name = self


### PR DESCRIPTION
I just merged #341 but after talking with @boxdot the correct change is to do the opposite: make sure we use whatever the library user provide as CSPRNG.

There are only two places where we still use `rand::thread_rng`: in tests and when generating an ID for the next websocket request.