### PR TITLE
Fix empty sync messages being sent

### DIFF
--- a/src/sender.rs
+++ b/src/sender.rs
@@ -394,6 +394,7 @@ where
         }
 
         // don't send session enders as sealed sender
+        // sync messages are never sent as unidentified (reasons unclear), see: https://github.com/signalapp/Signal-Android/blob/main/libsignal-service/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java#L779
         if end_session || sync_message {
             unidentified_access.take();
         }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -358,6 +358,8 @@ where
     ) -> SendMessageResult {
         let content_body = message.into();
         let message_to_self = recipient == &self.local_aci;
+        let sync_message =
+            matches!(content_body, ContentBody::SynchronizeMessage(..));
         let is_multi_device = self.is_multi_device().await;
 
         use crate::proto::data_message::Flags;
@@ -370,7 +372,7 @@ where
         };
 
         // only send a sync message when sending to self and skip the rest of the process
-        if message_to_self && is_multi_device {
+        if message_to_self && is_multi_device && !sync_message {
             debug!("sending note to self");
             let sync_message = self
                 .create_multi_device_sent_transcript_content(
@@ -392,7 +394,7 @@ where
         }
 
         // don't send session enders as sealed sender
-        if end_session {
+        if end_session || sync_message {
             unidentified_access.take();
         }
 


### PR DESCRIPTION
This happened when giving `send_message` a `SyncMessage` to one self. In that case, the message would not be sent and instead `create_multi_device_sent_transcript_content` would create a new sync message, which is empty as the `SyncMessage` is neither a `DataMessage` nor an `EditMessage`.

This PR changes the condition to ignore sync messages.

This currently fails for me as I am rate limited.
Would be nice if someone not rate limited could try it out, otherwise I will wait for a while for the rate limit to stop.