### PR TITLE
Key transparency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ libsignal-core = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.
 libsignal-account-keys = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4" }
 libsignal-net = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4", optional = true }
 libsignal-net-infra = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4", optional = true }
+libsignal-keytrans = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4", optional = true }
 signal-crypto = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4" }
 zkgroup = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4" }
 usernames = { git = "https://github.com/signalapp/libsignal", tag = "v0.94.4" }
@@ -44,6 +45,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"
 sha2 = "0.10"
 thiserror = "2.0"
+proptest = { version = "1", optional = true }
+curve25519-dalek = { version = "4", default-features = false, features = [
+  "alloc",
+  "zeroize",
+], optional = true }
 url = { version = "2.1", features = ["serde"] }
 uuid = { version = "1", features = ["serde"] }
 
@@ -72,6 +78,11 @@ tokio = { version = "1.0", features = ["macros", "rt"] }
 default = ["cdsi"]
 phonenumber = ["dep:phonenumber"]
 cdsi = ["dep:libsignal-net", "dep:libsignal-net-infra"]
+key-transparency = [
+  "dep:proptest",
+  "dep:curve25519-dalek",
+  "dep:libsignal-keytrans",
+]
 
 [patch.crates-io]
 curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', tag = 'signal-curve25519-4.1.3' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ prost-build = "0.14"
 anyhow = "1.0"
 tokio = { version = "1.0", features = ["macros", "rt"] }
 clap = { version = "4.4", features = ["derive"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 default = ["cdsi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ prost-build = "0.14"
 [dev-dependencies]
 anyhow = "1.0"
 tokio = { version = "1.0", features = ["macros", "rt"] }
+clap = { version = "4.4", features = ["derive"] }
 
 [features]
 default = ["cdsi"]
@@ -83,6 +84,10 @@ key-transparency = [
   "dep:curve25519-dalek",
   "dep:libsignal-keytrans",
 ]
+
+[[example]]
+name = "key_transparency"
+required-features = ["key-transparency"]
 
 [patch.crates-io]
 curve25519-dalek = { git = 'https://github.com/signalapp/curve25519-dalek', tag = 'signal-curve25519-4.1.3' }

--- a/examples/key_transparency.rs
+++ b/examples/key_transparency.rs
@@ -129,6 +129,19 @@ async fn main() -> Result<()> {
         .await
         .context("KT search and verify failed")?;
 
+    // Once monitored, exercise the cheaper monitor path too: proves the ACI is
+    // still correctly placed in a consistently-grown tree. In one session this
+    // validates the full monitor wiring end-to-end.
+    let mut monitor = None;
+    if result.now_monitored {
+        monitor = Some(
+            client
+                .monitor_and_verify(args.target_aci.into())
+                .await
+                .context("KT monitor and verify failed")?,
+        );
+    }
+
     // Emit a structured result. Identity keys are public, so echoing the
     // target key is fine; the profile key is not (it gates profile access).
     let json = json!({
@@ -136,6 +149,9 @@ async fn main() -> Result<()> {
         "aci": args.target_aci.to_string(),
         "key_matches": result.key_matches,
         "now_monitored": result.now_monitored,
+        "monitor": monitor.as_ref().map(|m| json!({
+            "verified": m.verified,
+        })),
     });
     println!("{}", serde_json::to_string_pretty(&json)?);
 

--- a/examples/key_transparency.rs
+++ b/examples/key_transparency.rs
@@ -56,6 +56,9 @@ struct Args {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt::init();
+
     let args = Args::parse();
 
     // Create credentials with stubbed phone number

--- a/examples/key_transparency.rs
+++ b/examples/key_transparency.rs
@@ -123,7 +123,7 @@ async fn main() -> Result<()> {
         PublicKey::deserialize(&key_bytes).expect("valid identity key bytes");
 
     // Build search params with flat, high-level types
-    let params = ChatSearchParams {
+    let params = ChatSearchParams::<E164> {
         target_aci: args.target_aci.into(),
         target_identity_key,
         target_e164: None,

--- a/examples/key_transparency.rs
+++ b/examples/key_transparency.rs
@@ -28,14 +28,6 @@ struct Args {
     #[arg(long)]
     staging: bool,
 
-    /// Your ACI (for authentication)
-    #[arg(long)]
-    aci: Uuid,
-
-    /// Your Signal access password (hex-encoded)
-    #[arg(long)]
-    password: String,
-
     /// Target ACI to verify
     #[arg(long)]
     target_aci: Uuid,

--- a/examples/key_transparency.rs
+++ b/examples/key_transparency.rs
@@ -1,0 +1,155 @@
+//! Key Transparency verification example.
+//!
+//! Usage: cargo run --example key_transparency -- [--staging] --aci ...
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use libsignal_core::E164;
+use libsignal_service::configuration::{ServiceCredentials, SignalServers};
+use libsignal_service::key_transparency::{
+    production_public_config, staging_public_config, ChatSearchParams,
+    InMemoryKeyTransparencyStore,
+};
+use libsignal_service::protocol::PublicKey;
+use libsignal_service::push_service::PushService;
+use libsignal_service::websocket;
+use serde_json::json;
+use std::str::FromStr;
+use uuid::Uuid;
+use zkgroup::profiles::ProfileKey;
+
+#[derive(Parser, Debug)]
+#[command(name = "key_transparency")]
+#[command(
+    about = "Verify identity keys against Signal's Key Transparency directory"
+)]
+#[command(version)]
+struct Args {
+    /// Use staging servers
+    #[arg(long)]
+    staging: bool,
+
+    /// Your ACI (for authentication)
+    #[arg(long)]
+    aci: Uuid,
+
+    /// Your Signal access password (hex-encoded)
+    #[arg(long)]
+    password: String,
+
+    /// Target ACI to verify
+    #[arg(long)]
+    target_aci: Uuid,
+
+    /// Target's identity key (32-byte Ed25519 public key, hex-encoded)
+    #[arg(long)]
+    target_identity: String,
+
+    /// Target's profile key (32-byte, hex-encoded, optional)
+    #[arg(long)]
+    target_profile_key: Option<String>,
+
+    /// Verbose output
+    #[arg(long)]
+    verbose: bool,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // Create credentials with stubbed phone number
+    let phonenumber: E164 = E164::from_str("+10000000000")?;
+
+    let credentials = ServiceCredentials {
+        phonenumber,
+        aci: Some(args.aci),
+        password: Some(args.password.clone()),
+        device_id: None,
+        pni: None,
+    };
+
+    // Create PushService and authenticated socket
+    let servers = if args.staging {
+        SignalServers::Staging
+    } else {
+        SignalServers::Production
+    };
+
+    let mut push_service =
+        PushService::new(servers, Some(credentials.clone()), "kt-example/1.0");
+    let mut socket = push_service
+        .ws::<websocket::Identified>(
+            "/v1/websocket/",
+            "/v1/keepalive",
+            &[],
+            Some(credentials),
+        )
+        .await
+        .context("Failed to create authenticated WebSocket")?;
+
+    // Create KT store and client
+    let store = InMemoryKeyTransparencyStore::new();
+    let config = if args.staging {
+        staging_public_config()
+    } else {
+        production_public_config()
+    };
+    let mut client = socket.key_transparency(config, &store);
+
+    // Clone target_profile_key for later use in output
+    let target_profile_key_for_output = args.target_profile_key.clone();
+
+    // Build profile key from hex string if provided
+    let profile_key: Option<ProfileKey> = args
+        .target_profile_key
+        .map(|pk_hex| -> Result<ProfileKey> {
+            let pk_bytes = hex::decode(&pk_hex)?;
+            let pk_array: [u8; 32] = pk_bytes
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("Profile key must be 32 bytes"))?;
+            Ok(ProfileKey::create(pk_array))
+        })
+        .transpose()?;
+
+    // Deserialize the target's identity key from hex bytes
+    let mut key_bytes = Vec::with_capacity(33);
+    key_bytes.push(0x05u8); // Djb key type prefix (KeyType::Djb = 0x05)
+    key_bytes.extend_from_slice(&hex::decode(&args.target_identity)?);
+    let target_identity_key =
+        PublicKey::deserialize(&key_bytes).expect("valid identity key bytes");
+
+    // Build search params with flat, high-level types
+    let params = ChatSearchParams {
+        target_aci: args.target_aci.into(),
+        target_identity_key,
+        target_e164: None,
+        target_username: None,
+        target_profile_key: profile_key,
+        last_tree_head_size: None,
+        distinguished_tree_head_size: None,
+    };
+
+    // Call search_and_verify
+    let result = client
+        .search_and_verify(params)
+        .await
+        .context("KT search and verify failed")?;
+
+    if args.verbose {
+        eprintln!("Verification successful");
+    }
+
+    // Build JSON output
+    let json = json!({
+        "status": "success",
+        "result": format!("{:?}", result),
+        "validated": result.key_matches,
+        "target_aci": args.target_aci.to_string(),
+        "target_identity": args.target_identity,
+        "target_profile_key": target_profile_key_for_output,
+    });
+    println!("{}", serde_json::to_string_pretty(&json)?);
+
+    Ok(())
+}

--- a/examples/key_transparency.rs
+++ b/examples/key_transparency.rs
@@ -47,10 +47,17 @@ struct Args {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    // Initialize tracing
-    tracing_subscriber::fmt::init();
-
     let args = Args::parse();
+
+    if args.verbose {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new(
+                "libsignal_service=trace",
+            ))
+            .init();
+    } else {
+        tracing_subscriber::fmt::init();
+    }
 
     // Create PushService and authenticated socket
     let servers = if args.staging {
@@ -79,14 +86,12 @@ async fn main() -> Result<()> {
     };
     let mut client = socket.key_transparency(config, &store);
 
-    // Clone target_profile_key for later use in output
-    let target_profile_key_for_output = args.target_profile_key.clone();
-
     // Build profile key from hex string if provided
     let profile_key: Option<ProfileKey> = args
         .target_profile_key
+        .as_ref()
         .map(|pk_hex| -> Result<ProfileKey> {
-            let pk_bytes = hex::decode(&pk_hex)?;
+            let pk_bytes = hex::decode(pk_hex)?;
             let pk_array: [u8; 32] = pk_bytes
                 .try_into()
                 .map_err(|_| anyhow::anyhow!("Profile key must be 32 bytes"))?;
@@ -124,18 +129,13 @@ async fn main() -> Result<()> {
         .await
         .context("KT search and verify failed")?;
 
-    if args.verbose {
-        eprintln!("Verification successful");
-    }
-
-    // Build JSON output
+    // Emit a structured result. Identity keys are public, so echoing the
+    // target key is fine; the profile key is not (it gates profile access).
     let json = json!({
-        "status": "success",
-        "result": format!("{:?}", result),
-        "validated": result.key_matches,
-        "target_aci": args.target_aci.to_string(),
-        "target_identity": args.target_identity,
-        "target_profile_key": target_profile_key_for_output,
+        "status": "ok",
+        "aci": args.target_aci.to_string(),
+        "key_matches": result.key_matches,
+        "now_monitored": result.now_monitored,
     });
     println!("{}", serde_json::to_string_pretty(&json)?);
 

--- a/examples/key_transparency.rs
+++ b/examples/key_transparency.rs
@@ -5,7 +5,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use libsignal_core::E164;
-use libsignal_service::configuration::{ServiceCredentials, SignalServers};
+use libsignal_service::configuration::SignalServers;
 use libsignal_service::key_transparency::{
     production_public_config, staging_public_config, ChatSearchParams,
     InMemoryKeyTransparencyStore,
@@ -14,7 +14,6 @@ use libsignal_service::protocol::PublicKey;
 use libsignal_service::push_service::PushService;
 use libsignal_service::websocket;
 use serde_json::json;
-use std::str::FromStr;
 use uuid::Uuid;
 use zkgroup::profiles::ProfileKey;
 
@@ -61,17 +60,6 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    // Create credentials with stubbed phone number
-    let phonenumber: E164 = E164::from_str("+10000000000")?;
-
-    let credentials = ServiceCredentials {
-        phonenumber,
-        aci: Some(args.aci),
-        password: Some(args.password.clone()),
-        device_id: None,
-        pni: None,
-    };
-
     // Create PushService and authenticated socket
     let servers = if args.staging {
         SignalServers::Staging
@@ -79,17 +67,16 @@ async fn main() -> Result<()> {
         SignalServers::Production
     };
 
-    let mut push_service =
-        PushService::new(servers, Some(credentials.clone()), "kt-example/1.0");
+    let mut push_service = PushService::new(servers, None, "kt-example/1.0");
     let mut socket = push_service
-        .ws::<websocket::Identified>(
+        .ws::<websocket::Unidentified>(
             "/v1/websocket/",
             "/v1/keepalive",
             &[],
-            Some(credentials),
+            None,
         )
         .await
-        .context("Failed to create authenticated WebSocket")?;
+        .context("Failed to create WebSocket")?;
 
     // Create KT store and client
     let store = InMemoryKeyTransparencyStore::new();

--- a/examples/key_transparency.rs
+++ b/examples/key_transparency.rs
@@ -94,10 +94,16 @@ async fn main() -> Result<()> {
         })
         .transpose()?;
 
-    // Deserialize the target's identity key from hex bytes
-    let mut key_bytes = Vec::with_capacity(33);
-    key_bytes.push(0x05u8); // Djb key type prefix (KeyType::Djb = 0x05)
-    key_bytes.extend_from_slice(&hex::decode(&args.target_identity)?);
+    // Deserialize the target's identity key. Accept either the raw 32-byte
+    // Ed25519 key (prepend the Djb 0x05 prefix) or the full 33-byte serialized
+    // form (already prefixed).
+    let mut key_bytes = hex::decode(&args.target_identity)?;
+    if key_bytes.len() == 32 {
+        let mut v = Vec::with_capacity(33);
+        v.push(0x05u8);
+        v.extend_from_slice(&key_bytes);
+        key_bytes = v;
+    }
     let target_identity_key =
         PublicKey::deserialize(&key_bytes).expect("valid identity key bytes");
 

--- a/src/key_transparency/mod.rs
+++ b/src/key_transparency/mod.rs
@@ -17,7 +17,7 @@ pub use websocket::{KeyTransparencyWebSocketError, ValueMonitor};
 pub use libsignal_keytrans::{MonitoringData, TreeHead, TreeRoot};
 
 use crate::utils::TryIntoE164;
-use crate::websocket::SignalWebSocket;
+use crate::websocket::{SignalWebSocket, Unidentified};
 use libsignal_core::{Aci, E164};
 use libsignal_keytrans::PublicConfig;
 use libsignal_protocol::PublicKey;
@@ -55,9 +55,12 @@ pub struct ChatSearchParams<P = E164> {
 // Public Config Constructors
 // ---------------------------------------------------------------------------
 
-/// Returns a PublicConfig for the production Key Transparency deployment.
+/// Returns a `PublicConfig` for the production Key Transparency deployment.
 ///
-/// Uses hardcoded keys from libsignal-net v0.91.0.
+/// Mirrors the key material in `libsignal_net::env::PROD.keytrans_config`
+/// (rust/net/src/env.rs, consts `KEYTRANS_*_PROD`). Hardcoded rather than sourced
+/// from `libsignal-net` so the `key-transparency` feature does not pull in the
+/// `cdsi` transport; re-check these on libsignal bumps.
 pub fn production_public_config() -> PublicConfig {
     use libsignal_keytrans::DeploymentMode;
     use libsignal_keytrans::VerifyingKey;
@@ -114,9 +117,10 @@ pub fn production_public_config() -> PublicConfig {
     }
 }
 
-/// Returns a PublicConfig for the staging Key Transparency deployment.
+/// Returns a `PublicConfig` for the staging Key Transparency deployment.
 ///
-/// Uses hardcoded keys from libsignal-net v0.91.0.
+/// Mirrors `libsignal_net::env::STAGING.keytrans_config`; see
+/// [`production_public_config`] for why these are hardcoded.
 pub fn staging_public_config() -> PublicConfig {
     use libsignal_keytrans::DeploymentMode;
     use libsignal_keytrans::VerifyingKey;
@@ -261,7 +265,7 @@ pub struct KeyTransparencyClient<'a, S: KeyTransparencyStore> {
     /// Persistent KT state.
     store: &'a S,
     /// WebSocket connection for KT server communication.
-    socket: &'a mut SignalWebSocket<crate::websocket::Identified>,
+    socket: &'a mut SignalWebSocket<Unidentified>,
 }
 
 impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
@@ -269,7 +273,7 @@ impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
     pub fn new(
         config: PublicConfig,
         store: &'a S,
-        socket: &'a mut SignalWebSocket<crate::websocket::Identified>,
+        socket: &'a mut SignalWebSocket<Unidentified>,
     ) -> Self {
         let inner = libsignal_keytrans::KeyTransparency { config };
         Self {

--- a/src/key_transparency/mod.rs
+++ b/src/key_transparency/mod.rs
@@ -239,10 +239,12 @@ pub struct VerifiedMonitorResult {
 // KeyTransparencyClient
 // ---------------------------------------------------------------------------
 
+use libsignal_core::ServiceId;
 use libsignal_keytrans::{
     FullSearchResponse, MonitorContext, MonitorKey, MonitorRequest,
     SearchContext, SlimSearchRequest,
 };
+use std::time::SystemTime;
 
 /// High-level Key Transparency client.
 ///
@@ -297,11 +299,13 @@ impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
 /// Transport methods require the `key-transparency` feature.
 #[cfg(feature = "key-transparency")]
 impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
-    /// Search for a contact's identity key in the KT log,
-    /// fetch the response from the server, and verify it.
+    /// Search for a contact's identity key in the KT log, fetch the response
+    /// from the server, and verify it.
     ///
-    /// Combines transport + verification in one call.
-    /// This is the most convenient entry point for consumers.
+    /// Refreshes the distinguished tree head (anchoring consistency), issues
+    /// the search, cryptographically verifies the ACI entry, and persists the
+    /// resulting monitoring data. `key_matches` is whether the committed value
+    /// equals `params.target_identity_key`.
     pub async fn search_and_verify<P>(
         &mut self,
         params: ChatSearchParams<P>,
@@ -309,13 +313,104 @@ impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
     where
         P: TryIntoE164,
     {
-        let _response = self
+        // Anchoring distinguished head first: the search request's
+        // `distinguishedTreeHeadSize` must be a real, verified size.
+        self.check_distinguished().await?;
+        let distinguished = self
+            .store
+            .get_last_distinguished_tree_head()
+            .await
+            .expect("check_distinguished persists a head");
+        let distinguished_size = distinguished.tree_head.tree_size;
+        let last_distinguished = libsignal_keytrans::LastTreeHead(
+            distinguished.tree_head,
+            distinguished.root,
+        );
+
+        // Capture what we need for verification before `params` moves into
+        // the transport call.
+        let target_aci = params.target_aci;
+        let expected_value = params.target_identity_key.serialize();
+        let search_key = [
+            b"a",
+            ServiceId::from(target_aci).service_id_binary().as_slice(),
+        ]
+        .concat();
+
+        // Seed incremental params from the store when the caller didn't.
+        let mut params = params;
+        params.distinguished_tree_head_size = Some(distinguished_size);
+        if params.last_tree_head_size.is_none() {
+            params.last_tree_head_size = self
+                .store
+                .get_last_tree_head()
+                .await
+                .map(|h| h.tree_head.tree_size);
+        }
+
+        let response = self
             .socket
             .key_transparency_search(params)
             .await
             .map_err(|e| KeyTransparencyError::Transport(e.to_string()))?;
-        // TODO: slim request from response, call self.verify_search()
-        todo!()
+
+        let tree_head = response.tree_head.ok_or_else(|| {
+            KeyTransparencyError::VerificationFailed(
+                "search response without tree head".into(),
+            )
+        })?;
+        let aci = response.aci.ok_or_else(|| {
+            KeyTransparencyError::VerificationFailed(
+                "search response without ACI entry".into(),
+            )
+        })?;
+
+        let last_tree_head = self
+            .store
+            .get_last_tree_head()
+            .await
+            .map(|h| libsignal_keytrans::LastTreeHead(h.tree_head, h.root));
+        let monitoring = self.store.get_monitoring_data(&search_key).await;
+
+        let search_response = FullSearchResponse::new(aci, &tree_head);
+        let context = SearchContext {
+            last_tree_head: last_tree_head.as_ref(),
+            last_distinguished_tree_head: Some(&last_distinguished),
+            data: monitoring,
+        };
+        let result = self.inner.verify_search(
+            SlimSearchRequest {
+                search_key: search_key.clone(),
+                version: None,
+            },
+            search_response,
+            context,
+            true,
+            SystemTime::now(),
+        )?;
+
+        // Persist the updated state.
+        if let Some(md) = &result.state_update.monitoring_data {
+            self.store
+                .set_monitoring_data(&search_key, md.clone())
+                .await;
+        }
+        self.store
+            .set_last_tree_head(
+                result.state_update.tree_head.clone(),
+                result.state_update.tree_root,
+            )
+            .await;
+
+        // Constant-time compare would be ideal; for the example a plain eq
+        // suffices. Upstream uses SearchValue::check_equal.
+        let key_matches = result.value.as_slice() == expected_value.as_ref();
+
+        Ok(VerifiedSearchResult {
+            aci: target_aci,
+            key_matches,
+            now_monitored: result.state_update.monitoring_data.is_some(),
+        })
     }
 
     /// Monitor a previously-searched contact for key changes.
@@ -323,10 +418,6 @@ impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
         &mut self,
         aci: libsignal_core::Aci,
     ) -> Result<VerifiedMonitorResult, KeyTransparencyError> {
-        // TODO:
-        // 1. Build MonitorRequest from stored monitoring data
-        // 2. Send via socket
-        // 3. Call self.verify_monitor()
         let _ = aci;
         let _request = MonitorRequest::default();
         let _response =
@@ -334,19 +425,67 @@ impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
                 .key_transparency_monitor(&_request)
                 .await
                 .map_err(|e| KeyTransparencyError::Transport(e.to_string()))?;
-        todo!()
+        todo!("monitor verify wiring; see bugs #5/#6")
     }
 
     /// Fetch and verify the distinguished tree head.
+    ///
+    /// Refreshes (and persists) the store's distinguished tree head and returns
+    /// its root hash. Mirrors `libsignal-net`'s `distinguished()`, which drives
+    /// the public `verify_search` with `SlimSearchRequest::new(b"distinguished")`.
     pub async fn check_distinguished(
         &mut self,
     ) -> Result<TreeRoot, KeyTransparencyError> {
-        let _response = self
+        let last_distinguished =
+            self.store.get_last_distinguished_tree_head().await;
+        let last_for_context = last_distinguished.as_ref().map(|h| {
+            libsignal_keytrans::LastTreeHead(h.tree_head.clone(), h.root)
+        });
+        let last_tree_head_size =
+            last_distinguished.as_ref().map(|h| h.tree_head.tree_size);
+
+        let response = self
             .socket
-            .key_transparency_distinguished(None)
+            .key_transparency_distinguished(last_tree_head_size)
             .await
             .map_err(|e| KeyTransparencyError::Transport(e.to_string()))?;
-        // TODO: call self.verify_distinguished()
-        todo!()
+
+        let tree_head = response.tree_head.ok_or_else(|| {
+            KeyTransparencyError::VerificationFailed(
+                "distinguished response without tree head".into(),
+            )
+        })?;
+        let distinguished = response.distinguished.ok_or_else(|| {
+            KeyTransparencyError::VerificationFailed(
+                "distinguished response without distinguished entry".into(),
+            )
+        })?;
+
+        let search_response =
+            FullSearchResponse::new(distinguished, &tree_head);
+        let context = SearchContext {
+            last_tree_head: None,
+            last_distinguished_tree_head: last_for_context.as_ref(),
+            data: None,
+        };
+        let result = self.inner.verify_search(
+            SlimSearchRequest {
+                search_key: b"distinguished".to_vec(),
+                version: None,
+            },
+            search_response,
+            context,
+            false,
+            SystemTime::now(),
+        )?;
+
+        let root = result.state_update.tree_root;
+        self.store
+            .set_last_distinguished_tree_head(
+                result.state_update.tree_head,
+                root,
+            )
+            .await;
+        Ok(root)
     }
 }

--- a/src/key_transparency/mod.rs
+++ b/src/key_transparency/mod.rs
@@ -404,7 +404,15 @@ impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
 
         // Constant-time compare would be ideal; for the example a plain eq
         // suffices. Upstream uses SearchValue::check_equal.
-        let key_matches = result.value.as_slice() == expected_value.as_ref();
+        // The committed value is version-prefixed (0x00 + serialized
+        // identity key); strip the version byte before comparing, mirroring
+        // libsignal-net's SearchValue::check_equal.
+        let key_matches = result
+            .value
+            .split_first()
+            .filter(|(version, _)| **version == 0)
+            .map(|(_, rest)| rest == expected_value.as_ref())
+            .unwrap_or(false);
 
         Ok(VerifiedSearchResult {
             aci: target_aci,

--- a/src/key_transparency/mod.rs
+++ b/src/key_transparency/mod.rs
@@ -227,12 +227,17 @@ pub struct VerifiedSearchResult {
 }
 
 /// Outcome of a verified monitor operation.
+///
+/// Monitor proves that a previously-searched entry is still correctly placed
+/// in a consistently-grown tree; it does not surface value changes (that
+/// requires re-searching). Mirrors `libsignal-net`'s `monitor()`, which returns
+/// updated `AccountData` rather than a change flag.
 #[derive(Debug, Clone)]
 pub struct VerifiedMonitorResult {
-    /// Whether the monitored contact's key has changed since last check.
-    pub key_changed: bool,
-    /// The new identity key, if a change was detected.
-    pub new_key: Option<libsignal_protocol::PublicKey>,
+    /// Whether the monitor proof verified against the current tree head.
+    pub verified: bool,
+    /// Root hash of the tree head the monitor proof was checked against.
+    pub tree_root: TreeRoot,
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +249,7 @@ use libsignal_keytrans::{
     FullSearchResponse, MonitorContext, MonitorKey, MonitorRequest,
     SearchContext, SlimSearchRequest,
 };
+use std::collections::HashMap;
 use std::time::SystemTime;
 
 /// High-level Key Transparency client.
@@ -385,6 +391,10 @@ impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
             },
             search_response,
             context,
+            // Always start monitoring on search; `false` is only used for the
+            // distinguished key (which isn't monitored). Mirrors
+            // libsignal-net's `verify_single_search_response`
+            // (rust/net/chat/src/api/keytrans/verify_ext.rs).
             true,
             SystemTime::now(),
         )?;
@@ -421,19 +431,121 @@ impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
         })
     }
 
-    /// Monitor a previously-searched contact for key changes.
+    /// Monitor a previously-searched contact for consistency.
+    ///
+    /// After [`search_and_verify`] establishes a contact's position in the
+    /// log, monitor proves — cheaply, via path proofs rather than a fresh
+    /// binary search — that the entry is still correctly placed in a
+    /// consistently-grown tree. Loads stored `MonitoringData` for the ACI's
+    /// search key, refreshes the distinguished head, builds a `MonitorRequest`
+    /// (with `entry_position`/`commitment_index` from the stored data and
+    /// `consistency` sizes from the store), POSTs, and verifies.
+    ///
+    /// Mirrors `libsignal-net`'s `monitor()`
+    /// (rust/net/chat/src/api/keytrans.rs); the public `verify_monitor` skips
+    /// upstream's `try_from_untyped` conversion, which the transport already
+    /// does on the `ChatMonitorResponse` bytes.
     pub async fn monitor_and_verify(
         &mut self,
         aci: libsignal_core::Aci,
     ) -> Result<VerifiedMonitorResult, KeyTransparencyError> {
-        let _ = aci;
-        let _request = MonitorRequest::default();
-        let _response =
-            self.socket
-                .key_transparency_monitor(&_request)
-                .await
-                .map_err(|e| KeyTransparencyError::Transport(e.to_string()))?;
-        todo!("monitor verify wiring; see bugs #5/#6")
+        let search_key =
+            [b"a", ServiceId::from(aci).service_id_binary().as_slice()]
+                .concat();
+        let monitoring = self
+            .store
+            .get_monitoring_data(&search_key)
+            .await
+            .ok_or(KeyTransparencyError::NotMonitored)?;
+        // Refresh the distinguished head first and read it back: it anchors
+        // consistency and seeds `lastDistinguishedTreeHeadSize`.
+        self.check_distinguished().await?;
+        let distinguished = self
+            .store
+            .get_last_distinguished_tree_head()
+            .await
+            .expect("check_distinguished persists a head");
+        let last_distinguished = libsignal_keytrans::LastTreeHead(
+            distinguished.tree_head.clone(),
+            distinguished.root,
+        );
+
+        // Sourced from the store per upstream (rust/net/chat/src/ws/keytrans.rs
+        // takes these directly, not from the proto `Consistency`). `verify_monitor`
+        // uses a `Consistency`-less request.
+        let last_tree_head_size = self
+            .store
+            .get_last_tree_head()
+            .await
+            .map(|h| h.tree_head.tree_size);
+        let distinguished_size = self
+            .store
+            .get_last_distinguished_tree_head()
+            .await
+            .map(|h| h.tree_head.tree_size);
+
+        let request = MonitorRequest {
+            keys: vec![MonitorKey {
+                search_key: search_key.clone(),
+                entry_position: monitoring.latest_log_position(),
+                commitment_index: monitoring.index.to_vec(),
+            }],
+            consistency: None,
+        };
+
+        let response = self
+            .socket
+            .key_transparency_monitor(
+                &request,
+                last_tree_head_size,
+                distinguished_size,
+            )
+            .await
+            .map_err(|e| KeyTransparencyError::Transport(e.to_string()))?;
+
+        if response.tree_head.is_none() {
+            return Err(KeyTransparencyError::VerificationFailed(
+                "monitor response without tree head".into(),
+            ));
+        }
+        let last_tree = self
+            .store
+            .get_last_tree_head()
+            .await
+            .map(|h| libsignal_keytrans::LastTreeHead(h.tree_head, h.root));
+        let mut data_map = HashMap::new();
+        data_map.insert(search_key.clone(), monitoring);
+        let context = MonitorContext {
+            last_tree_head: last_tree.as_ref(),
+            last_distinguished_tree_head: &last_distinguished,
+            data: data_map,
+        };
+        let mut verified = self.inner.verify_monitor(
+            &request,
+            &response,
+            context,
+            SystemTime::now(),
+        )?;
+
+        // Persist the updated monitoring data + tree head.
+        if let Some(md) = verified.monitoring_data.remove(&search_key) {
+            self.store.set_monitoring_data(&search_key, md).await;
+        }
+        self.store
+            .set_last_tree_head(verified.tree_head.clone(), verified.tree_root)
+            .await;
+        // The distinguished head is the same root; keep it fresh too.
+        self.store
+            .set_last_distinguished_tree_head(
+                verified.tree_head,
+                verified.tree_root,
+            )
+            .await;
+
+        Ok(VerifiedMonitorResult {
+            verified: true,
+            tree_root: verified.tree_root,
+        })
     }
 
     /// Fetch and verify the distinguished tree head.

--- a/src/key_transparency/mod.rs
+++ b/src/key_transparency/mod.rs
@@ -16,6 +16,7 @@ pub use websocket::{KeyTransparencyWebSocketError, ValueMonitor};
 // Re-export core KT types that consumers will need alongside our wrappers.
 pub use libsignal_keytrans::{MonitoringData, TreeHead, TreeRoot};
 
+use crate::utils::TryIntoE164;
 use crate::websocket::SignalWebSocket;
 use libsignal_core::{Aci, E164};
 use libsignal_keytrans::PublicConfig;
@@ -33,13 +34,13 @@ use zkgroup::profiles::ProfileKey;
 /// Signal Key Transparency log. All fields describe the **target** user
 /// (the one being searched for), not the searching user.
 #[derive(Debug)]
-pub struct ChatSearchParams {
+pub struct ChatSearchParams<P = E164> {
     /// The target user's ACI (always required).
     pub target_aci: Aci,
     /// The target user's identity key.
     pub target_identity_key: PublicKey,
-    /// Optional target E164 phone number for cross-verification.
-    pub target_e164: Option<E164>,
+    /// Optional target phone number for cross-verification.
+    pub target_e164: Option<P>,
     /// Optional target username for cross-verification.
     pub target_username: Option<Username>,
     /// Optional profile key used to derive the unidentified access key.
@@ -297,10 +298,13 @@ impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
     ///
     /// Combines transport + verification in one call.
     /// This is the most convenient entry point for consumers.
-    pub async fn search_and_verify(
+    pub async fn search_and_verify<P>(
         &mut self,
-        params: ChatSearchParams,
-    ) -> Result<VerifiedSearchResult, KeyTransparencyError> {
+        params: ChatSearchParams<P>,
+    ) -> Result<VerifiedSearchResult, KeyTransparencyError>
+    where
+        P: TryIntoE164,
+    {
         let _response = self
             .socket
             .key_transparency_search(params)

--- a/src/key_transparency/mod.rs
+++ b/src/key_transparency/mod.rs
@@ -1,0 +1,344 @@
+//! Key Transparency module for Signal service.
+//!
+//! Provides WebSocket transport for Signal's Key Transparency system
+//! and a state-storage trait for persisting KT verification data.
+//!
+//! Enable with the `key-transparency` feature flag.
+
+pub mod store;
+pub mod websocket;
+
+pub use store::{
+    InMemoryKeyTransparencyStore, KeyTransparencyStore, LastTreeHead,
+};
+pub use websocket::{KeyTransparencyWebSocketError, ValueMonitor};
+
+// Re-export core KT types that consumers will need alongside our wrappers.
+pub use libsignal_keytrans::{MonitoringData, TreeHead, TreeRoot};
+
+use crate::websocket::SignalWebSocket;
+use libsignal_core::{Aci, E164};
+use libsignal_keytrans::PublicConfig;
+use libsignal_protocol::PublicKey;
+use usernames::Username;
+use zkgroup::profiles::ProfileKey;
+
+// ---------------------------------------------------------------------------
+// ChatSearchParams – search parameters for KT requests
+// ---------------------------------------------------------------------------
+
+/// Full parameter set for a Key Transparency search request.
+///
+/// Bundles all inputs required to perform a search operation against the
+/// Signal Key Transparency log. All fields describe the **target** user
+/// (the one being searched for), not the searching user.
+#[derive(Debug)]
+pub struct ChatSearchParams {
+    /// The target user's ACI (always required).
+    pub target_aci: Aci,
+    /// The target user's identity key.
+    pub target_identity_key: PublicKey,
+    /// Optional target E164 phone number for cross-verification.
+    pub target_e164: Option<E164>,
+    /// Optional target username for cross-verification.
+    pub target_username: Option<Username>,
+    /// Optional profile key used to derive the unidentified access key.
+    pub target_profile_key: Option<ProfileKey>,
+    /// Optional last tree head size for incremental verification.
+    pub last_tree_head_size: Option<u64>,
+    /// Optional distinguished tree head size for incremental verification.
+    pub distinguished_tree_head_size: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// Public Config Constructors
+// ---------------------------------------------------------------------------
+
+/// Returns a PublicConfig for the production Key Transparency deployment.
+///
+/// Uses hardcoded keys from libsignal-net v0.91.0.
+pub fn production_public_config() -> PublicConfig {
+    use libsignal_keytrans::DeploymentMode;
+    use libsignal_keytrans::VerifyingKey;
+    use libsignal_keytrans::VerifyingKeys;
+    use libsignal_keytrans::VrfPublicKey;
+
+    let signature_key = VerifyingKey::from_bytes(
+        &hex::decode(
+            "a3973067984382cfa89ec26d7cc176680aefe92b3d2eba85159dad0b8354b622",
+        )
+        .unwrap()
+        .try_into()
+        .expect("32 bytes"),
+    )
+    .expect("valid production signature key");
+
+    let vrf_key_bytes: [u8; 32] = hex::decode(
+        "3849cf116c7bc9aef5f13f0c61a7c246e5bade4eb7e1c7b0efcacdd8c1e6a6ff",
+    )
+    .unwrap()
+    .try_into()
+    .expect("32 bytes");
+    let vrf_key = VrfPublicKey::try_from(vrf_key_bytes)
+        .expect("valid production VRF key");
+
+    let auditor_keys = VerifyingKeys::from([
+        VerifyingKey::from_bytes(
+            &hex::decode("2d973608e909a09e12cbdbd21ad58775fd72fe1034a5a079f26541d5764ce17f")
+                .unwrap()
+                .try_into()
+                .expect("32 bytes"),
+        )
+        .expect("valid auditor key 1"),
+        VerifyingKey::from_bytes(
+            &hex::decode("2f217a86cd2dbc95d46a84420942a95877b3723f634bc64bb9e406796df746ef")
+                .unwrap()
+                .try_into()
+                .expect("32 bytes"),
+        )
+        .expect("valid auditor key 2"),
+        VerifyingKey::from_bytes(
+            &hex::decode("7fe5d91de235188486d8fb836a6da37e625e2b10eb6d144185b9364cc83cbbb6")
+                .unwrap()
+                .try_into()
+                .expect("32 bytes"),
+        )
+        .expect("valid auditor key 3"),
+    ]);
+
+    PublicConfig {
+        mode: DeploymentMode::ThirdPartyAuditing(auditor_keys),
+        signature_key,
+        vrf_key,
+    }
+}
+
+/// Returns a PublicConfig for the staging Key Transparency deployment.
+///
+/// Uses hardcoded keys from libsignal-net v0.91.0.
+pub fn staging_public_config() -> PublicConfig {
+    use libsignal_keytrans::DeploymentMode;
+    use libsignal_keytrans::VerifyingKey;
+    use libsignal_keytrans::VerifyingKeys;
+    use libsignal_keytrans::VrfPublicKey;
+
+    let signature_key = VerifyingKey::from_bytes(
+        &hex::decode(
+            "ac0de1fd7f33552bbeb6ebc12b9d4ea10bf5f025c45073d3fb5f5648955a749e",
+        )
+        .unwrap()
+        .try_into()
+        .expect("32 bytes"),
+    )
+    .expect("valid staging signature key");
+
+    let vrf_key_bytes: [u8; 32] = hex::decode(
+        "ec3a268237cf5c47115cf222405d5f90cc633ebe05caf82c0dd5acf9d341dadb",
+    )
+    .unwrap()
+    .try_into()
+    .expect("32 bytes");
+    let vrf_key =
+        VrfPublicKey::try_from(vrf_key_bytes).expect("valid staging VRF key");
+
+    let auditor_keys = VerifyingKeys::from([
+        VerifyingKey::from_bytes(
+            &hex::decode("1123b13ee32479ae6af5739e5d687b51559abf7684120511f68cde7a21a0e755")
+                .unwrap()
+                .try_into()
+                .expect("32 bytes"),
+        )
+        .expect("valid auditor key 1"),
+        VerifyingKey::from_bytes(
+            &hex::decode("bd1e26a0fbdbfa923486ccc9296f4227db490b4add29f5507775171ea0fb7a4e")
+                .unwrap()
+                .try_into()
+                .expect("32 bytes"),
+        )
+        .expect("valid auditor key 2"),
+        VerifyingKey::from_bytes(
+            &hex::decode("093ee42d95502b3e81f4e604179c82c149fffb96167642b9eb81b03d6e2dd636")
+                .unwrap()
+                .try_into()
+                .expect("32 bytes"),
+        )
+        .expect("valid auditor key 3"),
+    ]);
+
+    PublicConfig {
+        mode: DeploymentMode::ThirdPartyAuditing(auditor_keys),
+        signature_key,
+        vrf_key,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error type – placeholder until error.rs is created
+// ---------------------------------------------------------------------------
+
+/// Errors that can occur during Key Transparency operations.
+///
+/// TODO: Replace with the full error enum from `error.rs` once that module is
+/// implemented (see plan task 2).
+#[derive(Debug, thiserror::Error)]
+pub enum KeyTransparencyError {
+    /// Verification of a proof failed.
+    #[error("KT verification failed: {0}")]
+    VerificationFailed(String),
+    /// Store error (I/O, serialization).
+    #[error("KT store error: {0}")]
+    Store(String),
+    /// The requested identifier has no monitoring data.
+    /// Call `search_and_verify` first to start monitoring.
+    #[error("no monitoring data; search first")]
+    NotMonitored,
+    /// The tree head is inconsistent with a previously stored one.
+    #[error("KT tree head inconsistency detected")]
+    TreeHeadInconsistency,
+    /// Transport error (e.g. network failure, server error).
+    #[error("KT transport error: {0}")]
+    Transport(String),
+}
+
+impl From<libsignal_keytrans::Error> for KeyTransparencyError {
+    fn from(e: libsignal_keytrans::Error) -> Self {
+        Self::VerificationFailed(e.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Outcome of a verified search operation.
+#[derive(Debug, Clone)]
+pub struct VerifiedSearchResult {
+    /// The ACI that was searched.
+    pub aci: libsignal_core::Aci,
+    /// Whether the identity key was found in the transparency log.
+    pub key_matches: bool,
+    /// Whether the search also started monitoring this contact.
+    pub now_monitored: bool,
+}
+
+/// Outcome of a verified monitor operation.
+#[derive(Debug, Clone)]
+pub struct VerifiedMonitorResult {
+    /// Whether the monitored contact's key has changed since last check.
+    pub key_changed: bool,
+    /// The new identity key, if a change was detected.
+    pub new_key: Option<libsignal_protocol::PublicKey>,
+}
+
+// ---------------------------------------------------------------------------
+// KeyTransparencyClient
+// ---------------------------------------------------------------------------
+
+use libsignal_keytrans::{
+    FullSearchResponse, MonitorContext, MonitorKey, MonitorRequest,
+    SearchContext, SlimSearchRequest,
+};
+
+/// High-level Key Transparency client.
+///
+/// Wraps `libsignal_keytrans` verification logic with storage management.
+/// Consumers use this to verify identity keys against Signal's transparency
+/// log and persist verified state.
+///
+/// This struct provides verification-only methods. For transport integration
+/// (fetching responses from the KT server via WebSocket), see the
+/// transport-aware methods.
+///
+/// # Type parameters
+///
+/// * `S` – A [`KeyTransparencyStore`] implementation that persists tree
+///   heads and monitoring data (e.g. `InMemoryKeyTransparencyStore` for
+///   testing, or a SQLite-backed store in Whisperfish).
+pub struct KeyTransparencyClient<'a, S: KeyTransparencyStore> {
+    /// The libsignal KT verification engine.
+    inner: libsignal_keytrans::KeyTransparency,
+    /// Persistent KT state.
+    store: &'a S,
+    /// WebSocket connection for KT server communication.
+    socket: &'a mut SignalWebSocket<crate::websocket::Identified>,
+}
+
+impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
+    /// Create a new KT client with the given configuration, storage backend, and websocket.
+    pub fn new(
+        config: PublicConfig,
+        store: &'a S,
+        socket: &'a mut SignalWebSocket<crate::websocket::Identified>,
+    ) -> Self {
+        let inner = libsignal_keytrans::KeyTransparency { config };
+        Self {
+            inner,
+            store,
+            socket,
+        }
+    }
+
+    /// Clear all stored KT state.
+    pub async fn clear(&self) -> Result<(), KeyTransparencyError> {
+        self.store.clear().await;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transport-aware methods
+// ---------------------------------------------------------------------------
+
+/// Transport methods require the `key-transparency` feature.
+#[cfg(feature = "key-transparency")]
+impl<'a, S: KeyTransparencyStore> KeyTransparencyClient<'a, S> {
+    /// Search for a contact's identity key in the KT log,
+    /// fetch the response from the server, and verify it.
+    ///
+    /// Combines transport + verification in one call.
+    /// This is the most convenient entry point for consumers.
+    pub async fn search_and_verify(
+        &mut self,
+        params: ChatSearchParams,
+    ) -> Result<VerifiedSearchResult, KeyTransparencyError> {
+        let _response = self
+            .socket
+            .key_transparency_search(params)
+            .await
+            .map_err(|e| KeyTransparencyError::Transport(e.to_string()))?;
+        // TODO: slim request from response, call self.verify_search()
+        todo!()
+    }
+
+    /// Monitor a previously-searched contact for key changes.
+    pub async fn monitor_and_verify(
+        &mut self,
+        aci: libsignal_core::Aci,
+    ) -> Result<VerifiedMonitorResult, KeyTransparencyError> {
+        // TODO:
+        // 1. Build MonitorRequest from stored monitoring data
+        // 2. Send via socket
+        // 3. Call self.verify_monitor()
+        let _ = aci;
+        let _request = MonitorRequest::default();
+        let _response =
+            self.socket
+                .key_transparency_monitor(&_request)
+                .await
+                .map_err(|e| KeyTransparencyError::Transport(e.to_string()))?;
+        todo!()
+    }
+
+    /// Fetch and verify the distinguished tree head.
+    pub async fn check_distinguished(
+        &mut self,
+    ) -> Result<TreeRoot, KeyTransparencyError> {
+        let _response = self
+            .socket
+            .key_transparency_distinguished(None)
+            .await
+            .map_err(|e| KeyTransparencyError::Transport(e.to_string()))?;
+        // TODO: call self.verify_distinguished()
+        todo!()
+    }
+}

--- a/src/key_transparency/store.rs
+++ b/src/key_transparency/store.rs
@@ -1,0 +1,189 @@
+//! Key Transparency state storage.
+//!
+//! Defines the [`KeyTransparencyStore`] trait for persisting Key Transparency
+//! client state (tree heads and per-identifier monitoring data). An in-memory
+//! implementation is provided for testing.
+
+use async_trait::async_trait;
+use libsignal_keytrans::{MonitoringData, TreeRoot};
+
+/// Persistent state for Key Transparency verification.
+///
+/// Implementors store the last verified tree head and per-identifier monitoring
+/// data so that the KT client can verify consistency across sessions.
+///
+/// Whisperfish would typically implement this trait over SQLite; an in-memory
+/// implementation is provided here for testing.
+#[async_trait]
+pub trait KeyTransparencyStore: Send + Sync {
+    /// Return the last tree head that was successfully verified, together with
+    /// its root hash.
+    async fn get_last_tree_head(&self) -> Option<LastTreeHead>;
+
+    /// Persist the most recently verified tree head and its root hash.
+    async fn set_last_tree_head(&self, head: TreeHead, root: TreeRoot);
+
+    /// Return the monitoring data for an identifier key (e.g. an ACI as raw
+    /// bytes). Returns `None` if the identifier is not being tracked.
+    async fn get_monitoring_data(&self, key: &[u8]) -> Option<MonitoringData>;
+
+    /// Persist monitoring data for an identifier key.
+    async fn set_monitoring_data(&self, key: &[u8], data: MonitoringData);
+
+    /// Remove all stored KT state. Useful for debugging or resetting a
+    /// corrupted local state.
+    async fn clear(&self);
+}
+
+/// A verified tree head paired with its root hash.
+///
+/// Thin wrapper around [`libsignal_keytrans::LastTreeHead`] that owns its
+/// data, making it suitable for storage.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LastTreeHead {
+    /// The tree head (tree size, timestamp, auditor signatures).
+    pub tree_head: TreeHead,
+    /// 32-byte root hash of the Merkle tree.
+    pub root: TreeRoot,
+}
+
+// Re-export TreeHead from libsignal_keytrans so consumers don't need to
+// depend on it directly just for the type.
+pub use libsignal_keytrans::TreeHead;
+
+// ---------------------------------------------------------------------------
+// In-memory implementation (for testing)
+// ---------------------------------------------------------------------------
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// In-memory [`KeyTransparencyStore`] suitable for tests.
+pub struct InMemoryKeyTransparencyStore {
+    last_tree_head: Mutex<Option<LastTreeHead>>,
+    monitoring_data: Mutex<HashMap<Vec<u8>, MonitoringData>>,
+}
+
+impl InMemoryKeyTransparencyStore {
+    pub fn new() -> Self {
+        Self {
+            last_tree_head: Mutex::new(None),
+            monitoring_data: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemoryKeyTransparencyStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl KeyTransparencyStore for InMemoryKeyTransparencyStore {
+    async fn get_last_tree_head(&self) -> Option<LastTreeHead> {
+        self.last_tree_head
+            .lock()
+            .expect("last_tree_head lock")
+            .clone()
+    }
+
+    async fn set_last_tree_head(&self, head: TreeHead, root: TreeRoot) {
+        *self.last_tree_head.lock().expect("last_tree_head lock") =
+            Some(LastTreeHead {
+                tree_head: head,
+                root,
+            });
+    }
+
+    async fn get_monitoring_data(&self, key: &[u8]) -> Option<MonitoringData> {
+        self.monitoring_data
+            .lock()
+            .expect("monitoring_data lock")
+            .get(key)
+            .cloned()
+    }
+
+    async fn set_monitoring_data(&self, key: &[u8], data: MonitoringData) {
+        self.monitoring_data
+            .lock()
+            .expect("monitoring_data lock")
+            .insert(key.to_vec(), data);
+    }
+
+    async fn clear(&self) {
+        *self.last_tree_head.lock().expect("last_tree_head lock") = None;
+        self.monitoring_data
+            .lock()
+            .expect("monitoring_data lock")
+            .clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_in_memory_store_round_trip() {
+        let store = InMemoryKeyTransparencyStore::new();
+
+        assert!(store.get_last_tree_head().await.is_none());
+
+        let root: TreeRoot = [42u8; 32];
+        let head = TreeHead {
+            tree_size: 1234_u64,
+            timestamp: 1_700_000_000_i64,
+            signatures: vec![],
+        };
+        store.set_last_tree_head(head.clone(), root).await;
+
+        let stored = store.get_last_tree_head().await.unwrap();
+        assert_eq!(stored.tree_head.tree_size, 1234);
+        assert_eq!(stored.root, root);
+
+        // Monitoring data round-trip
+        let key = b"some-aci-uuid";
+        let data = MonitoringData {
+            index: [1u8; 32],
+            pos: 100,
+            ptrs: HashMap::new(),
+            owned: false,
+            search_key: vec![1, 2, 3],
+        };
+        store.set_monitoring_data(key, data.clone()).await;
+
+        let stored_data = store.get_monitoring_data(key).await.unwrap();
+        assert_eq!(stored_data.pos, 100);
+        assert_eq!(stored_data.search_key, vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_store_clear() {
+        let store = InMemoryKeyTransparencyStore::new();
+
+        let root: TreeRoot = [0u8; 32];
+        let head = TreeHead {
+            tree_size: 1_u64,
+            timestamp: 0_i64,
+            signatures: vec![],
+        };
+        store.set_last_tree_head(head, root).await;
+        store
+            .set_monitoring_data(
+                b"key",
+                MonitoringData {
+                    index: [0u8; 32],
+                    pos: 0,
+                    ptrs: HashMap::new(),
+                    owned: false,
+                    search_key: vec![],
+                },
+            )
+            .await;
+
+        store.clear().await;
+        assert!(store.get_last_tree_head().await.is_none());
+        assert!(store.get_monitoring_data(b"key").await.is_none());
+    }
+}

--- a/src/key_transparency/store.rs
+++ b/src/key_transparency/store.rs
@@ -150,6 +150,7 @@ mod tests {
             ptrs: HashMap::new(),
             owned: false,
             search_key: vec![1, 2, 3],
+            max_observed_version: 0,
         };
         store.set_monitoring_data(key, data.clone()).await;
 
@@ -178,6 +179,7 @@ mod tests {
                     ptrs: HashMap::new(),
                     owned: false,
                     search_key: vec![],
+                    max_observed_version: 0,
                 },
             )
             .await;

--- a/src/key_transparency/store.rs
+++ b/src/key_transparency/store.rs
@@ -23,6 +23,20 @@ pub trait KeyTransparencyStore: Send + Sync {
     /// Persist the most recently verified tree head and its root hash.
     async fn set_last_tree_head(&self, head: TreeHead, root: TreeRoot);
 
+    /// Return the last verified *distinguished* tree head.
+    ///
+    /// Distinct from [`get_last_tree_head`]: the distinguished head anchors log
+    /// consistency across accounts and seeds every search's
+    /// `distinguishedTreeHeadSize`. `None` until the first `check_distinguished`.
+    async fn get_last_distinguished_tree_head(&self) -> Option<LastTreeHead>;
+
+    /// Persist the most recently verified distinguished tree head.
+    async fn set_last_distinguished_tree_head(
+        &self,
+        head: TreeHead,
+        root: TreeRoot,
+    );
+
     /// Return the monitoring data for an identifier key (e.g. an ACI as raw
     /// bytes). Returns `None` if the identifier is not being tracked.
     async fn get_monitoring_data(&self, key: &[u8]) -> Option<MonitoringData>;
@@ -61,6 +75,7 @@ use std::sync::Mutex;
 /// In-memory [`KeyTransparencyStore`] suitable for tests.
 pub struct InMemoryKeyTransparencyStore {
     last_tree_head: Mutex<Option<LastTreeHead>>,
+    last_distinguished_tree_head: Mutex<Option<LastTreeHead>>,
     monitoring_data: Mutex<HashMap<Vec<u8>, MonitoringData>>,
 }
 
@@ -68,6 +83,7 @@ impl InMemoryKeyTransparencyStore {
     pub fn new() -> Self {
         Self {
             last_tree_head: Mutex::new(None),
+            last_distinguished_tree_head: Mutex::new(None),
             monitoring_data: Mutex::new(HashMap::new()),
         }
     }
@@ -96,6 +112,27 @@ impl KeyTransparencyStore for InMemoryKeyTransparencyStore {
             });
     }
 
+    async fn get_last_distinguished_tree_head(&self) -> Option<LastTreeHead> {
+        self.last_distinguished_tree_head
+            .lock()
+            .expect("last_distinguished_tree_head lock")
+            .clone()
+    }
+
+    async fn set_last_distinguished_tree_head(
+        &self,
+        head: TreeHead,
+        root: TreeRoot,
+    ) {
+        *self
+            .last_distinguished_tree_head
+            .lock()
+            .expect("last_distinguished_tree_head lock") = Some(LastTreeHead {
+            tree_head: head,
+            root,
+        });
+    }
+
     async fn get_monitoring_data(&self, key: &[u8]) -> Option<MonitoringData> {
         self.monitoring_data
             .lock()
@@ -113,6 +150,10 @@ impl KeyTransparencyStore for InMemoryKeyTransparencyStore {
 
     async fn clear(&self) {
         *self.last_tree_head.lock().expect("last_tree_head lock") = None;
+        *self
+            .last_distinguished_tree_head
+            .lock()
+            .expect("last_distinguished_tree_head lock") = None;
         self.monitoring_data
             .lock()
             .expect("monitoring_data lock")

--- a/src/key_transparency/websocket.rs
+++ b/src/key_transparency/websocket.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 
 use crate::push_service::ServiceError;
 use crate::utils::{
-    serde_base64, serde_optional_base64, serde_optional_base64url,
+    serde_base64, serde_optional_base64, serde_optional_base64url, TryIntoE164,
 };
 use crate::websocket::SignalWebSocket;
 
@@ -54,7 +54,7 @@ pub struct ValueMonitor {
 /// JSON request body for `POST /v1/key-transparency/search`.
 ///
 /// Corresponds to the request body expected by Signal-Server:
-/// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+/// `service/src/main/java/org/wfromhispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
 ///
 /// See also libsignal-net:
 /// - `rust/net/chat/src/api/keytrans.rs`
@@ -83,11 +83,28 @@ struct RawChatSearchRequest {
     pub distinguished_tree_head_size: u64,
 }
 
-impl From<super::ChatSearchParams> for RawChatSearchRequest {
-    fn from(params: super::ChatSearchParams) -> Self {
-        RawChatSearchRequest {
+impl<P> TryFrom<super::ChatSearchParams<P>> for RawChatSearchRequest
+where
+    P: TryIntoE164,
+{
+    type Error = KeyTransparencyWebSocketError;
+
+    fn try_from(
+        params: super::ChatSearchParams<P>,
+    ) -> Result<Self, Self::Error> {
+        Ok(RawChatSearchRequest {
             aci: params.target_aci.service_id_string(),
-            e164: params.target_e164.as_ref().map(|e| e.to_string()),
+            e164: params
+                .target_e164
+                .map(|e| e.try_into_e164())
+                .transpose()
+                .map_err(|_e| {
+                    KeyTransparencyWebSocketError::RequestError(
+                        "unparsable phone number",
+                    )
+                })?
+                .as_ref()
+                .map(E164::to_string),
             username_hash: params
                 .target_username
                 .as_ref()
@@ -101,7 +118,7 @@ impl From<super::ChatSearchParams> for RawChatSearchRequest {
             distinguished_tree_head_size: params
                 .distinguished_tree_head_size
                 .unwrap_or(0),
-        }
+        })
     }
 }
 
@@ -253,11 +270,14 @@ impl SignalWebSocket<crate::websocket::Identified> {
     /// See also libsignal-net:
     /// - `rust/net/chat/src/api/keytrans.rs`
     /// - `rust/net/chat/src/ws/keytrans.rs`
-    pub async fn key_transparency_search(
+    pub async fn key_transparency_search<P>(
         &mut self,
-        params: super::ChatSearchParams,
-    ) -> Result<ChatSearchResponse, KeyTransparencyWebSocketError> {
-        let request: RawChatSearchRequest = params.into();
+        params: super::ChatSearchParams<P>,
+    ) -> Result<ChatSearchResponse, KeyTransparencyWebSocketError>
+    where
+        P: TryIntoE164,
+    {
+        let request: RawChatSearchRequest = params.try_into()?;
 
         let raw: RawChatSearchResponse = self
             .http_request(Method::POST, "/v1/key-transparency/search")?

--- a/src/key_transparency/websocket.rs
+++ b/src/key_transparency/websocket.rs
@@ -25,7 +25,7 @@ use crate::push_service::ServiceError;
 use crate::utils::{
     serde_base64, serde_optional_base64, serde_optional_base64url, TryIntoE164,
 };
-use crate::websocket::SignalWebSocket;
+use crate::websocket::{SignalWebSocket, Unidentified};
 
 use super::KeyTransparencyStore;
 
@@ -171,7 +171,7 @@ pub(crate) struct RawChatDistinguishedResponse {
 struct RawChatValueMonitorRequest {
     pub value: String,
     pub entry_position: u64,
-    #[serde(with = "serde_base64")]
+    #[serde(with = "crate::utils::serde_base64_no_pad")]
     pub commitment_index: Vec<u8>,
 }
 
@@ -261,7 +261,7 @@ pub(crate) enum WebSocketChatEvent {
 // ---------------------------------------------------------------------------
 // SignalWebSocket helper methods
 
-impl SignalWebSocket<crate::websocket::Identified> {
+impl SignalWebSocket<Unidentified> {
     /// Sends a KT search request.
     ///
     /// Corresponds to `POST /v1/key-transparency/search` in Signal-Server:
@@ -402,12 +402,16 @@ impl SignalWebSocket<crate::websocket::Identified> {
             )
         })?;
 
+        let consistency = request.consistency.as_ref();
+
         let body = RawChatMonitorRequest {
             aci,
             e164,
             username_hash,
-            last_non_distinguished_tree_head_size: None,
-            last_distinguished_tree_head_size: None,
+            last_non_distinguished_tree_head_size: consistency
+                .and_then(|c| c.last),
+            last_distinguished_tree_head_size: consistency
+                .and_then(|c| c.distinguished),
         };
 
         let raw: RawChatMonitorResponse = self

--- a/src/key_transparency/websocket.rs
+++ b/src/key_transparency/websocket.rs
@@ -92,28 +92,31 @@ where
     fn try_from(
         params: super::ChatSearchParams<P>,
     ) -> Result<Self, Self::Error> {
+        // `unidentifiedAccessKey` is the e164's UAK (derived from the target's
+        // profile key) and is only sent alongside an e164; see libsignal-net
+        // `RawChatSearchRequest::new` and Signal-Android.
+        let e164 = params
+            .target_e164
+            .map(|e| e.try_into_e164())
+            .transpose()
+            .map_err(|_e| {
+                KeyTransparencyWebSocketError::RequestError(
+                    "unparsable phone number",
+                )
+            })?;
+        let unidentified_access_key = e164
+            .as_ref()
+            .and(params.target_profile_key.as_ref())
+            .map(|pk| pk.derive_access_key().to_vec());
         Ok(RawChatSearchRequest {
             aci: params.target_aci.service_id_string(),
-            e164: params
-                .target_e164
-                .map(|e| e.try_into_e164())
-                .transpose()
-                .map_err(|_e| {
-                    KeyTransparencyWebSocketError::RequestError(
-                        "unparsable phone number",
-                    )
-                })?
-                .as_ref()
-                .map(E164::to_string),
+            e164: e164.as_ref().map(E164::to_string),
             username_hash: params
                 .target_username
                 .as_ref()
                 .map(|u| u.hash().to_vec()),
             aci_identity_key: params.target_identity_key.serialize().to_vec(),
-            unidentified_access_key: params
-                .target_profile_key
-                .as_ref()
-                .map(|pk| pk.derive_access_key().to_vec()),
+            unidentified_access_key,
             last_tree_head_size: params.last_tree_head_size,
             distinguished_tree_head_size: params
                 .distinguished_tree_head_size

--- a/src/key_transparency/websocket.rs
+++ b/src/key_transparency/websocket.rs
@@ -1,0 +1,460 @@
+//! WebSocket transport for Key Transparency operations.
+//!
+//! Provides structured JSON request/response types for the Signal KT server API,
+//! exchanged over the Signal chat WebSocket connection.
+//!
+//! The three endpoints mirror the server API:
+//!
+//! * `POST /v1/key-transparency/search`
+//! * `GET  /v1/key-transparency/distinguished?lastTreeHeadSize={}`
+//! * `POST /v1/key-transparency/monitor`
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use libsignal_core::{Aci, E164};
+use libsignal_keytrans::{
+    ChatDistinguishedResponse, ChatSearchResponse, MonitorRequest,
+    MonitorResponse,
+};
+use prost::Message;
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::push_service::ServiceError;
+use crate::utils::{
+    serde_base64, serde_optional_base64, serde_optional_base64url,
+};
+use crate::websocket::SignalWebSocket;
+
+use super::KeyTransparencyStore;
+
+#[derive(Error, Debug)]
+pub enum KeyTransparencyWebSocketError {
+    #[error("Protobuf decode error: {0}")]
+    ProtobufDecode(#[from] prost::DecodeError),
+    #[error("WebSocket transport error: {0}")]
+    WebSocket(#[from] ServiceError),
+    #[error("request formatting error: {0}")]
+    RequestError(&'static str),
+}
+
+/// Owned monitor request value, deserialized from storage.
+///
+/// This mirrors the protobuf `MonitorRequest` but owns its data,
+/// so it can be passed across async boundaries without lifetime issues.
+#[derive(Debug)]
+pub struct ValueMonitor {
+    pub aci: Aci,
+    pub e164: Option<String>,
+    pub username_hash: Option<Vec<u8>>,
+    pub commitment_index: Vec<u8>,
+}
+
+/// JSON request body for `POST /v1/key-transparency/search`.
+///
+/// Corresponds to the request body expected by Signal-Server:
+/// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+///
+/// See also libsignal-net:
+/// - `rust/net/chat/src/api/keytrans.rs`
+/// - `rust/net/chat/src/ws/keytrans.rs`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RawChatSearchRequest {
+    pub aci: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub e164: Option<String>,
+    /// Base64-encoded username hash, matching Signal-Server's expectations.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "serde_optional_base64url"
+    )]
+    pub username_hash: Option<Vec<u8>>,
+    #[serde(with = "serde_base64")]
+    pub aci_identity_key: Vec<u8>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "serde_optional_base64"
+    )]
+    pub unidentified_access_key: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_tree_head_size: Option<u64>,
+    pub distinguished_tree_head_size: u64,
+}
+
+impl From<super::ChatSearchParams> for RawChatSearchRequest {
+    fn from(params: super::ChatSearchParams) -> Self {
+        RawChatSearchRequest {
+            aci: params.target_aci.service_id_string(),
+            e164: params.target_e164.as_ref().map(|e| e.to_string()),
+            username_hash: params
+                .target_username
+                .as_ref()
+                .map(|u| u.hash().to_vec()),
+            aci_identity_key: params.target_identity_key.serialize().to_vec(),
+            unidentified_access_key: params
+                .target_profile_key
+                .as_ref()
+                .map(|pk| pk.derive_access_key().to_vec()),
+            last_tree_head_size: params.last_tree_head_size,
+            distinguished_tree_head_size: params
+                .distinguished_tree_head_size
+                .unwrap_or(0),
+        }
+    }
+}
+
+/// JSON response body for `POST /v1/key-transparency/search`.
+///
+/// The `serialized_response` field is a base64-encoded protobuf
+/// `ChatSearchResponse` containing the search result and tree head data.
+///
+/// Corresponds to the response from Signal-Server:
+/// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+///
+/// See also libsignal-net:
+/// - `rust/net/chat/src/api/keytrans.rs`
+/// - `rust/net/chat/src/ws/keytrans.rs`
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawChatSearchResponse {
+    #[serde(with = "serde_base64")]
+    pub serialized_response: Vec<u8>,
+}
+
+/// JSON response body for `GET /v1/key-transparency/distinguished`.
+///
+/// The `serialized_response` field is a base64-encoded protobuf
+/// `ChatDistinguishedResponse` containing the distinguished tree head.
+///
+/// Corresponds to the response from Signal-Server:
+/// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+///
+/// See also libsignal-net:
+/// - `rust/net/chat/src/api/keytrans.rs`
+/// - `rust/net/chat/src/ws/keytrans.rs`
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawChatDistinguishedResponse {
+    #[serde(with = "serde_base64")]
+    pub serialized_response: Vec<u8>,
+}
+
+/// JSON sub-structure for a single monitored value in a monitor request.
+///
+/// Corresponds to the value entry in Signal-Server's monitor endpoint:
+/// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+///
+/// See also libsignal-net:
+/// - `rust/net/chat/src/api/keytrans.rs`
+/// - `rust/net/chat/src/ws/keytrans.rs`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RawChatValueMonitorRequest {
+    pub value: String,
+    pub entry_position: u64,
+    #[serde(with = "serde_base64")]
+    pub commitment_index: Vec<u8>,
+}
+
+/// JSON request body for `POST /v1/key-transparency/monitor`.
+///
+/// Corresponds to the request body expected by Signal-Server:
+/// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+///
+/// See also libsignal-net:
+/// - `rust/net/chat/src/api/keytrans.rs`
+/// - `rust/net/chat/src/ws/keytrans.rs`
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RawChatMonitorRequest {
+    pub aci: RawChatValueMonitorRequest,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub e164: Option<RawChatValueMonitorRequest>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username_hash: Option<RawChatValueMonitorRequest>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_non_distinguished_tree_head_size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_distinguished_tree_head_size: Option<u64>,
+}
+
+/// JSON response body for `POST /v1/key-transparency/monitor`.
+///
+/// The `serialized_response` field is a base64-encoded protobuf
+/// `ChatMonitorResponse` containing the monitor result and tree head data.
+///
+/// Corresponds to the response from Signal-Server:
+/// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+///
+/// See also libsignal-net:
+/// - `rust/net/chat/src/api/keytrans.rs`
+/// - `rust/net/chat/src/ws/keytrans.rs`
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RawChatMonitorResponse {
+    #[serde(with = "serde_base64")]
+    pub serialized_response: Vec<u8>,
+}
+
+/// Raw tree head data extracted from a Key Transparency response.
+///
+/// Tree heads are returned inside the protobuf `serialized_response`
+/// of search, distinguished, and monitor responses.  This type represents
+/// the JSON-equivalent fields that would appear if the server exposed
+/// the tree head directly.
+///
+/// Corresponds to the tree head data in Signal-Server:
+/// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+///
+/// See also libsignal-net:
+/// - `rust/net/chat/src/api/keytrans.rs`
+/// - `rust/net/chat/src/ws/keytrans.rs`
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RawChatTreeHead {
+    pub tree_head_size: u64,
+    pub epoch_id: u64,
+    #[serde(with = "serde_base64")]
+    pub root_hash: Vec<u8>,
+    #[serde(with = "serde_base64")]
+    pub signature: Vec<u8>,
+}
+
+/// Events that can be received over the Signal chat WebSocket for Key Transparency.
+///
+/// Each variant wraps the corresponding raw JSON response type received from the
+/// Signal-Server endpoint.
+///
+/// Corresponds to the response types in Signal-Server:
+/// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+///
+/// See also libsignal-net:
+/// - `rust/net/chat/src/api/keytrans.rs`
+/// - `rust/net/chat/src/ws/keytrans.rs`
+#[allow(dead_code)]
+#[derive(Debug)]
+pub(crate) enum WebSocketChatEvent {
+    Search(RawChatSearchResponse),
+    Distinguished(RawChatDistinguishedResponse),
+    Monitor(RawChatMonitorResponse),
+}
+
+// ---------------------------------------------------------------------------
+// SignalWebSocket helper methods
+
+impl SignalWebSocket<crate::websocket::Identified> {
+    /// Sends a KT search request.
+    ///
+    /// Corresponds to `POST /v1/key-transparency/search` in Signal-Server:
+    /// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+    ///
+    /// See also libsignal-net:
+    /// - `rust/net/chat/src/api/keytrans.rs`
+    /// - `rust/net/chat/src/ws/keytrans.rs`
+    pub async fn key_transparency_search(
+        &mut self,
+        params: super::ChatSearchParams,
+    ) -> Result<ChatSearchResponse, KeyTransparencyWebSocketError> {
+        let request: RawChatSearchRequest = params.into();
+
+        let raw: RawChatSearchResponse = self
+            .http_request(Method::POST, "/v1/key-transparency/search")?
+            .send_json(Some(request))
+            .await?
+            .service_error_for_status()
+            .await?
+            .json()
+            .await?;
+        let response = ChatSearchResponse::decode(&*raw.serialized_response)?;
+        Ok(response)
+    }
+
+    /// Fetches the distinguished KT tree head.
+    ///
+    /// Corresponds to `GET /v1/key-transparency/distinguished?lastTreeHeadSize={}` in Signal-Server:
+    /// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+    ///
+    /// See also libsignal-net:
+    /// - `rust/net/chat/src/api/keytrans.rs`
+    /// - `rust/net/chat/src/ws/keytrans.rs`
+    pub async fn key_transparency_distinguished(
+        &mut self,
+        last_tree_head_size: Option<u64>,
+    ) -> Result<ChatDistinguishedResponse, ServiceError> {
+        let mut path = String::from("/v1/key-transparency/distinguished");
+        if let Some(size) = last_tree_head_size {
+            path.push_str(&format!("?lastTreeHeadSize={}", size));
+        }
+
+        let raw: RawChatDistinguishedResponse = self
+            .http_request(Method::GET, &path)?
+            .send()
+            .await?
+            .service_error_for_status()
+            .await?
+            .json()
+            .await?;
+        let response =
+            ChatDistinguishedResponse::decode(&*raw.serialized_response)
+                .map_err(|e| ServiceError::SendError {
+                    reason: format!("protobuf decode: {}", e),
+                })?;
+        Ok(response)
+    }
+
+    /// Sends a KT monitor request.
+    ///
+    /// Corresponds to `POST /v1/key-transparency/monitor` in Signal-Server:
+    /// `service/src/main/java/org/whispersystems/textsecuregcm/controllers/KeyTransparencyController.java`
+    ///
+    /// See also libsignal-net:
+    /// - `rust/net/chat/src/api/keytrans.rs`
+    /// - `rust/net/chat/src/ws/keytrans.rs`
+    pub async fn key_transparency_monitor(
+        &mut self,
+        request: &MonitorRequest,
+    ) -> Result<MonitorResponse, KeyTransparencyWebSocketError> {
+        let mut aci = None;
+        let mut e164 = None;
+        let mut username_hash = None;
+
+        for key in &request.keys {
+            let prefix = key.search_key.first().ok_or_else(|| {
+                KeyTransparencyWebSocketError::RequestError(
+                    "empty search key in MonitorRequest",
+                )
+            })?;
+            let value_bytes = &key.search_key[1..];
+
+            match prefix {
+                b'a' => {
+                    let parsed = Aci::parse_from_service_id_binary(value_bytes)
+                        .ok_or_else(|| {
+                            KeyTransparencyWebSocketError::RequestError(
+                                "invalid ACI search key in MonitorRequest",
+                            )
+                        })?;
+                    aci = Some(RawChatValueMonitorRequest {
+                        value: parsed.service_id_string(),
+                        entry_position: key.entry_position,
+                        commitment_index: key.commitment_index.clone(),
+                    });
+                },
+                b'n' => {
+                    let e164_str = String::from_utf8(value_bytes.to_vec())
+                        .map_err(|_| {
+                            KeyTransparencyWebSocketError::RequestError(
+                                "invalid E164 search key in MonitorRequest",
+                            )
+                        })?;
+                    let parsed = e164_str.parse::<E164>().map_err(|_| {
+                        KeyTransparencyWebSocketError::RequestError(
+                            "invalid E164 search key in MonitorRequest",
+                        )
+                    })?;
+                    e164 = Some(RawChatValueMonitorRequest {
+                        value: parsed.to_string(),
+                        entry_position: key.entry_position,
+                        commitment_index: key.commitment_index.clone(),
+                    });
+                },
+                b'u' => {
+                    username_hash = Some(RawChatValueMonitorRequest {
+                        value: URL_SAFE_NO_PAD.encode(value_bytes),
+                        entry_position: key.entry_position,
+                        commitment_index: key.commitment_index.clone(),
+                    });
+                },
+                _ => {
+                    panic!(
+                        "unknown prefix byte {:#x} in MonitorRequest",
+                        prefix
+                    )
+                },
+            }
+        }
+
+        let aci = aci.ok_or_else(|| {
+            KeyTransparencyWebSocketError::RequestError(
+                "missing ACI key in MonitorRequest",
+            )
+        })?;
+
+        let body = RawChatMonitorRequest {
+            aci,
+            e164,
+            username_hash,
+            last_non_distinguished_tree_head_size: None,
+            last_distinguished_tree_head_size: None,
+        };
+
+        let raw: RawChatMonitorResponse = self
+            .http_request(Method::POST, "/v1/key-transparency/monitor")?
+            .send_json(Some(body))
+            .await?
+            .service_error_for_status()
+            .await?
+            .json()
+            .await?;
+        let response = MonitorResponse::decode(&*raw.serialized_response)?;
+        Ok(response)
+    }
+
+    /// Creates a KeyTransparencyClient for this websocket connection.
+    ///
+    /// This is a convenience method that constructs a KeyTransparencyClient
+    /// with the given config and store, using this websocket for transport.
+    pub fn key_transparency<'a, S: KeyTransparencyStore>(
+        &'a mut self,
+        config: super::PublicConfig,
+        store: &'a S,
+    ) -> super::KeyTransparencyClient<'a, S> {
+        super::KeyTransparencyClient::new(config, store, self)
+    }
+}
+
+/// Parses a [`ValueMonitor`] into a protobuf [`MonitorRequest`].
+///
+/// The protobuf expects a list of [`MonitorKey`] entries, one per monitored value.
+/// Each entry carries the opaque search key, the entry position, and the commitment index.
+pub fn value_monitor_to_request(
+    value: &ValueMonitor,
+) -> Result<MonitorRequest, ServiceError> {
+    let mut request = MonitorRequest::default();
+
+    let aci_search_key = [
+        b"a",
+        libsignal_core::ServiceId::from(value.aci)
+            .service_id_binary()
+            .as_slice(),
+    ]
+    .concat();
+
+    request.keys.push(libsignal_keytrans::MonitorKey {
+        search_key: aci_search_key,
+        entry_position: 0, // TODO: filled from AccountData
+        commitment_index: value.commitment_index.clone(),
+    });
+
+    if let Some(ref e164) = value.e164 {
+        let e164_search_key = [b"n", e164.as_bytes()].concat();
+        request.keys.push(libsignal_keytrans::MonitorKey {
+            search_key: e164_search_key,
+            entry_position: 0, // TODO
+            commitment_index: value.commitment_index.clone(),
+        });
+    }
+
+    if let Some(ref username_hash) = value.username_hash {
+        let u_search_key = [b"u", username_hash.as_slice()].concat();
+        request.keys.push(libsignal_keytrans::MonitorKey {
+            search_key: u_search_key,
+            entry_position: 0, // TODO
+            commitment_index: value.commitment_index.clone(),
+        });
+    }
+
+    Ok(request)
+}

--- a/src/key_transparency/websocket.rs
+++ b/src/key_transparency/websocket.rs
@@ -13,8 +13,8 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
 use libsignal_core::{Aci, E164};
 use libsignal_keytrans::{
-    ChatDistinguishedResponse, ChatSearchResponse, MonitorRequest,
-    MonitorResponse,
+    ChatDistinguishedResponse, ChatMonitorResponse, ChatSearchResponse,
+    MonitorRequest, MonitorResponse,
 };
 use prost::Message;
 use reqwest::Method;
@@ -338,6 +338,8 @@ impl SignalWebSocket<Unidentified> {
     pub async fn key_transparency_monitor(
         &mut self,
         request: &MonitorRequest,
+        last_non_distinguished_tree_head_size: Option<u64>,
+        last_distinguished_tree_head_size: Option<u64>,
     ) -> Result<MonitorResponse, KeyTransparencyWebSocketError> {
         let mut aci = None;
         let mut e164 = None;
@@ -405,16 +407,15 @@ impl SignalWebSocket<Unidentified> {
             )
         })?;
 
-        let consistency = request.consistency.as_ref();
+        let has_e164 = e164.is_some();
+        let has_username_hash = username_hash.is_some();
 
         let body = RawChatMonitorRequest {
             aci,
             e164,
             username_hash,
-            last_non_distinguished_tree_head_size: consistency
-                .and_then(|c| c.last),
-            last_distinguished_tree_head_size: consistency
-                .and_then(|c| c.distinguished),
+            last_non_distinguished_tree_head_size,
+            last_distinguished_tree_head_size,
         };
 
         let raw: RawChatMonitorResponse = self
@@ -425,7 +426,30 @@ impl SignalWebSocket<Unidentified> {
             .await?
             .json()
             .await?;
-        let response = MonitorResponse::decode(&*raw.serialized_response)?;
+        // The chat server sends a `ChatMonitorResponse` (per-identifier
+        // proofs); `verify_monitor` expects a `MonitorResponse` with proofs
+        // in request order. Map aci, then e164, then username_hash.
+        let chat = ChatMonitorResponse::decode(&*raw.serialized_response)?;
+        let mut proofs = Vec::with_capacity(
+            1 + has_e164 as usize + has_username_hash as usize,
+        );
+        let aci_proof = chat.aci.ok_or_else(|| {
+            KeyTransparencyWebSocketError::RequestError(
+                "missing ACI monitor proof",
+            )
+        })?;
+        proofs.push(aci_proof);
+        if let Some(p) = chat.e164 {
+            proofs.push(p);
+        }
+        if let Some(p) = chat.username_hash {
+            proofs.push(p);
+        }
+        let response = MonitorResponse {
+            tree_head: chat.tree_head,
+            proofs,
+            inclusion: chat.inclusion,
+        };
         Ok(response)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,9 @@ pub mod unidentified_access;
 pub mod utils;
 pub mod websocket;
 
+#[cfg(feature = "key-transparency")]
+pub mod key_transparency;
+
 pub use crate::account_manager::{
     decrypt_device_name, encrypt_device_name, AccountManager, Profile,
     ProfileManagerError,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,6 +27,17 @@ pub const BASE64_URL_SAFE_NO_PAD: base64::engine::GeneralPurpose =
             ),
     );
 
+/// Standard alphabet base64 without padding, used for KT monitor `commitmentIndex`.
+pub const BASE64_STANDARD_NO_PAD: base64::engine::GeneralPurpose =
+    base64::engine::GeneralPurpose::new(
+        &base64::alphabet::STANDARD,
+        base64::engine::GeneralPurposeConfig::new()
+            .with_encode_padding(false)
+            .with_decode_padding_mode(
+                base64::engine::DecodePaddingMode::Indifferent,
+            ),
+    );
+
 pub fn parse_aci_with_fallback(
     bytes: Option<&[u8]>,
     utf8: Option<&str>,
@@ -165,6 +176,34 @@ pub mod serde_base64 {
         use serde::de::Error;
         <&str>::deserialize(deserializer).and_then(|string| {
             BASE64_RELAXED
+                .decode(string)
+                .map_err(|err| Error::custom(err.to_string()))
+        })
+    }
+}
+
+/// Serde for standard-alphabet base64 encoded with no padding.
+/// Used for the KT monitor `commitmentIndex` field.
+pub mod serde_base64_no_pad {
+    use super::BASE64_STANDARD_NO_PAD;
+    use base64::prelude::*;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<T, S>(bytes: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: AsRef<[u8]>,
+        S: Serializer,
+    {
+        serializer.serialize_str(&BASE64_STANDARD_NO_PAD.encode(bytes.as_ref()))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+        <&str>::deserialize(deserializer).and_then(|string| {
+            BASE64_STANDARD_NO_PAD
                 .decode(string)
                 .map_err(|err| Error::custom(err.to_string()))
         })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,6 +16,17 @@ pub const BASE64_RELAXED: base64::engine::GeneralPurpose =
             ),
     );
 
+/// URL-safe base64 without padding, used for KT key identifiers.
+pub const BASE64_URL_SAFE_NO_PAD: base64::engine::GeneralPurpose =
+    base64::engine::GeneralPurpose::new(
+        &base64::alphabet::URL_SAFE,
+        base64::engine::GeneralPurposeConfig::new()
+            .with_encode_padding(false)
+            .with_decode_padding_mode(
+                base64::engine::DecodePaddingMode::Indifferent,
+            ),
+    );
+
 pub fn parse_aci_with_fallback(
     bytes: Option<&[u8]>,
     utf8: Option<&str>,
@@ -190,6 +201,45 @@ pub mod serde_optional_base64 {
         use serde::de::Error;
         match Option::<String>::deserialize(deserializer)? {
             Some(s) => BASE64_RELAXED
+                .decode(s)
+                .map_err(|err| Error::custom(err.to_string()))
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Serde helpers for optional base64url (no pad) encoded bytes.
+pub mod serde_optional_base64url {
+    use super::BASE64_URL_SAFE_NO_PAD;
+    use base64::prelude::*;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<T, S>(
+        bytes: &Option<T>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        T: AsRef<[u8]>,
+        S: Serializer,
+    {
+        match bytes {
+            Some(bytes) => {
+                serializer.serialize_str(&BASE64_URL_SAFE_NO_PAD.encode(bytes))
+            },
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<Option<Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+        match Option::<String>::deserialize(deserializer)? {
+            Some(s) => BASE64_URL_SAFE_NO_PAD
                 .decode(s)
                 .map_err(|err| Error::custom(err.to_string()))
                 .map(Some),


### PR DESCRIPTION
This is currently very much slop.

The goal is to test this with the example that's currently shipped. You can easily test this against your own key (which we should probably actually do in our apps):

```sh
cargo run --example key_transparency --features key-transparency -- --password $PASSWORD --aci $ACI --target-aci $ACI --target-identity $IDENTITY
```