### PR TITLE
Bugfix: Include auth headers for attachment uploads.

### DIFF
--- a/src/push_service/cdn.rs
+++ b/src/push_service/cdn.rs
@@ -426,9 +426,11 @@ impl PushService {
         .header("Upload-Offset", resume_info.content_start)
         .header("Upload-Length", buf.len())
         .header(CONTENT_TYPE, content_type)
+        .header("Authorization", headers["Authorization"].clone())
         .body(buf)
         .send()
-        .await?;
+        .await?
+        .error_for_status()?;
 
         trace!("attachment uploaded");
 

--- a/src/push_service/cdn.rs
+++ b/src/push_service/cdn.rs
@@ -417,20 +417,25 @@ impl PushService {
 
         trace!("digested content");
 
-        self.request(
+        let mut request = self.request(
             Method::PATCH,
             Endpoint::cdn(3, resumable_url.path()),
             HttpAuthOverride::Unidentified,
-        )?
-        .header("Tus-Resumable", "1.0.0")
-        .header("Upload-Offset", resume_info.content_start)
-        .header("Upload-Length", buf.len())
-        .header(CONTENT_TYPE, content_type)
-        .header("Authorization", headers["Authorization"].clone())
-        .body(buf)
-        .send()
-        .await?
-        .error_for_status()?;
+        )?;
+
+        for (key, value) in headers {
+            request = request.header(key, value);
+        }
+
+        request
+            .header("Tus-Resumable", "1.0.0")
+            .header("Upload-Offset", resume_info.content_start)
+            .header("Upload-Length", buf.len())
+            .header(CONTENT_TYPE, content_type)
+            .body(buf)
+            .send()
+            .await?
+            .error_for_status()?;
 
         trace!("attachment uploaded");
 

--- a/src/push_service/cdn.rs
+++ b/src/push_service/cdn.rs
@@ -275,7 +275,6 @@ impl PushService {
         &mut self,
         cdn_id: u32,
         resumable_url: &Url,
-        content_type: &str,
         content_length: u64,
         headers: HashMap<String, String>,
         content: impl std::io::Read + std::io::Seek + Send,
@@ -287,7 +286,6 @@ impl PushService {
             self.upload_to_cdn3(
                 resumable_url,
                 &headers,
-                content_type,
                 content_length,
                 content,
             )
@@ -386,7 +384,6 @@ impl PushService {
         &mut self,
         resumable_url: &Url,
         headers: &HashMap<String, String>,
-        content_type: &str,
         content_length: u64,
         mut content: impl std::io::Read + std::io::Seek + Send,
     ) -> Result<AttachmentDigest, ServiceError> {
@@ -431,7 +428,7 @@ impl PushService {
             .header("Tus-Resumable", "1.0.0")
             .header("Upload-Offset", resume_info.content_start)
             .header("Upload-Length", buf.len())
-            .header(CONTENT_TYPE, content_type)
+            .header(CONTENT_TYPE, "application/offset+octet-stream")
             .body(buf)
             .send()
             .await?

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -249,7 +249,6 @@ where
             .upload_attachment_v4(
                 attachment_upload_form.cdn,
                 &resumable_upload_url,
-                &spec.content_type,
                 contents.len() as u64,
                 attachment_upload_form.headers,
                 &mut std::io::Cursor::new(&contents),


### PR DESCRIPTION
Yesterday attachment uploads started failing for me with error 401. I took a wild guess that the auth headers are now required in the upload request, and that appears to have worked.

I also added an `error_for_status()` check so that these types of errors aren't silently ignored in the future.