### PR TITLE
Fix deprecated SPDX license used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "libsignal-service"
 version = "0.1.0"
 authors = ["Ruben De Smet <ruben.de.smet@rubdos.be>", "Gabriel Féron <g@leirbag.net>"]
 edition = "2021"
-license = "AGPL-3.0"
+license = "AGPL-3.0-only"
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION
According to https://spdx.org/licenses/, AGPL-3.0 is deprecated. Swapped this out by AGPL-3.0-only (there would also exists -or-later, but to me knowledge we are forced to use -only as that is also the license used by Signal: https://github.com/signalapp/libsignal/blob/eb7e0e7d18c76b29a0de706ed8932730f68b677e/Cargo.toml#L42).