### PR TITLE
Tolerate bad linked device names

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -432,15 +432,18 @@ impl AccountManager {
             .map(|i| {
                 Ok(DeviceInfo {
                     id: i.id,
-                    name: i
-                        .name
-                        .map(|s| {
-                            decrypt_device_name_from_device_info(
-                                &s,
-                                &aci_identity_keypair,
-                            )
-                        })
-                        .transpose()?,
+                    name: i.name.map(|s| {
+                        match decrypt_device_name_from_device_info(
+                            &s,
+                            &aci_identity_keypair,
+                        ) {
+                            Ok(name) => name,
+                            Err(e) => {
+                                tracing::error!("{e}");
+                                String::from("N/A")
+                            },
+                        }
+                    }),
                     created: i.created,
                     last_seen: i.last_seen,
                 })

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -432,15 +432,15 @@ impl AccountManager {
             .map(|i| {
                 Ok(DeviceInfo {
                     id: i.id,
-                    name: i.name.map(|s| {
+                    name: i.name.and_then(|s| {
                         match decrypt_device_name_from_device_info(
                             &s,
                             &aci_identity_keypair,
                         ) {
-                            Ok(name) => name,
+                            Ok(name) => Some(name),
                             Err(e) => {
                                 tracing::error!("{e}");
-                                String::from("N/A")
+                                None
                             },
                         }
                     }),


### PR DESCRIPTION
Some clients, \*ahem\* Whisperfish \*cough\*, don't set their device name properly, leaving something like `Whisperfisg=` sent to the server. While it is valid base64, it's by no means valid encrypted data. If one name fails to decrypt, nothing is returned. This is highly undesired in itself.

Tolerate such data by logging an error and replacing the name with a neutral `N/A` instead. This is easy to catch and translate in UI as well.