### PR TITLE
chore: update to libsignal v0.94.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ hex = "0.4"
 hkdf = "0.12"
 hmac = "0.12"
 phonenumber = { version = "0.3", optional = true }
-prost = "0.13"
+prost = "0.14"
 rand = "0.9"
 rand_core_06 = { version = "0.6", package = "rand_core" }
 serde = { version = "1.0", features = ["derive"] }
@@ -62,7 +62,7 @@ tracing-futures = "0.2"
 tokio = { version = "1.0", features = ["macros"] }
 
 [build-dependencies]
-prost-build = "0.13"
+prost-build = "0.14"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,23 @@
 [package]
 name = "libsignal-service"
 version = "0.1.0"
-authors = ["Ruben De Smet <ruben.de.smet@rubdos.be>", "Gabriel Féron <g@leirbag.net>"]
+authors = [
+  "Ruben De Smet <ruben.de.smet@rubdos.be>",
+  "Gabriel Féron <g@leirbag.net>",
+]
 edition = "2021"
 license = "AGPL-3.0-only"
 readme = "README.md"
 
 [dependencies]
-libsignal-protocol = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
-libsignal-core = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
-libsignal-account-keys = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
-libsignal-net = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0", optional = true }
-libsignal-net-infra = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0", optional = true }
-signal-crypto = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
-zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
-usernames = { git = "https://github.com/signalapp/libsignal", tag = "v0.91.0" }
+libsignal-protocol = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4" }
+libsignal-core = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4" }
+libsignal-account-keys = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4" }
+libsignal-net = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4", optional = true }
+libsignal-net-infra = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4", optional = true }
+signal-crypto = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4" }
+zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4" }
+usernames = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4" }
 
 aes = "0.8"
 aes-gcm = "0.10"
@@ -24,7 +27,10 @@ async-trait = "0.1"
 base64 = "0.22"
 bincode = "1.3"
 bytes = "1"
-chrono = { version = "0.4", features = ["serde", "clock"], default-features = false }
+chrono = { version = "0.4", features = [
+  "serde",
+  "clock",
+], default-features = false }
 derive_more = { version = "2.1", features = ["debug"] }
 futures = "0.3"
 hex = "0.4"
@@ -42,7 +48,12 @@ url = { version = "2.1", features = ["serde"] }
 uuid = { version = "1", features = ["serde"] }
 
 # http
-reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls-manual-roots", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "multipart",
+  "rustls-tls-manual-roots",
+  "stream",
+] }
 reqwest-websocket = { version = "0.4.2", features = ["json"] }
 
 tracing = { version = "0.1", features = ["log"] }

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -361,6 +361,7 @@ where
                 let mut data = message_decrypt_signal(
                     &SignalMessage::try_from(&ciphertext[..])?,
                     &sender,
+                    &self.local_address,
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store.clone(),
                     csprng,
@@ -753,6 +754,7 @@ async fn sealed_sender_decrypt_with_validated_usmc(
             message_decrypt_signal(
                 &ctext,
                 remote_address,
+                local_address,
                 session_store,
                 identity_store,
                 &mut rng,

--- a/src/groups_v2/operations.rs
+++ b/src/groups_v2/operations.rs
@@ -10,7 +10,7 @@ use zkgroup::{
         AnyProfileKeyCredentialPresentation, ExpiringProfileKeyCredential,
         ProfileKey,
     },
-    ServerPublicParams,
+    ServerPublicParams, PRESENTATION_VERSION_3,
 };
 
 use crate::{
@@ -801,14 +801,31 @@ impl GroupOperations {
     ///
     /// This creates a ZK proof (ExpiringProfileKeyCredentialPresentation) that the
     /// Signal server can verify to validate the member's identity and profile key.
-    pub fn create_member_presentation(
+    ///
+    /// # Presentation protocol version for `ExpiringProfileKeyCredentialPresentation` ZK proofs.
+    ///
+    /// This is the version number sent as a const generic parameter to
+    /// `create_expiring_profile_key_credential_presentation`. It must match the
+    /// version expected by the Signal server's zkgroup verification logic.
+    ///
+    /// - Current default value: `PRESENTATION_VERSION_3` (raw value `2`), which is also
+    ///   the default type parameter for `ExpiringProfileKeyCredentialPresentation`
+    ///   in libsignal's zkgroup API.
+    /// - To check the default, look at libsignal's zkgroup source:
+    ///   `rust/zkgroup/src/api/profiles/profile_key_credential_presentation.rs` —
+    ///   `ExpiringProfileKeyCredentialPresentation<const V: u8 = PRESENTATION_VERSION_3>`.
+    // NOTE: Do NOT automatically bump this to the latest version (e.g.
+    // `PRESENTATION_VERSION_4`) without verifying that the Signal server accepts
+    // it. A mismatched version will cause ZK proof verification to fail and
+    // members will be rejected when joining groups.
+    pub fn create_member_presentation<const V: u8>(
         &self,
         server_public_params: &ServerPublicParams,
         credential: &ExpiringProfileKeyCredential,
     ) -> Vec<u8> {
         let randomness: [u8; 32] = rand::random();
         let presentation = server_public_params
-            .create_expiring_profile_key_credential_presentation(
+            .create_expiring_profile_key_credential_presentation::<V>(
                 randomness,
                 self.group_secret_params,
                 *credential,
@@ -852,7 +869,10 @@ impl GroupOperations {
 
         // Add self as administrator with presentation
         let self_presentation = self
-            .create_member_presentation(server_public_params, self_credential);
+            .create_member_presentation::<PRESENTATION_VERSION_3>(
+                server_public_params,
+                self_credential,
+            );
         members.push(proto::Member {
             user_id: vec![],     // Server extracts from presentation
             profile_key: vec![], // Server extracts from presentation
@@ -867,10 +887,11 @@ impl GroupOperations {
         for candidate in member_candidates {
             if let Some(credential) = &candidate.credential {
                 // Has credential - add as full member with presentation
-                let presentation = self.create_member_presentation(
-                    server_public_params,
-                    credential,
-                );
+                let presentation = self
+                    .create_member_presentation::<PRESENTATION_VERSION_3>(
+                        server_public_params,
+                        credential,
+                    );
                 members.push(proto::Member {
                     user_id: vec![],
                     profile_key: vec![],
@@ -956,8 +977,11 @@ impl GroupOperations {
         role: super::model::Role,
         server_public_params: &ServerPublicParams,
     ) -> proto::group_change::actions::AddMemberAction {
-        let presentation =
-            self.create_member_presentation(server_public_params, credential);
+        let presentation = self
+            .create_member_presentation::<PRESENTATION_VERSION_3>(
+                server_public_params,
+                credential,
+            );
         proto::group_change::actions::AddMemberAction {
             added: Some(proto::Member {
                 user_id: vec![],     // Server extracts from presentation

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -653,6 +653,10 @@ where
 
                         process_prekey_bundle(
                             &remote_address,
+                            &self
+                                .local_aci
+                                .to_protocol_address(self.device_id)
+                                .expect("valid device id"),
                             &mut self.protocol_store.clone(),
                             &mut self.protocol_store,
                             &pre_key,
@@ -1028,6 +1032,10 @@ where
 
                 process_prekey_bundle(
                     &pre_key_address,
+                    &self
+                        .local_aci
+                        .to_protocol_address(self.device_id)
+                        .expect("valid device id"),
                     &mut self.protocol_store.clone(),
                     &mut self.protocol_store,
                     &pre_key_bundle,

--- a/src/websocket/directory.rs
+++ b/src/websocket/directory.rs
@@ -36,15 +36,6 @@ impl SignalWebSocket<Identified> {
     /// # Returns
     /// * `Ok(CdsiAuth)` - Authentication credentials
     /// * `Err(ServiceError)` - Network or protocol error
-    ///
-    /// # Example
-    /// ```no_run
-    /// # use libsignal_service::websocket::{SignalWebSocket, Identified};
-    /// # async fn example(mut ws: SignalWebSocket<Identified>) {
-    /// let auth = ws.get_cdsi_auth().await.unwrap();
-    /// // Use auth.username and auth.password for CDSI connection
-    /// # }
-    /// ```
     async fn get_cdsi_auth(&mut self) -> Result<CdsiAuth, ServiceError> {
         let response = self
             .http_request(Method::GET, "/v2/directory/auth")?


### PR DESCRIPTION
- Update all libsignal crates from v0.91.0 to v0.94.0
- Add local_address parameter to message_decrypt_signal calls
- Add local_address parameter to process_prekey_bundle calls
- Make ExpiringProfileKeyCredentialPresentation version a const generic parameter on create_member_presentation with explicit specification at all call sites using PRESENTATION_VERSION_3