### PR TITLE
Fix renaming devices

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -661,8 +661,7 @@ impl AccountManager {
         let public_key = aci_identity_store.get_identity(&addr).await?;
         let Some(public_key) = public_key else {
             return Err(ServiceError::SendError {
-                reason: format!("public key for device {addr:?} not found")
-                    .into(),
+                reason: format!("public key for device {addr:?} not found"),
             });
         };
         let encrypted_device_name =


### PR DESCRIPTION
I had to change the function signature quite a bit to compensate for `async` shenanigans (the original signature required `IdentityKey` which was `async` and the function itself is `async`). If this is not acceptable, I can try to change it, but this seems to work fine.

Tested with Whisperfish; the changed name gets saved and is displayed again correctly.