### PR TITLE
Fix CI on the main branch

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --all-features --no-deps -p libsignal-service -p libsignal-protocol -p zkgroup -p libsignal-service-actix -p libsignal-service-hyper
+          args: --all-features --no-deps -p libsignal-service -p libsignal-protocol -p zkgroup
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ The example below serves as an example of how this library can be included in `C
 ```toml
 [dependencies]
 libsignal-service = { git = "https://github.com/whisperfish/libsignal-service-rs", branch = "main" }
-libsignal-service-actix = { git = "https://github.com/whisperfish/libsignal-service-rs", branch = "main" }
 
 libsignal-protocol = { git = "https://github.com/signalapp/libsignal-client", branch = "main" }
 zkgroup = { version = "0.9.0", git = "https://github.com/signalapp/libsignal-client", branch = "main" }


### PR DESCRIPTION
This removes generating  the documentation for the packages `libsignal-service-hyper` and `libsignal-service-actix`, which do not exist anymore, from CI. There was also still a reference to `-actix` used in the README, which I also removed.

Untested, as the pages step does not run in PRs, only on `main`.