### PR TITLE
Pre-key consistency

### DIFF
--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -223,6 +223,18 @@ impl PreKeysStore for ExampleStore {
     ) -> Result<usize, SignalProtocolError> {
         todo!()
     }
+
+    async fn signed_prekey_id(
+        &self,
+    ) -> Result<Option<SignedPreKeyId>, SignalProtocolError> {
+        todo!()
+    }
+
+    async fn last_resort_kyber_prekey_id(
+        &self,
+    ) -> Result<Option<KyberPreKeyId>, SignalProtocolError> {
+        todo!()
+    }
 }
 
 #[allow(dead_code)]

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -183,6 +183,11 @@ impl AccountManager {
         {
             if protocol_store.signed_pre_keys_count().await? > 0
                 && protocol_store.kyber_pre_keys_count(true).await? > 0
+                && protocol_store.signed_prekey_id().await?.is_some()
+                && protocol_store
+                    .last_resort_kyber_prekey_id()
+                    .await?
+                    .is_some()
             {
                 tracing::debug!("Available keys sufficient");
                 return Ok(());

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -172,6 +172,13 @@ impl AccountManager {
                 "Checking pre keys"
             ))
             .await?;
+        if !check_pre_keys {
+            tracing::info!(
+                "Last resort pre-keys are not up to date; refreshing."
+            );
+        } else {
+            tracing::debug!("Last resort pre-keys are up to date.");
+        }
 
         // XXX We should honestly compare the pre-key count with the number of pre-keys we have
         // locally. If we have more than the server, we should upload them.

--- a/src/pre_keys.rs
+++ b/src/pre_keys.rs
@@ -9,7 +9,7 @@ use libsignal_protocol::{
     error::SignalProtocolError, kem, GenericSignedPreKey, IdentityKey,
     IdentityKeyPair, IdentityKeyStore, KeyPair, KyberPreKeyId,
     KyberPreKeyRecord, KyberPreKeyStore, PreKeyRecord, PreKeyStore,
-    SignedPreKeyRecord, SignedPreKeyStore, Timestamp,
+    SignedPreKeyId, SignedPreKeyRecord, SignedPreKeyStore, Timestamp,
 };
 
 use rand::{CryptoRng, Rng};
@@ -79,6 +79,14 @@ pub trait PreKeysStore:
         &self,
         last_resort: bool,
     ) -> Result<usize, SignalProtocolError>;
+
+    async fn signed_prekey_id(
+        &self,
+    ) -> Result<Option<SignedPreKeyId>, SignalProtocolError>;
+
+    async fn last_resort_kyber_prekey_id(
+        &self,
+    ) -> Result<Option<KyberPreKeyId>, SignalProtocolError>;
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
The server view and client view on which prekeys are available *might* diverge over time, because of bugs and transmission failures. This PR tries to address this at least in part.

This PR also allows the client to assert that their last resort ("repeated use") keys are up-to-date and in sync, which is crucial if we don't want the device to get locked (https://github.com/signalapp/Signal-Server/commit/cdb651b68fc42447e765157c6311cd10f93828c6)