### PR TITLE
feat: SignalServiceProfile: Clone

### DIFF
--- a/src/websocket/profile.rs
+++ b/src/websocket/profile.rs
@@ -10,7 +10,7 @@ use crate::{
     websocket::{self, account::DeviceCapabilities, SignalWebSocket},
 };
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SignalServiceProfile {
     #[serde(default, with = "serde_optional_base64")]


### PR DESCRIPTION
I'm refactoring some code flow, and it would be quite useful to do some metadata processing in another place than the decryption (which takes SSP by value)