### PR TITLE
Close websocket when keepalive are no longer received

### DIFF
--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -201,7 +201,7 @@ impl SignalWebSocketProcess {
             futures::select! {
                 _ = ka_interval.tick().fuse() => {
                     use prost::Message;
-                    if self.outgoing_keep_alive_set.len() > 6 {
+                    if self.outgoing_keep_alive_set.len() > 0 {
                         tracing::warn!("Websocket will be closed due to failed keepalives.");
                         if let Err(e) = self.ws.close(reqwest_websocket::CloseCode::Away, None).await {
                             tracing::debug!("Could not close WebSocket: {:?}", e);


### PR DESCRIPTION
Hi,

I sometimes have network failures, and I noticed that when my connection is dropped, the websocket might not close itself, and then libsignal-service stop working forever.

It's a TCP behavior: when the server disconnect without sending a tcp reset (RST) (for example if your VPN is killed and you have kill-switch enabled), the client will not "know" that the server is not reachable anymore, and the tcp connection will remain open.

To fix this, we have different solutions, implement tcp_keepalive at OS or software level, or add a keepalive at application (websocket) level. I saw that you already implement Signal keepalives, but actually there is an issue with the implementation :

- When the connection drop, the websocket is not automatically closed ;
- libsignal-service continue to send keepalives in the ws, with success (although there is no longer any server listening) ;
- we continue to receive on a "zombie" websocket so we don't receive new messages anymore ;
- worse: when the connection comes back, libsignal-service continue to use this "zombie" ws, and will no longer be able to send nor receive new messages...

My proposition is to close the websocket if we have not received keepalive responses for more than 6 minutes: when there are more than 6 keepalive ids in the hashset `outgoing_keep_alive_set`

Thank you