### PR TITLE
Remove unused dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
 
 tokio = { version = "1.0", features = ["macros"] }
-serde_with = "3.14.0"
 
 [build-dependencies]
 prost-build = "0.13"

--- a/src/push_service/mod.rs
+++ b/src/push_service/mod.rs
@@ -18,7 +18,6 @@ use protobuf::ProtobufResponseExt;
 use reqwest::{Method, RequestBuilder};
 use reqwest_websocket::RequestBuilderExt;
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 use tracing::{debug_span, Instrument};
 
 pub const KEEPALIVE_TIMEOUT_SECONDS: Duration = Duration::from_secs(55);
@@ -134,7 +133,6 @@ pub struct MismatchedDevices {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde_as]
 #[serde(rename_all = "camelCase")]
 pub struct StaleDevices {
     pub stale_devices: Vec<u32>,


### PR DESCRIPTION
As far as I can see, this dependency does nothing. There is one struct annotated with `serde_as`, but as far as I can see from the [serde_with documentation](https://docs.rs/crate/serde_with/latest), it would also require annotating fields to actually do something.

This was introduced in #361.