### PR TITLE
Fix profile demo code

### DIFF
--- a/src/groups_v2/manager.rs
+++ b/src/groups_v2/manager.rs
@@ -182,7 +182,7 @@ impl<C: CredentialsCache> GroupsManager<C> {
                 .await?;
             self.credentials_cache
                 .write(credentials_response.parse()?)?;
-            self.credentials_cache.get(&today)?.ok_or_else(|| {
+            self.credentials_cache.get(&today)?.ok_or({
                 ServiceError::InvalidFrame {
                     reason:
                         "credentials received did not contain requested day",

--- a/src/profile_cipher.rs
+++ b/src/profile_cipher.rs
@@ -23,8 +23,8 @@ use crate::{
 ///     given_name: "Bill",
 ///     family_name: None,
 /// };
-/// let cipher = ProfileCipher::from(profile_key);
-/// let encrypted = cipher.encrypt_name(&name).unwrap();
+/// let cipher = ProfileCipher::new(profile_key);
+/// let encrypted = cipher.encrypt_name(&name, &mut rng).unwrap();
 /// let decrypted = cipher.decrypt_name(&encrypted).unwrap().unwrap();
 /// assert_eq!(decrypted.as_ref(), name);
 /// ```

--- a/src/push_service/cdn.rs
+++ b/src/push_service/cdn.rs
@@ -153,7 +153,7 @@ impl PushService {
             .await?
             .headers()
             .get("location")
-            .ok_or_else(|| ServiceError::InvalidFrame {
+            .ok_or(ServiceError::InvalidFrame {
                 reason: "missing location header in HTTP response",
             })?
             .to_str()
@@ -195,9 +195,9 @@ impl PushService {
                         .map_err(|_| ServiceError::InvalidFrame {
                             reason: "invalid format for Range HTTP header",
                         })?
-                        .split("-")
+                        .split('-')
                         .nth(1)
-                        .ok_or_else(|| ServiceError::InvalidFrame {
+                        .ok_or(ServiceError::InvalidFrame {
                             reason:
                                 "invalid value format for Range HTTP header",
                         })?

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -201,7 +201,7 @@ impl SignalWebSocketProcess {
             futures::select! {
                 _ = ka_interval.tick().fuse() => {
                     use prost::Message;
-                    if self.outgoing_keep_alive_set.len() > 0 {
+                    if !self.outgoing_keep_alive_set.is_empty() {
                         tracing::warn!("Websocket will be closed due to failed keepalives.");
                         if let Err(e) = self.ws.close(reqwest_websocket::CloseCode::Away, None).await {
                             tracing::debug!("Could not close WebSocket: {:?}", e);


### PR DESCRIPTION
While rebasing usernames to main, `cargo test` told me that the example code for profile handling is wrong, so fix that. It got broken in 6401dc34872a5f0c2fba32c1f136d98ccf3dd418 I think.

And make Clippy happy once again.