### PR TITLE
fix: disable default root certificates in push service

### DIFF
--- a/src/push_service/mod.rs
+++ b/src/push_service/mod.rs
@@ -158,6 +158,7 @@ impl PushService {
     ) -> Self {
         let cfg = cfg.into();
         let client = reqwest::ClientBuilder::new()
+            .tls_built_in_root_certs(false)
             .add_root_certificate(
                 reqwest::Certificate::from_pem(
                     cfg.certificate_authority.as_bytes(),


### PR DESCRIPTION
Explicitly disable built-in root certificates when creating HTTP client to ensure only the provided certificate authority is used for TLS verification.

When `reqwest` is somewhere else in the dependency tree, any of the webpki or native root certs features might be enabled, which would make this reqwest Client accept certs beyond the Signal root authority.