### PR TITLE
Add with_max_outstanding_keepalives opt-in constructor

### DIFF
--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -91,9 +91,22 @@ struct SignalWebSocketInner {
     stream: Option<SignalRequestStream>,
 }
 
+/// Default value for [`SignalWebSocket::with_max_outstanding_keepalives`].
+/// `1` matches the historical "close on first unacked keepalive"
+/// behavior — every existing caller of [`SignalWebSocket::new`] sees
+/// this default and is therefore unaffected by the introduction of
+/// the knob.
+pub const DEFAULT_MAX_OUTSTANDING_KEEPALIVES: usize = 1;
+
 struct SignalWebSocketProcess {
     /// Whether to enable keep-alive or not (and send a request to this path)
     keep_alive_path: String,
+
+    /// Number of unacked keepalive requests that may be in flight before
+    /// `run()` decides the WebSocket is dead and closes it. Set via
+    /// [`SignalWebSocket::with_max_outstanding_keepalives`]; defaults to
+    /// [`DEFAULT_MAX_OUTSTANDING_KEEPALIVES`].
+    max_outstanding_keepalives: usize,
 
     /// Receives requests from the application, which we forward to Signal.
     requests: mpsc::Receiver<(
@@ -229,8 +242,17 @@ impl SignalWebSocketProcess {
             futures::select! {
                 _ = ka_interval.tick().fuse() => {
                     use prost::Message;
-                    if !self.outgoing_keep_alive_set.is_empty() {
-                        tracing::warn!("Websocket will be closed due to failed keepalives.");
+                    // Close trigger gated by max_outstanding_keepalives,
+                    // which defaults to 1 (the historical "close on any
+                    // unacked keepalive" behavior). Callers that need
+                    // tolerance for executor-scheduling races can pass
+                    // a larger value via with_max_outstanding_keepalives.
+                    if self.outgoing_keep_alive_set.len() >= self.max_outstanding_keepalives {
+                        tracing::warn!(
+                            outstanding = self.outgoing_keep_alive_set.len(),
+                            threshold = self.max_outstanding_keepalives,
+                            "Websocket will be closed due to failed keepalives.",
+                        );
                         if let Err(e) = self.ws.close(reqwest_websocket::CloseCode::Away, None).await {
                             tracing::debug!("Could not close WebSocket: {:?}", e);
                         }
@@ -357,6 +379,32 @@ impl<C: WebSocketType> SignalWebSocket<C> {
         keep_alive_path: String,
         unidentified_push_service: PushService,
     ) -> (Self, impl Future<Output = ()>) {
+        Self::with_max_outstanding_keepalives(
+            ws,
+            keep_alive_path,
+            unidentified_push_service,
+            DEFAULT_MAX_OUTSTANDING_KEEPALIVES,
+        )
+    }
+
+    /// Like [`Self::new`] but lets the caller raise the threshold for
+    /// "outstanding keepalives at which `run()` decides the WebSocket
+    /// is dead and closes it." Default (used by [`Self::new`]) is 1,
+    /// matching the historical close-on-first-unacked-keepalive
+    /// behavior. Callers running on platforms where the
+    /// `futures::select!` arm-dispatch race can spuriously trip the
+    /// close (single-threaded executors, slow rv32 cores, etc.) can
+    /// pass a small constant like 3 to absorb a few cycles of
+    /// scheduling jitter before deciding the connection is dead.
+    /// Real TCP failures still surface independently via the
+    /// underlying transport's `io::Error` path; this only changes the
+    /// application-level KA watchdog.
+    pub fn with_max_outstanding_keepalives(
+        ws: WebSocket,
+        keep_alive_path: String,
+        unidentified_push_service: PushService,
+        max_outstanding_keepalives: usize,
+    ) -> (Self, impl Future<Output = ()>) {
         // Create process
         let (incoming_request_sink, incoming_request_stream) =
             mpsc::unbounded();
@@ -364,6 +412,7 @@ impl<C: WebSocketType> SignalWebSocket<C> {
 
         let process = SignalWebSocketProcess {
             keep_alive_path,
+            max_outstanding_keepalives,
             requests: outgoing_requests,
             request_sink: incoming_request_sink,
             outgoing_requests: HashMap::default(),

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -91,21 +91,16 @@ struct SignalWebSocketInner {
     stream: Option<SignalRequestStream>,
 }
 
-/// Default value for [`SignalWebSocket::with_max_outstanding_keepalives`].
-/// `1` matches the historical "close on first unacked keepalive"
-/// behavior — every existing caller of [`SignalWebSocket::new`] sees
-/// this default and is therefore unaffected by the introduction of
-/// the knob.
+/// Default for [`SignalWebSocket::with_max_outstanding_keepalives`]:
+/// close on the first unacked keepalive.
 pub const DEFAULT_MAX_OUTSTANDING_KEEPALIVES: usize = 1;
 
 struct SignalWebSocketProcess {
     /// Whether to enable keep-alive or not (and send a request to this path)
     keep_alive_path: String,
 
-    /// Number of unacked keepalive requests that may be in flight before
-    /// `run()` decides the WebSocket is dead and closes it. Set via
-    /// [`SignalWebSocket::with_max_outstanding_keepalives`]; defaults to
-    /// [`DEFAULT_MAX_OUTSTANDING_KEEPALIVES`].
+    /// Close threshold for unacked keepalives; see
+    /// [`SignalWebSocket::with_max_outstanding_keepalives`].
     max_outstanding_keepalives: usize,
 
     /// Receives requests from the application, which we forward to Signal.
@@ -242,17 +237,10 @@ impl SignalWebSocketProcess {
             futures::select! {
                 _ = ka_interval.tick().fuse() => {
                     use prost::Message;
-                    // Close trigger gated by max_outstanding_keepalives,
-                    // which defaults to 1 (the historical "close on any
-                    // unacked keepalive" behavior). Callers that need
-                    // tolerance for executor-scheduling races can pass
-                    // a larger value via with_max_outstanding_keepalives.
+                    // Close once unacked keepalives reach the configured
+                    // threshold; see SignalWebSocket::with_max_outstanding_keepalives.
                     if self.outgoing_keep_alive_set.len() >= self.max_outstanding_keepalives {
-                        tracing::warn!(
-                            outstanding = self.outgoing_keep_alive_set.len(),
-                            threshold = self.max_outstanding_keepalives,
-                            "Websocket will be closed due to failed keepalives.",
-                        );
+                        tracing::warn!("Websocket will be closed due to failed keepalives.");
                         if let Err(e) = self.ws.close(reqwest_websocket::CloseCode::Away, None).await {
                             tracing::debug!("Could not close WebSocket: {:?}", e);
                         }
@@ -374,6 +362,7 @@ impl<C: WebSocketType> SignalWebSocket<C> {
         self.inner.lock().unwrap()
     }
 
+    /// Alias for [`Self::with_max_outstanding_keepalives`] with [`DEFAULT_MAX_OUTSTANDING_KEEPALIVES`].
     pub fn new(
         ws: WebSocket,
         keep_alive_path: String,
@@ -387,18 +376,10 @@ impl<C: WebSocketType> SignalWebSocket<C> {
         )
     }
 
-    /// Like [`Self::new`] but lets the caller raise the threshold for
-    /// "outstanding keepalives at which `run()` decides the WebSocket
-    /// is dead and closes it." Default (used by [`Self::new`]) is 1,
-    /// matching the historical close-on-first-unacked-keepalive
-    /// behavior. Callers running on platforms where the
-    /// `futures::select!` arm-dispatch race can spuriously trip the
-    /// close (single-threaded executors, slow rv32 cores, etc.) can
-    /// pass a small constant like 3 to absorb a few cycles of
-    /// scheduling jitter before deciding the connection is dead.
-    /// Real TCP failures still surface independently via the
-    /// underlying transport's `io::Error` path; this only changes the
-    /// application-level KA watchdog.
+    /// Construct `SignalWebSocket` with configurable KA threshold.
+    ///
+    /// A more lenient `max_outstanding_keepalives` can potentially
+    /// compensate for spotty or slow networks, or for slower processors.
     pub fn with_max_outstanding_keepalives(
         ws: WebSocket,
         keep_alive_path: String,


### PR DESCRIPTION
`SignalWebSocketProcess::run`'s KA-timer arm closes the WS the
moment ANY keepalive is outstanding (`!is_empty()`), which is
racy when `futures::select!` picks the timer arm before draining
a queued KA response (the macro documents arm dispatch as
"random," not fair). On x86_64 desktop the race is rare enough
to never trip; on a single-threaded async executor on slow
hardware (Precursor, the upcoming Baochip ASIC, possibly the
Whisperfish phone targets) it fires within seconds of opening
every WS.

Adds `SignalWebSocket::with_max_outstanding_keepalives(...,
max: usize)` as an opt-in second constructor; the existing
`pub fn new()` keeps its signature and now delegates with
`DEFAULT_MAX_OUTSTANDING_KEEPALIVES = 1`, preserving today's
behavior exactly. Internally `SignalWebSocketProcess` gains one
`usize` field; the close trigger becomes
`len() >= self.max_outstanding_keepalives`.

**Zero behavior change** for any existing caller. Callers that
need the tolerance (we use `max=3` in `xous-app-signal`)
opt in via the new constructor.

Verified locally: `cargo fmt --check` + `cargo clippy
--all-targets -- -D warnings` clean. Have not independently
MSRV-checked against 1.89, but the patch only uses basic struct
and method patterns; CI should confirm.

Happy to discuss:
- the default value (kept at 1 to preserve current behavior; could
  reasonably be 2 to forgive a single race without much slowdown)
- whether to grow this into a full `SignalWebSocketBuilder` —
  the new fn would become `Builder::build()`'s internal call
- adding a unit test if you want one (the race itself isn't
  trivially testable, but the constructor split is)

Filing as draft to leave room for that discussion before merge.

This work was the result of debugging with a coding agent, where the above findings are the result of this effort.