### PR TITLE
fix: expose timestamp and server_timestamp

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -232,6 +232,22 @@ where
             }
         }
 
+        // Extract both kinds of timestamps.
+        // Note that we do not `?` here, but rather only later, in case we ever have a branch which
+        // is not concerned with envelope metadata.
+        let timestamp = chrono::DateTime::from_timestamp_millis(
+            envelope.timestamp() as i64,
+        )
+        .ok_or(ServiceError::InvalidFrame {
+            reason: "unparseable timestamp",
+        });
+        let server_timestamp = chrono::DateTime::from_timestamp_millis(
+            envelope.server_timestamp() as i64,
+        )
+        .ok_or(ServiceError::InvalidFrame {
+            reason: "unparseable server timestamp",
+        });
+
         use crate::proto::envelope::Type;
         let plaintext = match envelope.r#type() {
             Type::PrekeyBundle => {
@@ -251,7 +267,8 @@ where
                         .parse_source_service_id()
                         .expect("prekey bundle format"),
                     sender_device: envelope.source_device().try_into()?,
-                    timestamp: envelope.server_timestamp(),
+                    timestamp: timestamp?,
+                    server_timestamp: server_timestamp?,
                     needs_receipt: false,
                     unidentified_sender: false,
                     was_plaintext: false,
@@ -295,7 +312,8 @@ where
                         .parse_source_service_id()
                         .expect("plaintext content format"),
                     sender_device: envelope.source_device().try_into()?,
-                    timestamp: envelope.server_timestamp(),
+                    timestamp: timestamp?,
+                    server_timestamp: server_timestamp?,
                     needs_receipt: false,
                     unidentified_sender: false,
                     was_plaintext: true,
@@ -324,7 +342,8 @@ where
                         .parse_source_service_id()
                         .expect("ciphertext envelope format"),
                     sender_device: envelope.source_device().try_into()?,
-                    timestamp: envelope.timestamp(),
+                    timestamp: timestamp?,
+                    server_timestamp: server_timestamp?,
                     needs_receipt: false,
                     unidentified_sender: false,
                     was_plaintext: false,
@@ -410,7 +429,8 @@ where
                         .expect("unidentified sender envelope format"),
                     sender,
                     sender_device: device_id,
-                    timestamp: envelope.timestamp(),
+                    timestamp: timestamp?,
+                    server_timestamp: server_timestamp?,
                     unidentified_sender: true,
                     needs_receipt,
                     was_plaintext: false,

--- a/src/content.rs
+++ b/src/content.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use libsignal_core::DeviceId;
 use libsignal_protocol::{ProtocolAddress, ServiceId};
 use prost::Message;
@@ -25,7 +26,8 @@ pub struct Metadata {
     pub sender: ServiceId,
     pub destination: ServiceId,
     pub sender_device: DeviceId,
-    pub timestamp: u64,
+    pub timestamp: chrono::DateTime<Utc>,
+    pub server_timestamp: chrono::DateTime<Utc>,
     pub needs_receipt: bool,
     pub unidentified_sender: bool,
     pub was_plaintext: bool,
@@ -40,13 +42,14 @@ impl fmt::Display for Metadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Metadata {{ sender: {}, guid: {} }}",
+            "Metadata {{ sender: {}, guid: {}, server timestamp: {} }}",
             self.sender.service_id_string(),
             // XXX: should this still be optional?
             self.server_guid
                 .map(|u| u.to_string())
                 .as_deref()
                 .unwrap_or("None"),
+            self.server_timestamp,
         )
     }
 }


### PR DESCRIPTION
These two fields were being confused, and now they're both exposed and parsed as chrono::DateTime. Should be a lot cleaner this way!