### PR TITLE
feat: capture body in UnhandledResponseCode

### DIFF
--- a/src/push_service/error.rs
+++ b/src/push_service/error.rs
@@ -3,6 +3,7 @@ use libsignal_core::curve::CurveError;
 use libsignal_protocol::{
     FingerprintError, ServiceIdKind, SignalProtocolError,
 };
+use reqwest::StatusCode;
 use zkgroup::{ZkGroupDeserializationFailure, ZkGroupVerificationFailure};
 
 use crate::{
@@ -49,8 +50,9 @@ pub enum ServiceError {
     Unauthorized,
     #[error("Registration lock is set: {0:?}")]
     Locked(RegistrationLockFailure),
-    #[error("Unexpected response: HTTP {http_code}")]
-    UnhandledResponseCode { http_code: u16 },
+
+    #[error("Unexpected response: HTTP {status}: {body}")]
+    UnhandledResponseCode { status: StatusCode, body: String },
 
     #[error("Websocket error: {0}")]
     WsError(Box<reqwest_websocket::Error>),

--- a/src/push_service/response.rs
+++ b/src/push_service/response.rs
@@ -4,6 +4,20 @@ use crate::proto::WebSocketResponseMessage;
 
 use super::ServiceError;
 
+async fn json_or_unhandled<R, T>(response: R) -> Result<T, ServiceError>
+where
+    T: for<'de> serde::Deserialize<'de>,
+    R: SignalServiceResponse,
+    ServiceError: From<<R as SignalServiceResponse>::Error>,
+{
+    let status = response.status_code();
+    let body = response.text().await?;
+    serde_json::from_str(&body).map_err(move |error| {
+        tracing::error!(%error, "JSON decoding in error handling failed; returning UnhandledResponseCode");
+        ServiceError::UnhandledResponseCode { status, body }
+    })
+}
+
 pub(crate) async fn service_error_for_status<R>(
     response: R,
 ) -> Result<R, ServiceError>
@@ -42,46 +56,19 @@ where
             })
         },
         StatusCode::CONFLICT => {
-            let mismatched_devices =
-                response.json().await.map_err(|error| {
-                    tracing::error!(
-                        %error,
-                        "failed to decode HTTP 409 status"
-                    );
-                    ServiceError::UnhandledResponseCode {
-                        http_code: StatusCode::CONFLICT.as_u16(),
-                    }
-                })?;
+            let mismatched_devices = json_or_unhandled(response).await?;
             Err(ServiceError::MismatchedDevicesException(mismatched_devices))
         },
         StatusCode::GONE => {
-            let stale_devices = response.json().await.map_err(|error| {
-                tracing::error!(%error, "failed to decode HTTP 410 status");
-                ServiceError::UnhandledResponseCode {
-                    http_code: StatusCode::GONE.as_u16(),
-                }
-            })?;
+            let stale_devices = json_or_unhandled(response).await?;
             Err(ServiceError::StaleDevices(stale_devices))
         },
         StatusCode::LOCKED => {
-            let locked = response.json().await.map_err(|error| {
-                tracing::error!(%error, "failed to decode HTTP 423 status");
-                ServiceError::UnhandledResponseCode {
-                    http_code: StatusCode::LOCKED.as_u16(),
-                }
-            })?;
+            let locked = json_or_unhandled(response).await?;
             Err(ServiceError::Locked(locked))
         },
         StatusCode::PRECONDITION_REQUIRED => {
-            let proof_required = response.json().await.map_err(|error| {
-                tracing::error!(
-                    %error,
-                    "failed to decode HTTP 428 status"
-                );
-                ServiceError::UnhandledResponseCode {
-                    http_code: StatusCode::PRECONDITION_REQUIRED.as_u16(),
-                }
-            })?;
+            let proof_required = json_or_unhandled(response).await?;
             Err(ServiceError::ProofRequiredError(proof_required))
         },
         StatusCode::LENGTH_REQUIRED => {
@@ -91,15 +78,7 @@ where
                 max: u32,
             }
             let error: LinkedDeviceNumberError =
-                response.json().await.map_err(|error| {
-                    tracing::warn!(
-                        %error,
-                        "failed to decode linked device HTTP 411 status"
-                    );
-                    ServiceError::UnhandledResponseCode {
-                        http_code: StatusCode::LENGTH_REQUIRED.as_u16(),
-                    }
-                })?;
+                json_or_unhandled(response).await?;
             Err(ServiceError::DeviceLimitReached {
                 current: error.current,
                 max: error.max,
@@ -107,11 +86,9 @@ where
         },
         // XXX: fill in rest from PushServiceSocket
         code => {
-            let response_text = response.text().await?;
-            tracing::trace!(status_code =% code, body = response_text, "unhandled HTTP response");
-            Err(ServiceError::UnhandledResponseCode {
-                http_code: code.as_u16(),
-            })
+            let body = response.text().await?;
+            tracing::debug!(status_code = %code, %body, "unhandled HTTP response");
+            Err(ServiceError::UnhandledResponseCode { status: code, body })
         },
     }
 }

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -182,14 +182,24 @@ impl SignalWebSocketProcess {
                     } else if let Some(_x) =
                         self.outgoing_keep_alive_set.take(&id)
                     {
-                        let status_code = response.status();
-                        if status_code != 200 {
+                        let status = reqwest::StatusCode::from_u16(
+                            response.status() as _,
+                        )
+                        .map_err(|e| {
+                            ServiceError::IO(std::io::Error::other(format!(
+                                "invalid http status code {} - {e}",
+                                response.status()
+                            )))
+                        })?;
+                        if !status.is_success() {
                             tracing::warn!(
-                                status_code,
-                                "response code for keep-alive != 200"
+                                %status,
+                                "response code for keep-alive not successful"
                             );
                             return Err(ServiceError::UnhandledResponseCode {
-                                http_code: response.status() as u16,
+                                status,
+                                body: String::from_utf8_lossy(response.body())
+                                    .into_owned(),
                             });
                         }
                     } else {


### PR DESCRIPTION
Refactors service_error_for_status to always fall back to raw body processing in cases where the mechanical error handling fails.

Especially useful in debugging 400 Bad Request cases.