### PR TITLE
refactor: don't store Rng in MessageSender

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -722,7 +722,7 @@ impl AccountManager {
         &mut self,
         aci_protocol_store: &mut AciStore,
         pni_protocol_store: &mut PniStore,
-        mut sender: MessageSender<AciOrPni, R>,
+        mut sender: MessageSender<AciOrPni>,
         local_aci: Aci,
         e164: PhoneNumber,
         csprng: &mut R,
@@ -902,6 +902,7 @@ impl AccountManager {
     }
 }
 
+#[expect(clippy::result_large_err)]
 fn calculate_hmac256(
     mac_key: &[u8],
     ciphertext: &[u8],
@@ -912,6 +913,7 @@ fn calculate_hmac256(
     Ok(mac.finalize().into_bytes())
 }
 
+#[expect(clippy::result_large_err)]
 pub fn encrypt_device_name<R: rand::Rng + rand::CryptoRng>(
     csprng: &mut R,
     device_name: &str,
@@ -948,6 +950,7 @@ pub fn encrypt_device_name<R: rand::Rng + rand::CryptoRng>(
     Ok(device_name)
 }
 
+#[expect(clippy::result_large_err)]
 fn decrypt_device_name_from_device_info(
     string: &str,
     aci: &IdentityKeyPair,
@@ -957,6 +960,7 @@ fn decrypt_device_name_from_device_info(
     crate::decrypt_device_name(aci.private_key(), &name)
 }
 
+#[expect(clippy::result_large_err)]
 pub fn decrypt_device_name(
     private_key: &PrivateKey,
     device_name: &DeviceName,

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -454,7 +454,7 @@ struct Plaintext {
     data: Vec<u8>,
 }
 
-#[allow(clippy::comparison_chain)]
+#[expect(clippy::comparison_chain, clippy::result_large_err)]
 fn add_padding(version: u32, contents: &[u8]) -> Result<Vec<u8>, ServiceError> {
     if version < 2 {
         Err(ServiceError::PaddingVersion(version))
@@ -477,7 +477,7 @@ fn add_padding(version: u32, contents: &[u8]) -> Result<Vec<u8>, ServiceError> {
     }
 }
 
-#[allow(clippy::comparison_chain)]
+#[expect(clippy::comparison_chain, clippy::result_large_err)]
 fn strip_padding_version(
     version: u32,
     contents: &mut Vec<u8>,
@@ -494,7 +494,7 @@ fn strip_padding_version(
     }
 }
 
-#[allow(clippy::comparison_chain)]
+#[expect(clippy::result_large_err)]
 fn strip_padding(contents: &mut Vec<u8>) -> Result<(), ServiceError> {
     let new_length = Iso7816::raw_unpad(contents)?.len();
     contents.resize(new_length, 0);

--- a/src/content.rs
+++ b/src/content.rs
@@ -70,6 +70,7 @@ impl Content {
     }
 
     /// Converts a proto::Content into a public Content, including metadata.
+    #[expect(clippy::result_large_err)]
     pub fn from_proto(
         p: crate::proto::Content,
         metadata: Metadata,

--- a/src/groups_v2/manager.rs
+++ b/src/groups_v2/manager.rs
@@ -38,6 +38,7 @@ pub struct CredentialResponse {
     credentials: Vec<TemporalCredential>,
 }
 
+#[expect(clippy::result_large_err)]
 impl CredentialResponse {
     pub fn parse(
         self,
@@ -198,6 +199,7 @@ impl<C: CredentialsCache> GroupsManager<C> {
         )
     }
 
+    #[expect(clippy::result_large_err)]
     fn get_authorization_string<R: Rng + CryptoRng>(
         &self,
         csprng: &mut R,
@@ -303,6 +305,7 @@ impl<C: CredentialsCache> GroupsManager<C> {
     }
 }
 
+#[expect(clippy::result_large_err)]
 pub fn decrypt_group(
     master_key_bytes: &[u8],
     encrypted_group: crate::proto::Group,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::all)]
 
-use rand::{CryptoRng, Rng};
+use rand::{thread_rng, Rng, RngCore};
 include!(concat!(env!("OUT_DIR"), "/signalservice.rs"));
 include!(concat!(env!("OUT_DIR"), "/signal.rs"));
 
@@ -69,10 +69,11 @@ impl WebSocketResponseMessage {
 }
 
 impl SyncMessage {
-    pub fn with_padding<R: Rng + CryptoRng>(csprng: &mut R) -> Self {
-        let random_size = csprng.gen_range(1..=512);
+    pub fn with_padding() -> Self {
+        let mut rng = thread_rng();
+        let random_size = rng.gen_range(1..=512);
         let mut padding: Vec<u8> = vec![0; random_size];
-        csprng.fill_bytes(&mut padding);
+        rng.fill_bytes(&mut padding);
 
         Self {
             padding: Some(padding),

--- a/src/provisioning/cipher.rs
+++ b/src/provisioning/cipher.rs
@@ -70,6 +70,7 @@ impl ProvisioningCipher {
         self.key_material.public()
     }
 
+    #[expect(clippy::result_large_err)]
     pub fn encrypt<R: Rng + CryptoRng>(
         &self,
         csprng: &mut R,
@@ -110,6 +111,7 @@ impl ProvisioningCipher {
         })
     }
 
+    #[expect(clippy::result_large_err)]
     pub fn decrypt(
         &self,
         provision_envelope: ProvisionEnvelope,

--- a/src/push_service/cdn.rs
+++ b/src/push_service/cdn.rs
@@ -92,7 +92,7 @@ impl PushService {
             .await?
             .error_for_status()?
             .bytes_stream()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
             .into_async_read();
 
         Ok(response_stream)

--- a/src/push_service/mod.rs
+++ b/src/push_service/mod.rs
@@ -285,9 +285,9 @@ pub(crate) mod protobuf {
     #[async_trait::async_trait]
     pub(crate) trait ProtobufResponseExt {
         /// Get the response body decoded from Protobuf
-        async fn protobuf<T: prost::Message + Default>(
-            self,
-        ) -> Result<T, ServiceError>;
+        async fn protobuf<T>(self) -> Result<T, ServiceError>
+        where
+            T: prost::Message + Default;
     }
 
     impl ProtobufRequestBuilderExt for RequestBuilder {
@@ -305,9 +305,10 @@ pub(crate) mod protobuf {
 
     #[async_trait]
     impl ProtobufResponseExt for Response {
-        async fn protobuf<T: Message + Default>(
-            self,
-        ) -> Result<T, ServiceError> {
+        async fn protobuf<T>(self) -> Result<T, ServiceError>
+        where
+            T: Message + Default,
+        {
             let body = self.bytes().await?;
             let decoded = T::decode(body)?;
             Ok(decoded)

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -6,7 +6,7 @@ use libsignal_protocol::{
     ProtocolStore, SenderCertificate, SenderKeyStore, ServiceId,
     SignalProtocolError,
 };
-use rand::{CryptoRng, Rng};
+use rand::{thread_rng, CryptoRng, Rng};
 use tracing::{debug, error, info, trace, warn};
 use tracing_futures::Instrument;
 use uuid::Uuid;
@@ -86,12 +86,11 @@ pub struct AttachmentSpec {
 }
 
 #[derive(Clone)]
-pub struct MessageSender<S, R> {
+pub struct MessageSender<S> {
     identified_ws: SignalWebSocket,
     unidentified_ws: SignalWebSocket,
     service: PushService,
     cipher: ServiceCipher<S>,
-    csprng: R,
     protocol_store: S,
     local_aci: Aci,
     local_pni: Pni,
@@ -153,10 +152,9 @@ pub struct EncryptedMessages {
     used_identity_key: IdentityKey,
 }
 
-impl<S, R> MessageSender<S, R>
+impl<S> MessageSender<S>
 where
     S: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone,
-    R: Rng + CryptoRng,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -164,7 +162,6 @@ where
         unidentified_ws: SignalWebSocket,
         service: PushService,
         cipher: ServiceCipher<S>,
-        csprng: R,
         protocol_store: S,
         local_aci: impl Into<Aci>,
         local_pni: impl Into<Pni>,
@@ -177,7 +174,6 @@ where
             identified_ws,
             unidentified_ws,
             cipher,
-            csprng,
             protocol_store,
             local_aci: local_aci.into(),
             local_pni: local_pni.into(),
@@ -190,19 +186,20 @@ where
     /// Encrypts and uploads an attachment
     ///
     /// Contents are accepted as an owned, plain text Vec, because encryption happens in-place.
-    #[tracing::instrument(skip(self, contents), fields(size = contents.len()))]
-    pub async fn upload_attachment(
+    #[tracing::instrument(skip(self, contents, csprng), fields(size = contents.len()))]
+    pub async fn upload_attachment<R: Rng + CryptoRng>(
         &mut self,
         spec: AttachmentSpec,
         mut contents: Vec<u8>,
+        csprng: &mut R,
     ) -> Result<AttachmentPointer, AttachmentUploadError> {
         let len = contents.len();
         // Encrypt
         let (key, iv) = {
             let mut key = [0u8; 64];
             let mut iv = [0u8; 16];
-            self.csprng.fill_bytes(&mut key);
-            self.csprng.fill_bytes(&mut iv);
+            csprng.fill_bytes(&mut key);
+            csprng.fill_bytes(&mut iv);
             (key, iv)
         };
 
@@ -323,7 +320,7 @@ where
             caption: None,
             blur_hash: None,
         };
-        self.upload_attachment(spec, out).await
+        self.upload_attachment(spec, out, &mut thread_rng()).await
     }
 
     /// Return whether we have to prepare sync messages for other devices
@@ -548,6 +545,8 @@ where
 
         let content_bytes = content.encode_to_vec();
 
+        let mut rng = thread_rng();
+
         for _ in 0..4u8 {
             let Some(EncryptedMessages {
                 messages,
@@ -632,7 +631,7 @@ where
                             &mut self.protocol_store,
                             &pre_key,
                             SystemTime::now(),
-                            &mut self.csprng,
+                            &mut rng,
                         )
                         .await
                         .map_err(|e| {
@@ -710,7 +709,7 @@ where
                 blob: Some(ptr),
                 complete: Some(complete),
             }),
-            ..SyncMessage::with_padding(&mut self.csprng)
+            ..SyncMessage::with_padding()
         };
 
         self.send_message(
@@ -735,7 +734,7 @@ where
     ) -> Result<(), MessageSenderError> {
         let msg = SyncMessage {
             configuration: Some(configuration),
-            ..SyncMessage::with_padding(&mut self.csprng)
+            ..SyncMessage::with_padding()
         };
 
         let ts = Utc::now().timestamp_millis() as u64;
@@ -782,7 +781,7 @@ where
 
         let msg = SyncMessage {
             message_request_response,
-            ..SyncMessage::with_padding(&mut self.csprng)
+            ..SyncMessage::with_padding()
         };
 
         let ts = Utc::now().timestamp_millis() as u64;
@@ -801,7 +800,7 @@ where
     ) -> Result<(), MessageSenderError> {
         let msg = SyncMessage {
             keys: Some(keys),
-            ..SyncMessage::with_padding(&mut self.csprng)
+            ..SyncMessage::with_padding()
         };
 
         let ts = Utc::now().timestamp_millis() as u64;
@@ -826,7 +825,7 @@ where
             request: Some(sync_message::Request {
                 r#type: Some(request_type.into()),
             }),
-            ..SyncMessage::with_padding(&mut self.csprng)
+            ..SyncMessage::with_padding()
         };
 
         let ts = Utc::now().timestamp_millis() as u64;
@@ -840,12 +839,13 @@ where
     fn create_pni_signature(
         &mut self,
     ) -> Result<crate::proto::PniSignatureMessage, MessageSenderError> {
+        let mut rng = thread_rng();
         let signature = self
             .pni_identity
             .expect("PNI key set when PNI signature requested")
             .sign_alternate_identity(
                 self.aci_identity.identity_key(),
-                &mut self.csprng,
+                &mut rng,
             )?;
         Ok(crate::proto::PniSignatureMessage {
             pni: Some(self.local_pni.service_id_binary()),
@@ -1007,6 +1007,8 @@ where
                 Err(e) => Err(e)?,
             };
 
+            let mut rng = thread_rng();
+
             for pre_key_bundle in pre_keys {
                 if recipient == &self.local_aci
                     && self.device_id == pre_key_bundle.device_id()?
@@ -1028,7 +1030,7 @@ where
                     &mut self.protocol_store,
                     &pre_key_bundle,
                     SystemTime::now(),
-                    &mut self.csprng,
+                    &mut rng,
                 )
                 .await?;
             }
@@ -1040,7 +1042,7 @@ where
                 &recipient_protocol_address,
                 unidentified_access,
                 content,
-                &mut self.csprng,
+                &mut thread_rng(),
             )
             .instrument(tracing::trace_span!("encrypting message"))
             .await?;
@@ -1098,7 +1100,7 @@ where
                 unidentified_status,
                 ..Default::default()
             }),
-            ..SyncMessage::with_padding(&mut self.csprng)
+            ..SyncMessage::with_padding()
         })
     }
 }


### PR DESCRIPTION
A `Rng` instance was stored in `MessageSender`, and was used to generate random numbers. However, this might cause a problem: Cloning `MessageSender` also cloned the RNG, leading to the generation of identical random numbers from multiple cloned instances. This is a security risk.

This commit removes the `Rng` from the `MessageSender` struct.  Random number generation is now handled on a per-function basis, using `thread_rng()` when needed. This ensures that each function call gets its own independent RNG state, preventing the previously observed issue.

Also see whisperfish/presage#292.