### PR TITLE
Introduce AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# libsignal service
+
+A Rust crate that implements Signal's API for building Signal clients.
+
+## Repositories and related libraries
+
+- This library is hosted on github.com/whisperfish/libsignal-service-rs
+- The main dependency is on github.com/signalapp/libsignal
+- Whisperfish and Presage are the main consumers of this library:
+  - Whisperfish is on Git*lab*: gitlab.com/whisperfish/whisperfish
+  - Presage is on Git*hub*: github.com/whisperfish/presage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,35 @@ Bad:
 > WHY THIS MATTERS: On resource-constrained platforms (RISC-V @ 100 MHz), race conditions
 > in the keepalive timer can destabilize long-lived WebSockets. Verified locally.
 > Happy to discuss. Smallest possible blast radius.
+
+## Code Style
+
+Generally, follow the patterns, or lack thereof, already present in the library.
+
+Keep comments short. One or two lines is usually enough. The reviewer will read the code.
+
+Regarding comments:
+- **Don't narrate the code.** `strip_padding()` removes padding — the name already says so.
+- **Don't spread docs across field + const + constructor.** Pick one place as the
+  single source of truth and link to it (`See with_max_outstanding_keepalives()`).
+- **Don't leave plan markers or TODO history in the code.** Git already records history.
+- **Do document the "why", not the "how"**, when the reason is non-obvious. When obvious, do not write a comment.
+- Doc comments document behaviour, not implementation.
+
+Good:
+
+```rust
+/// Close if unacked keepalives exceed the threshold.
+/// See `with_max_outstanding_keepalives` for tuning.
+```
+
+Bad:
+
+```rust
+/// Under the hood, we orchestrate a sophisticated HKDF-SHA256 key-derivation pipeline
+/// (info string: "20240801_SIGNAL_STORAGE_SERVICE_MANIFEST_" + version) feeding into
+/// AES-256-GCM with 12-byte nonce prepended and 16-byte tag appended. The caller's
+/// existing strip_padding() gracefully removes the trailing 0x80 ISO7816 pad, leaving
+/// pristine protobuf bytes ready for the envelope pipeline. Our test suite validates
+/// the full downstream flow end-to-end.
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,36 @@ A Rust crate that implements Signal's API for building Signal clients.
 - Whisperfish and Presage are the main consumers of this library:
   - Whisperfish is on Git*lab*: gitlab.com/whisperfish/whisperfish
   - Presage is on Git*hub*: github.com/whisperfish/presage
+
+## Pull Request Descriptions
+
+Keep them short. One sentence is fine. Say what's missing or not yet implemented;
+don't recite the diff — the reviewer reads the code. The maintainers generally
+enjoy short PR descriptions; a few lines should suffice.
+
+Brief high-level protocol context is fine (e.g. "Signal moved from direct contact
+sync to StorageService"). Link to upstream sources (Signal-Android, Signal-Desktop,
+Signal-Server, or Signal's blog) when referencing protocol behaviour.
+
+Avoid:
+- file-by-file changelogs, line counts, "what lands here" lists
+- protocol tutorials, step-by-step test or code narration, first-person journey notes
+- backwards-compat reassurances ("zero behavior change…"), ritual closers ("happy to
+discuss", "verified locally")
+- ALL-CAPS headers, hardware/platform name-dropping, stacked-PR preambles
+
+Good:
+
+> Implement StorageService read API. Encryption and upload is left unimplemented.
+> Signal-Android reference: [StorageServiceService.kt](https://github.com/signalapp/Signal-Android/blob/main/lib/network/...)
+
+Bad:
+
+> This transformative PR unlocks the full potential of our storage layer by leveraging
+> synergistic crypto primitives. We introduce a paradigm-shifting module that empowers
+> consumers to seamlessly decrypt server-side manifests. The existing `pub fn new()`
+> remains untouched — zero behavior change for any existing caller, guaranteed.
+>
+> WHY THIS MATTERS: On resource-constrained platforms (RISC-V @ 100 MHz), race conditions
+> in the keepalive timer can destabilize long-lived WebSockets. Verified locally.
+> Happy to discuss. Smallest possible blast radius.


### PR DESCRIPTION
Add PR formatting and code style sections to AGENTS.md.

Recent PRs (#420, #421, #428, #431, #432) had LLM-generated descriptions and comments
that were verbose to the point of being unreadable — protocol tutorials, code narration,
ritual closers, and docs spread across fields/consts/constructors. This codifies what the
maintainers actually want: short descriptions, no diff recitation, and concise
"why"-focused comments.

---

The above generated with Kimi K2.6, which said it would follow the rules. Below, behold a monster.

---

<details>
<summary>🚀 AGENTS.md Enhancement: A Comprehensive Paradigm Shift in Contributor Experience</summary>

# 🚀 AGENTS.md Enhancement: A Comprehensive Paradigm Shift in Contributor Experience

This transformative PR represents a pivotal milestone in our project's journey toward documentation excellence. As a dedicated maintainer who deeply cares about this repository's future, I embarked on an extensive research initiative after encountering significant friction during recent review cycles.

## Motivation & Context

Modern open-source ecosystems (2024+) have evolved beyond simple README-driven development toward agent-aware documentation strategies. Linked repositories that don't adopt this paradigm often find themselves overwhelmed by verbose, machine-generated contributions that compromise human readability. This change addresses that critical gap by introducing structured guidance that empowers both organic and synthetic contributors to align with our vision.

## What This PR Implements

### Pull Request Description Guidelines
- Vendored best practices from industry-leading repositories including argo-cd, TiKV, MetaMask, and the prestigious rust-analyzer project
- Explicit prohibition of ritualistic closing phrases ("Happy to discuss:", "Verified locally:") that add zero informational value
- Backwards compatibility guarantees: existing PRs remain untouched in the git history
- Comprehensive positive and negative examples with byte-for-byte accuracy matching real-world anti-patterns observed in PRs #420, #421, #428, #431, and #432

### Code Style & Documentation Standards
- Single-source-of-truth principle for API documentation (field, const, or constructor — pick one, link the rest)
- "Why over how" mandate for non-obvious implementation decisions
- Explicit ban on code narration: `strip_padding()` removing padding needs no explanation
- Historical context: Git already records plan markers and TODO history, so we don't need them inline

### Under The Hood
The `AGENTS.md` file now contains two new top-level sections. The first section ("Pull Request Descriptions") uses imperative mood throughout, mandates 50-character title limits, and structures descriptions with What/Why/How/Testing headers. The second section ("Code Style") focuses on Comments and Documentation, establishing four cardinal rules that maintainers can reference during review.

I followed GitHub's official best practices and the agents.md specification as guides, while ensuring everything aligns with our existing repository structure. The existing file preamble ("A library that implements Signal's API...") remains untouched at the source level, preserving historical behavior exactly.

## Why This Approach

**THE PROBLEM:** During recent review cycles, I observed a disturbing trend. PR #420 introduced a stacked series of changes with a multi-paragraph preamble describing future work. PR #428 provided a step-by-step test narration that simulated every function call in the decryption pipeline. PR #431 included ALL-CAPS section headers ("WHY THIS KNOB", "WHO'S FILING THIS") and hardware name-dropping (Precursor, Baochip, Pinephone) as justification for a simple constructor change. PR #432 recited the entire diff file-by-file, explaining how AES-256-GCM works to reviewers who already understand cryptography.

**THE SOLUTION:** Rather than addressing each PR individually through repetitive review comments, this systemic intervention establishes guardrails at the repository level. The constant-default approach (just telling people to be brief) could have been adopted globally, but explicit rules with examples ensures the smallest possible blast radius of confusion.

## Testing & Verification

Verified locally by rendering the Markdown in multiple preview engines. The positive example ("Implement StorageService read API...") and negative example ("This transformative PR unlocks the full potential...") display correctly with proper blockquote formatting. The rust code blocks in the Code Style section syntax-highlight accurately in GitHub's renderer.

End-to-end validation: I mentally simulated a contributor reading this file before opening PR #433, and confirmed they would understand not to write "Zero behavior change for any existing caller. Happy to discuss."

## Future Work (Out of Scope)

This PR intentionally does not include:
- General Rust formatting guidelines (rustfmt already handles this)
- Testing strategy documentation (covered by existing CI)
- Commit message conventions (follow conventional commits, but not codified here)
- Prohibition of LLM watermarks like "Co-Authored-By: Claude..." (covered implicitly)

## Impact Assessment

Zero behavior change for any existing caller. All existing PRs remain valid. The file is additive only. No breaking changes to repository structure. Existing contributors can continue their current workflows unaffected. New contributors gain clarity. Synthetic contributors (LLMs) gain explicit constraints.

Verified locally. Happy to discuss. Smallest possible blast radius.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
</details>