### PR TITLE
chore: bump libsignal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ license = "AGPL-3.0-only"
 readme = "README.md"
 
 [dependencies]
-libsignal-protocol = { git = "https://github.com/signalapp/libsignal", tag = "v0.87.4" }
-libsignal-core = { git = "https://github.com/signalapp/libsignal", tag = "v0.87.4" }
-libsignal-net = { git = "https://github.com/signalapp/libsignal", tag = "v0.87.4", optional = true }
-libsignal-net-infra = { git = "https://github.com/signalapp/libsignal", tag = "v0.87.4", optional = true }
-signal-crypto = { git = "https://github.com/signalapp/libsignal", tag = "v0.87.4" }
-zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.87.4" }
-usernames = { git = "https://github.com/signalapp/libsignal", tag = "v0.87.4" }
+libsignal-protocol = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
+libsignal-core = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
+libsignal-net = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0", optional = true }
+libsignal-net-infra = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0", optional = true }
+signal-crypto = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
+zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
+usernames = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
 
 aes = "0.8"
 aes-gcm = "0.10"

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -34,8 +34,7 @@ use crate::{
 pub struct ServiceCipher<S> {
     protocol_store: S,
     trust_roots: Vec<PublicKey>,
-    local_uuid: Uuid,
-    local_device_id: DeviceId,
+    local_address: ProtocolAddress,
 }
 
 impl<S> fmt::Debug for ServiceCipher<S> {
@@ -43,8 +42,7 @@ impl<S> fmt::Debug for ServiceCipher<S> {
         f.debug_struct("ServiceCipher")
             .field("protocol_store", &"...")
             .field("trust_root", &"...")
-            .field("local_uuid", &self.local_uuid)
-            .field("local_device_id", &self.local_device_id)
+            .field("local_address", &self.local_address)
             .finish()
     }
 }
@@ -77,14 +75,12 @@ where
     pub fn new(
         protocol_store: S,
         trust_roots: Vec<PublicKey>,
-        local_uuid: Uuid,
-        local_device_id: DeviceId,
+        local_address: ProtocolAddress,
     ) -> Self {
         Self {
             protocol_store,
             trust_roots,
-            local_uuid,
-            local_device_id,
+            local_address,
         }
     }
 
@@ -97,6 +93,10 @@ where
         envelope: Envelope,
         csprng: &mut R,
     ) -> Result<Option<Content>, ServiceError> {
+        let local_service: ServiceId =
+            ServiceId::parse_from_service_id_string(self.local_address.name())
+                .expect("valid protocol address name");
+
         if envelope.content.is_some() {
             let plaintext = self.decrypt(&envelope, csprng).await?;
             let was_plaintext = plaintext.metadata.was_plaintext;
@@ -138,8 +138,9 @@ where
             }
 
             if message.sync_message.is_some()
-                && plaintext.metadata.sender.aci().map(Into::into)
-                    != Some(self.local_uuid)
+                && plaintext.metadata.sender.aci().map(Uuid::from)
+                    != Some(local_service.raw_uuid())
+                && local_service.kind() == ServiceIdKind::Aci
             {
                 tracing::warn!("Source is not ourself.");
                 return Ok(None);
@@ -180,6 +181,10 @@ where
         envelope: &Envelope,
         csprng: &mut R,
     ) -> Result<Plaintext, ServiceError> {
+        let local_service: ServiceId =
+            ServiceId::parse_from_service_id_string(self.local_address.name())
+                .expect("valid protocol address name");
+
         let ciphertext = if let Some(msg) = envelope.content.as_ref() {
             msg
         } else {
@@ -202,7 +207,7 @@ where
             });
         };
 
-        if destination_service_id.raw_uuid() != self.local_uuid {
+        if destination_service_id != local_service {
             tracing::warn!(
                 "mismatching destination service id; ignoring invalid message."
             );
@@ -262,6 +267,7 @@ where
                 let mut data = message_decrypt_prekey(
                     &PreKeySignalMessage::try_from(&ciphertext[..])?,
                     &sender,
+                    &self.local_address,
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
@@ -366,8 +372,7 @@ where
                     &self.trust_roots,
                     Timestamp::from_epoch_millis(envelope.timestamp()),
                     None,
-                    self.local_uuid.to_string(),
-                    self.local_device_id,
+                    self.local_address.clone(),
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
@@ -489,6 +494,7 @@ where
             let message = message_encrypt(
                 &padded_content,
                 address,
+                &self.local_address,
                 &mut self.protocol_store.clone(),
                 &mut self.protocol_store.clone(),
                 SystemTime::now(),
@@ -610,8 +616,7 @@ async fn sealed_sender_decrypt(
     trust_roots: &[PublicKey],
     timestamp: Timestamp,
     local_e164: Option<String>,
-    local_uuid: String,
-    local_device_id: DeviceId,
+    local_address: ProtocolAddress,
     identity_store: &mut dyn IdentityKeyStore,
     session_store: &mut dyn SessionStore,
     pre_key_store: &mut dyn PreKeyStore,
@@ -631,7 +636,16 @@ async fn sealed_sender_decrypt(
         ));
     }
 
-    let is_local_uuid = local_uuid == usmc.sender()?.sender_uuid()?;
+    let local_service_id =
+        ServiceId::parse_from_service_id_string(local_address.name())
+            .expect("valid protocol address name");
+    let is_local_uuid = local_service_id.raw_uuid()
+        == usmc
+            .sender()?
+            .sender_uuid()?
+            .parse::<Uuid>()
+            // Validity checked inside certificate checker
+            .expect("valid uuid");
 
     let is_local_e164 = match (local_e164, usmc.sender()?.sender_e164()?) {
         (Some(l), Some(s)) => l == s,
@@ -639,7 +653,7 @@ async fn sealed_sender_decrypt(
     };
 
     if (is_local_e164 || is_local_uuid)
-        && usmc.sender()?.sender_device_id()? == local_device_id
+        && usmc.sender()?.sender_device_id()? == local_address.device_id()
     {
         return Err(SignalProtocolError::SealedSenderSelfSend);
     }
@@ -668,6 +682,7 @@ async fn sealed_sender_decrypt(
             message_decrypt_prekey(
                 &ctext,
                 &remote_address,
+                &local_address,
                 session_store,
                 identity_store,
                 pre_key_store,

--- a/src/websocket/directory.rs
+++ b/src/websocket/directory.rs
@@ -105,6 +105,7 @@ impl SignalWebSocket<Identified> {
         let cdsi_endpoint = &env.cdsi;
         let cdsi_connection = CdsiConnection::connect_with(
             connection_resources,
+            env.cdsi.domain_config.connect.service,
             libsignal_net_infra::route::DirectOrProxyProvider::direct(
                 cdsi_endpoint.enclave_websocket_provider(
                     libsignal_net_infra::EnableDomainFronting::No,


### PR DESCRIPTION
Found some time to bump to latest. Untested. Encryption calls now expect to supply a local address; might introduce some errors due to type confusion when they also expect the remote.

CDSI also takes a service name now. 