### PR TITLE
Expose unrestricted unidentified access through AccountManager

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -71,6 +71,7 @@ pub struct Profile {
     pub about: Option<String>,
     pub about_emoji: Option<String>,
     pub avatar: Option<String>,
+    pub unrestricted_unidentified_access: bool,
 }
 
 impl AccountManager {

--- a/src/profile_cipher.rs
+++ b/src/profile_cipher.rs
@@ -157,6 +157,8 @@ impl ProfileCipher {
             about,
             about_emoji,
             avatar: encrypted_profile.avatar,
+            unrestricted_unidentified_access: encrypted_profile
+                .unrestricted_unidentified_access,
         })
     }
 


### PR DESCRIPTION
This field is unavailable if you decrypt through the accountmanager, and it's moved out if you try to manually decrypt via the ProfileCipher. Since the RNG rework.