### PR TITLE
Prekey refactor

### DIFF
--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -237,6 +237,20 @@ impl PreKeysStore for ExampleStore {
     ) -> Result<Option<KyberPreKeyId>, SignalProtocolError> {
         todo!()
     }
+
+    async fn replace_one_time_ec_pre_keys(
+        &mut self,
+        _keys: &[PreKeyRecord],
+    ) -> Result<(), SignalProtocolError> {
+        todo!()
+    }
+
+    async fn replace_one_time_kyber_pre_keys(
+        &mut self,
+        _keys: &[KyberPreKeyRecord],
+    ) -> Result<(), SignalProtocolError> {
+        todo!()
+    }
 }
 
 #[allow(dead_code)]

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -145,6 +145,10 @@ impl AccountManager {
     /// signed pre-keys.
     ///
     /// Equivalent to Java's RefreshPreKeysJob
+    ///
+    /// **WARNING**: Callers must ensure the message queue is exhausted (no pending messages requiring pre-keys)
+    /// before calling this method. The replace operations are not atomic with message handling and
+    /// can cause a race condition where messages use a pre-key was removed during this operation.
     #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip(self, protocol_store))]
     pub async fn update_pre_key_bundle<P: PreKeysStore>(
@@ -176,6 +180,12 @@ impl AccountManager {
         };
         tracing::trace!("Remaining pre-keys on server: {:?}", prekey_status);
 
+        tracing::info!(
+            "Server pre-key counts: EC={}, Kyber={}",
+            prekey_status.count,
+            prekey_status.pq_count
+        );
+
         let check_pre_keys = self
             .check_pre_keys(protocol_store, service_id_kind)
             .instrument(tracing::span!(
@@ -191,26 +201,21 @@ impl AccountManager {
             tracing::debug!("Last resort pre-keys are up to date.");
         }
 
-        // XXX We should honestly compare the pre-key count with the number of pre-keys we have
-        // locally. If we have more than the server, we should upload them.
-        // Currently the trait doesn't allow us to do that, so we just upload the batch size and
-        // pray.
-        if check_pre_keys
-            && (prekey_status.count >= PRE_KEY_MINIMUM
-                && prekey_status.pq_count >= PRE_KEY_MINIMUM)
+        // Early return if server has enough keys (hysteresis to avoid thrashing)
+        if prekey_status.count >= PRE_KEY_MINIMUM
+            && prekey_status.pq_count >= PRE_KEY_MINIMUM
+            && protocol_store.signed_pre_keys_count().await? > 0
+            && protocol_store.kyber_pre_keys_count(true).await? > 0
+            && protocol_store.signed_prekey_id().await?.is_some()
+            && protocol_store
+                .last_resort_kyber_prekey_id()
+                .await?
+                .is_some()
         {
-            if protocol_store.signed_pre_keys_count().await? > 0
-                && protocol_store.kyber_pre_keys_count(true).await? > 0
-                && protocol_store.signed_prekey_id().await?.is_some()
-                && protocol_store
-                    .last_resort_kyber_prekey_id()
-                    .await?
-                    .is_some()
-            {
-                tracing::debug!("Available keys sufficient");
-                return Ok(());
-            }
-            tracing::info!("Available keys sufficient; forcing refresh.");
+            tracing::debug!(
+                "Server and local keys sufficient; skipping generation"
+            );
+            return Ok(());
         }
 
         let identity_key_pair = protocol_store
@@ -227,7 +232,7 @@ impl AccountManager {
         let has_last_resort_key = !last_resort_keys.is_empty();
 
         let (pre_keys, signed_pre_key, pq_pre_keys, pq_last_resort_key) =
-            crate::pre_keys::replenish_pre_keys(
+            crate::pre_keys::generate_pre_keys(
                 protocol_store,
                 &mut rand::rng(),
                 &identity_key_pair,
@@ -237,7 +242,8 @@ impl AccountManager {
             )
             .await?;
 
-        let pq_last_resort_key = if has_last_resort_key {
+        // Now convert to entities for upload
+        let pq_last_resort_key_entity = if has_last_resort_key {
             if last_resort_keys.len() > 1 {
                 tracing::warn!(
                     "More than one last resort key found; only uploading first"
@@ -246,35 +252,42 @@ impl AccountManager {
             Some(KyberPreKeyEntity::try_from(last_resort_keys[0].clone())?)
         } else {
             pq_last_resort_key
+                .clone()
                 .map(KyberPreKeyEntity::try_from)
                 .transpose()?
         };
 
         let identity_key = *identity_key_pair.identity_key();
 
-        let pre_keys: Vec<_> = pre_keys
-            .into_iter()
+        let pre_keys_entities: Vec<_> = pre_keys
+            .iter()
+            .cloned()
             .map(PreKeyEntity::try_from)
             .collect::<Result<_, _>>()?;
-        let signed_pre_key = signed_pre_key.try_into()?;
-        let pq_pre_keys: Vec<_> = pq_pre_keys
-            .into_iter()
+        let signed_pre_key_entity = signed_pre_key.clone().try_into()?;
+        let pq_pre_keys_entities: Vec<_> = pq_pre_keys
+            .iter()
+            .cloned()
             .map(KyberPreKeyEntity::try_from)
             .collect::<Result<_, _>>()?;
 
         tracing::info!(
             "Uploading pre-keys: {} one-time, {} PQ, {} PQ last resort",
-            pre_keys.len(),
-            pq_pre_keys.len(),
-            if pq_last_resort_key.is_some() { 1 } else { 0 }
+            pre_keys_entities.len(),
+            pq_pre_keys_entities.len(),
+            if pq_last_resort_key_entity.is_some() {
+                1
+            } else {
+                0
+            }
         );
 
         let pre_key_state = PreKeyState {
-            pre_keys,
-            signed_pre_key,
+            pre_keys: pre_keys_entities,
+            signed_pre_key: signed_pre_key_entity,
             identity_key,
-            pq_pre_keys,
-            pq_last_resort_key,
+            pq_pre_keys: pq_pre_keys_entities,
+            pq_last_resort_key: pq_last_resort_key_entity,
         };
 
         self.websocket
@@ -284,6 +297,16 @@ impl AccountManager {
                 "Uploading pre keys"
             ))
             .await?;
+
+        // Persist all pre-keys using the bundle wrapper
+        crate::pre_keys::store_pre_key_bundle(
+            protocol_store,
+            &pre_keys,
+            &signed_pre_key,
+            &pq_pre_keys,
+            pq_last_resort_key.as_ref(),
+        )
+        .await?;
 
         Ok(())
     }
@@ -497,7 +520,7 @@ impl AccountManager {
             aci_signed_pre_key,
             _aci_kyber_pre_keys,
             aci_last_resort_kyber_prekey,
-        ) = crate::pre_keys::replenish_pre_keys(
+        ) = crate::pre_keys::generate_pre_keys(
             aci_protocol_store,
             csprng,
             &aci_identity_key_pair,
@@ -507,12 +530,30 @@ impl AccountManager {
         )
         .await?;
 
+        // Persist the generated keys
+        for key in &_aci_pre_keys {
+            aci_protocol_store.save_pre_key(key.id()?, key).await?;
+        }
+        for key in &_aci_kyber_pre_keys {
+            aci_protocol_store
+                .save_kyber_pre_key(key.id()?, key)
+                .await?;
+        }
+        aci_protocol_store
+            .save_signed_pre_key(aci_signed_pre_key.id()?, &aci_signed_pre_key)
+            .await?;
+        if let Some(ref k) = aci_last_resort_kyber_prekey {
+            aci_protocol_store
+                .store_last_resort_kyber_pre_key(k.id()?, k)
+                .await?;
+        }
+
         let (
             _pni_pre_keys,
             pni_signed_pre_key,
             _pni_kyber_pre_keys,
             pni_last_resort_kyber_prekey,
-        ) = crate::pre_keys::replenish_pre_keys(
+        ) = crate::pre_keys::generate_pre_keys(
             pni_protocol_store,
             csprng,
             &pni_identity_key_pair,
@@ -521,6 +562,24 @@ impl AccountManager {
             0,
         )
         .await?;
+
+        // Persist the generated keys
+        for key in &_pni_pre_keys {
+            pni_protocol_store.save_pre_key(key.id()?, key).await?;
+        }
+        for key in &_pni_kyber_pre_keys {
+            pni_protocol_store
+                .save_kyber_pre_key(key.id()?, key)
+                .await?;
+        }
+        pni_protocol_store
+            .save_signed_pre_key(pni_signed_pre_key.id()?, &pni_signed_pre_key)
+            .await?;
+        if let Some(ref k) = pni_last_resort_kyber_prekey {
+            pni_protocol_store
+                .store_last_resort_kyber_pre_key(k.id()?, k)
+                .await?;
+        }
 
         let aci_identity_key = aci_identity_key_pair.identity_key();
         let pni_identity_key = pni_identity_key_pair.identity_key();
@@ -818,7 +877,12 @@ impl AccountManager {
                 _kyber_pre_keys,
                 last_resort_kyber_prekey,
             ) = if local_device_id == *DEFAULT_DEVICE_ID {
-                crate::pre_keys::replenish_pre_keys(
+                let (
+                    pre_keys,
+                    signed_pre_key,
+                    kyber_pre_keys,
+                    last_resort_kyber_prekey,
+                ) = crate::pre_keys::generate_pre_keys(
                     pni_protocol_store,
                     csprng,
                     &pni_identity_key_pair,
@@ -826,7 +890,32 @@ impl AccountManager {
                     0,
                     0,
                 )
-                .await?
+                .await?;
+
+                // Persist the generated keys
+                for key in &pre_keys {
+                    pni_protocol_store.save_pre_key(key.id()?, key).await?;
+                }
+                for key in &kyber_pre_keys {
+                    pni_protocol_store
+                        .save_kyber_pre_key(key.id()?, key)
+                        .await?;
+                }
+                pni_protocol_store
+                    .save_signed_pre_key(signed_pre_key.id()?, &signed_pre_key)
+                    .await?;
+                if let Some(ref k) = last_resort_kyber_prekey {
+                    pni_protocol_store
+                        .store_last_resort_kyber_pre_key(k.id()?, k)
+                        .await?;
+                }
+
+                (
+                    pre_keys,
+                    signed_pre_key,
+                    kyber_pre_keys,
+                    last_resort_kyber_prekey,
+                )
             } else {
                 // Generate a signed prekey
                 let signed_pre_key_pair = KeyPair::generate(csprng);

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -291,7 +291,7 @@ impl AccountManager {
         };
 
         self.websocket
-            .register_pre_keys(service_id_kind, pre_key_state)
+            .register_pre_keys(service_id_kind, &pre_key_state)
             .instrument(tracing::span!(
                 tracing::Level::DEBUG,
                 "Uploading pre keys"

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -516,9 +516,9 @@ impl AccountManager {
             .await?;
 
         let (
-            _aci_pre_keys,
+            aci_pre_keys,
             aci_signed_pre_key,
-            _aci_kyber_pre_keys,
+            aci_kyber_pre_keys,
             aci_last_resort_kyber_prekey,
         ) = crate::pre_keys::generate_pre_keys(
             aci_protocol_store,
@@ -531,10 +531,10 @@ impl AccountManager {
         .await?;
 
         // Persist the generated keys
-        for key in &_aci_pre_keys {
+        for key in &aci_pre_keys {
             aci_protocol_store.save_pre_key(key.id()?, key).await?;
         }
-        for key in &_aci_kyber_pre_keys {
+        for key in &aci_kyber_pre_keys {
             aci_protocol_store
                 .save_kyber_pre_key(key.id()?, key)
                 .await?;

--- a/src/pre_keys.rs
+++ b/src/pre_keys.rs
@@ -192,16 +192,10 @@ pub struct PreKeyState {
 }
 
 pub(crate) const PRE_KEY_BATCH_SIZE: u32 = 100;
-pub(crate) const PRE_KEY_MINIMUM: u32 = 10;
 pub(crate) const PRE_KEY_MEDIUM_MAX_VALUE: u32 = 0xFFFFFF;
+pub(crate) const PRE_KEY_MINIMUM: u32 = 10;
 
-/// Generate pre-keys without persisting them to storage.
-///
-/// This function performs in-memory generation of pre-keys but does not persist them.
-/// It may still call `next_pre_key_id()`, `next_signed_pre_key_id()`, and `next_pq_pre_key_id()`
-/// to obtain offsets for IDs.
-///
-/// Returns the generated records for the caller to persist as needed.
+/// Generate in-memory pre-keys for the caller to persist as needed.
 pub(crate) async fn generate_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
     protocol_store: &mut P,
     csprng: &mut R,
@@ -313,22 +307,22 @@ pub(crate) async fn store_pre_key_bundle<P: PreKeysStore>(
 ) -> Result<(), SignalProtocolError> {
     // Persist EC pre-keys (replace all)
     protocol_store
-        .replace_one_time_ec_pre_keys(&pre_keys)
+        .replace_one_time_ec_pre_keys(pre_keys)
         .await?;
 
     // Persist Kyber pre-keys
     protocol_store
-        .replace_one_time_kyber_pre_keys(&pq_pre_keys)
+        .replace_one_time_kyber_pre_keys(pq_pre_keys)
         .await?;
 
     // Persist signed pre-key
     let signed_pre_key_id = signed_pre_key.id()?;
     protocol_store
-        .save_signed_pre_key(signed_pre_key_id, &signed_pre_key)
+        .save_signed_pre_key(signed_pre_key_id, signed_pre_key)
         .await?;
 
     // Persist last resort Kyber key if present
-    if let Some(ref k) = pq_last_resort_key {
+    if let Some(k) = pq_last_resort_key {
         let id = k.id()?;
         protocol_store
             .store_last_resort_kyber_pre_key(id, k)

--- a/src/pre_keys.rs
+++ b/src/pre_keys.rs
@@ -14,7 +14,6 @@ use libsignal_protocol::{
 
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
-use tracing::Instrument;
 
 #[async_trait(?Send)]
 /// Additional methods for the Kyber pre key store
@@ -87,6 +86,18 @@ pub trait PreKeysStore:
     async fn last_resort_kyber_prekey_id(
         &self,
     ) -> Result<Option<KyberPreKeyId>, SignalProtocolError>;
+
+    /// Replace one-time EC pre-keys with a new set.
+    async fn replace_one_time_ec_pre_keys(
+        &mut self,
+        keys: &[PreKeyRecord],
+    ) -> Result<(), SignalProtocolError>;
+
+    /// Replace one-time Kyber pre-keys with a new set.
+    async fn replace_one_time_kyber_pre_keys(
+        &mut self,
+        keys: &[KyberPreKeyRecord],
+    ) -> Result<(), SignalProtocolError>;
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -180,11 +191,18 @@ pub struct PreKeyState {
     pub pq_pre_keys: Vec<KyberPreKeyEntity>,
 }
 
-pub(crate) const PRE_KEY_MINIMUM: u32 = 10;
 pub(crate) const PRE_KEY_BATCH_SIZE: u32 = 100;
+pub(crate) const PRE_KEY_MINIMUM: u32 = 10;
 pub(crate) const PRE_KEY_MEDIUM_MAX_VALUE: u32 = 0xFFFFFF;
 
-pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
+/// Generate pre-keys without persisting them to storage.
+///
+/// This function performs in-memory generation of pre-keys but does not persist them.
+/// It may still call `next_pre_key_id()`, `next_signed_pre_key_id()`, and `next_pq_pre_key_id()`
+/// to obtain offsets for IDs.
+///
+/// Returns the generated records for the caller to persist as needed.
+pub(crate) async fn generate_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
     protocol_store: &mut P,
     csprng: &mut R,
     identity_key_pair: &IdentityKeyPair,
@@ -205,7 +223,8 @@ pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
         protocol_store.next_signed_pre_key_id().await?;
     let pq_pre_keys_offset_id = protocol_store.next_pq_pre_key_id().await?;
 
-    let span = tracing::span!(tracing::Level::DEBUG, "Generating pre keys");
+    let _span =
+        tracing::span!(tracing::Level::DEBUG, "Generating pre keys").entered();
 
     let mut pre_keys = vec![];
     let mut pq_pre_keys = vec![];
@@ -217,12 +236,6 @@ pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
             (((pre_keys_offset_id + i) % (PRE_KEY_MEDIUM_MAX_VALUE - 1)) + 1)
                 .into();
         let pre_key_record = PreKeyRecord::new(pre_key_id, &key_pair);
-        protocol_store
-                    .save_pre_key(pre_key_id, &pre_key_record)
-                    .instrument(tracing::trace_span!(parent: &span, "save pre key", ?pre_key_id)).await?;
-        // TODO: Shouldn't this also remove the previous pre-keys from storage?
-        //       I think we might want to update the storage, and then sync the storage to the
-        //       server.
 
         pre_keys.push(pre_key_record);
     }
@@ -238,12 +251,6 @@ pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
             pre_key_id,
             identity_key_pair.private_key(),
         )?;
-        protocol_store
-                    .save_kyber_pre_key(pre_key_id, &pre_key_record)
-                    .instrument(tracing::trace_span!(parent: &span, "save kyber pre key", ?pre_key_id)).await?;
-        // TODO: Shouldn't this also remove the previous pre-keys from storage?
-        //       I think we might want to update the storage, and then sync the storage to the
-        //       server.
 
         pq_pre_keys.push(pre_key_record);
     }
@@ -261,13 +268,6 @@ pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
         &signed_pre_key_pair,
         &signed_pre_key_signature,
     );
-
-    protocol_store
-                .save_signed_pre_key(
-                    next_signed_pre_key_id.into(),
-                    &signed_prekey_record,
-                )
-                    .instrument(tracing::trace_span!(parent: &span, "save signed pre key", signed_pre_key_id = ?next_signed_pre_key_id)).await?;
 
     let pq_last_resort_key = if use_last_resort_key {
         let pre_key_id = (((pq_pre_keys_offset_id + kyber_pre_key_count)
@@ -287,12 +287,6 @@ pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
             pre_key_id,
             identity_key_pair.private_key(),
         )?;
-        protocol_store
-                    .store_last_resort_kyber_pre_key(pre_key_id, &pre_key_record)
-                    .instrument(tracing::trace_span!(parent: &span, "save last resort kyber pre key", ?pre_key_id)).await?;
-        // TODO: Shouldn't this also remove the previous pre-keys from storage?
-        //       I think we might want to update the storage, and then sync the storage to the
-        //       server.
 
         Some(pre_key_record)
     } else {
@@ -305,4 +299,41 @@ pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
         pq_pre_keys,
         pq_last_resort_key,
     ))
+}
+
+/// Stores a complete pre-key bundle to the protocol store.
+/// Takes references to all keys and persists them.
+/// Returns the first error encountered (if any), or Ok(()) on success.
+pub(crate) async fn store_pre_key_bundle<P: PreKeysStore>(
+    protocol_store: &mut P,
+    pre_keys: &[PreKeyRecord],
+    signed_pre_key: &SignedPreKeyRecord,
+    pq_pre_keys: &[KyberPreKeyRecord],
+    pq_last_resort_key: Option<&KyberPreKeyRecord>,
+) -> Result<(), SignalProtocolError> {
+    // Persist EC pre-keys (replace all)
+    protocol_store
+        .replace_one_time_ec_pre_keys(&pre_keys)
+        .await?;
+
+    // Persist Kyber pre-keys
+    protocol_store
+        .replace_one_time_kyber_pre_keys(&pq_pre_keys)
+        .await?;
+
+    // Persist signed pre-key
+    let signed_pre_key_id = signed_pre_key.id()?;
+    protocol_store
+        .save_signed_pre_key(signed_pre_key_id, &signed_pre_key)
+        .await?;
+
+    // Persist last resort Kyber key if present
+    if let Some(ref k) = pq_last_resort_key {
+        let id = k.id()?;
+        protocol_store
+            .store_last_resort_kyber_pre_key(id, k)
+            .await?;
+    }
+
+    Ok(())
 }

--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -272,11 +272,11 @@ pub async fn link_device<
             IdentityKeyPair::new(pni_public_key, pni_private_key);
 
         let (
-            _aci_pre_keys,
+            aci_pre_keys,
             aci_signed_pre_key,
-            _aci_pq_pre_keys,
+            aci_pq_pre_keys,
             aci_pq_last_resort_pre_key,
-        ) = crate::pre_keys::replenish_pre_keys(
+        ) = crate::pre_keys::generate_pre_keys(
             aci_store,
             csprng,
             &aci_key_pair,
@@ -286,17 +286,21 @@ pub async fn link_device<
         )
         .await?;
 
+        // Clone for persistence after successful link_device
+        let aci_signed_for_persist = aci_signed_pre_key.clone();
+        let aci_last_resort_for_persist = aci_pq_last_resort_pre_key.clone();
+
         let aci_pq_last_resort_pre_key =
             aci_pq_last_resort_pre_key.expect("requested last resort key");
-        assert!(_aci_pre_keys.is_empty());
-        assert!(_aci_pq_pre_keys.is_empty());
+        assert!(aci_pre_keys.is_empty());
+        assert!(aci_pq_pre_keys.is_empty());
 
         let (
-            _pni_pre_keys,
+            pni_pre_keys,
             pni_signed_pre_key,
-            _pni_pq_pre_keys,
+            pni_pq_pre_keys,
             pni_pq_last_resort_pre_key,
-        ) = crate::pre_keys::replenish_pre_keys(
+        ) = crate::pre_keys::generate_pre_keys(
             pni_store,
             csprng,
             &pni_key_pair,
@@ -306,10 +310,14 @@ pub async fn link_device<
         )
         .await?;
 
+        // Clone for persistence after successful link_device
+        let pni_signed_for_persist = pni_signed_pre_key.clone();
+        let pni_last_resort_for_persist = pni_pq_last_resort_pre_key.clone();
+
         let pni_pq_last_resort_pre_key =
             pni_pq_last_resort_pre_key.expect("requested last resort key");
-        assert!(_pni_pre_keys.is_empty());
-        assert!(_pni_pq_pre_keys.is_empty());
+        assert!(pni_pre_keys.is_empty());
+        assert!(pni_pq_pre_keys.is_empty());
 
         let encrypted_device_name = BASE64_RELAXED.encode(
             encrypt_device_name(csprng, device_name, &aci_public_key)?
@@ -355,6 +363,25 @@ pub async fn link_device<
                 },
             )
             .await?;
+
+        // Now persist the keys after successful link_device
+        crate::pre_keys::store_pre_key_bundle(
+            aci_store,
+            &aci_pre_keys,
+            &aci_signed_for_persist,
+            &aci_pq_pre_keys,
+            aci_last_resort_for_persist.as_ref(),
+        )
+        .await?;
+
+        crate::pre_keys::store_pre_key_bundle(
+            pni_store,
+            &pni_pre_keys,
+            &pni_signed_for_persist,
+            &pni_pq_pre_keys,
+            pni_last_resort_for_persist.as_ref(),
+        )
+        .await?;
 
         tx.send(SecondaryDeviceProvisioning::NewDeviceRegistration(
             NewDeviceRegistration {

--- a/src/websocket/keys.rs
+++ b/src/websocket/keys.rs
@@ -145,13 +145,13 @@ impl SignalWebSocket<websocket::Identified> {
     pub async fn register_pre_keys(
         &mut self,
         service_id_kind: ServiceIdKind,
-        pre_key_state: PreKeyState,
+        pre_key_state: &PreKeyState,
     ) -> Result<(), ServiceError> {
         self.http_request(
             Method::PUT,
             format!("/v2/keys?identity={}", service_id_kind),
         )?
-        .send_json(&pre_key_state)
+        .send_json(pre_key_state)
         .await?
         .service_error_for_status()
         .await?;

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -1,3 +1,4 @@
+#![allow(async_fn_in_trait)]
 use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, MutexGuard};


### PR DESCRIPTION
Introduces methods to *replace* old prekeys. Implementors should:

1. Take care to remove all but the supplied one-time prekeys
2. Only replenish prekeys after receiving the QueueEmpty signal, or better: mark "deleted" prekeys as stale and remove after some hours.

Not in this PR: prekey staleness management.

This is mostly done by some cheap LLMs to play around, so I'll have to reread everything a few times to make sure it's kinda sound.