### PR TITLE
Use Auth header for ws login

### DIFF
--- a/src/push_service/mod.rs
+++ b/src/push_service/mod.rs
@@ -219,18 +219,14 @@ impl PushService {
         let mut url = Endpoint::service(path).into_url(&self.cfg)?;
         url.set_scheme("wss").expect("valid https base url");
 
-        if let Some(credentials) = credentials {
-            url.query_pairs_mut()
-                .append_pair("login", &credentials.login())
-                .append_pair(
-                    "password",
-                    credentials.password.as_ref().expect("a password"),
-                );
-        }
-
         let mut builder = self.client.get(url);
         for (key, value) in additional_headers {
             builder = builder.header(*key, *value);
+        }
+
+        if let Some(credentials) = credentials {
+            builder =
+                builder.basic_auth(credentials.login(), credentials.password);
         }
 
         let ws = builder


### PR DESCRIPTION
Looks like upstream enforces this now, so all presage/lss/Whisperfish builds are currently broken. Testing as we speak.