### PR TITLE
Tolerate plaintext device names

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -990,8 +990,23 @@ fn decrypt_device_name_from_device_info(
     string: &str,
     aci: &IdentityKeyPair,
 ) -> Result<String, ServiceError> {
-    let data = BASE64_RELAXED.decode(string)?;
-    let name = DeviceName::decode(&*data)?;
+    let Ok(data) = BASE64_RELAXED.decode(string) else {
+        tracing::trace!(
+            "Device name not base64 encoded, assuming plaintext: {}",
+            string.to_string()
+        );
+        return Ok(string.to_string());
+    };
+    let name = match DeviceName::decode(data.as_slice()) {
+        Ok(decoded) => decoded,
+        Err(_) => {
+            tracing::trace!(
+                "Decoding device name failed, assuming plaintext: {}",
+                string.to_string()
+            );
+            return Ok(string.to_string());
+        },
+    };
     crate::decrypt_device_name(aci.private_key(), &name)
 }
 


### PR DESCRIPTION
Apparently sometimes the device name can be plaintext, possibly not even base64 encoded, so let's not throw errors when that happens. This is visible in Whisperfish when opening linked devices list.