### PR TITLE
Don't handle CDN errors as service errors

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -135,13 +135,12 @@ where
                 }
             }
 
-            if message.sync_message.is_some() {
-                if plaintext.metadata.sender.aci().map(Into::into)
+            if message.sync_message.is_some()
+                && plaintext.metadata.sender.aci().map(Into::into)
                     != Some(self.local_uuid)
-                {
-                    tracing::warn!("Source is not ourself.");
-                    return Ok(None);
-                }
+            {
+                tracing::warn!("Source is not ourself.");
+                return Ok(None);
             }
 
             if let Some(bytes) = message.sender_key_distribution_message {

--- a/src/push_service/cdn.rs
+++ b/src/push_service/cdn.rs
@@ -90,8 +90,7 @@ impl PushService {
             )?
             .send()
             .await?
-            .service_error_for_status()
-            .await?
+            .error_for_status()?
             .bytes_stream()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
             .into_async_read();
@@ -149,8 +148,7 @@ impl PushService {
         Ok(request
             .send()
             .await?
-            .service_error_for_status()
-            .await?
+            .error_for_status()?
             .headers()
             .get("location")
             .ok_or(ServiceError::InvalidFrame {
@@ -244,7 +242,7 @@ impl PushService {
             request = request.header(key, value);
         }
 
-        let response = request.send().await?.service_error_for_status().await?;
+        let response = request.send().await?.error_for_status()?;
 
         let upload_offset = response
             .headers()
@@ -333,8 +331,7 @@ impl PushService {
             .multipart(form)
             .send()
             .await?
-            .service_error_for_status()
-            .await?;
+            .error_for_status()?;
 
         debug!("HyperPushService::PUT response: {:?}", response);
 


### PR DESCRIPTION
While reviewing #356 I noticed that using `error_for_status` and `service_error_for_status` were used inconsistently. This PR tries to fix it. Rationale: when we're talking to a CDN, it doesn't make sense to translate e.g. HTTP 404 into `ServiceError::NotFound` which in some places can trigger (or could, rather) marking a recipient as unregistered. To me, this does not make any sense, so instead always return the HTTP error wrapped in `ServiceError::Http` to underline that we're _not_ talking with Signal servers with the request. We could also add an `ServiceError::CdnError` and add return the error there, but that's beyond of this PR.

Includes #356 as it is now. I'll drop the commit if/when that gets merged. Until then this is a draft.