### PR TITLE
Send AEP to linked device

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -20,7 +20,6 @@ use tracing_futures::Instrument;
 use zkgroup::profiles::ProfileKey;
 
 use crate::content::ContentBody;
-use crate::master_key::MasterKey;
 use crate::pre_keys::{
     KyberPreKeyEntity, PreKeyEntity, PreKeysStore, SignedPreKeyEntity,
     PRE_KEY_BATCH_SIZE, PRE_KEY_MINIMUM,
@@ -28,7 +27,7 @@ use crate::pre_keys::{
 use crate::prelude::{MessageSender, MessageSenderError};
 use crate::proto::sync_message::PniChangeNumber;
 use crate::proto::{DeviceName, SyncMessage};
-use crate::provisioning::generate_registration_id;
+use crate::provisioning::{generate_registration_id, ProvisioningSecrets};
 use crate::push_service::{
     AvatarWrite, HttpAuthOverride, ReqwestExt, DEFAULT_DEVICE_ID,
 };
@@ -45,7 +44,7 @@ use crate::websocket::registration::{
 };
 use crate::websocket::{self, SignalWebSocket};
 use crate::{
-    configuration::{Endpoint, ServiceCredentials},
+    configuration::Endpoint,
     pre_keys::PreKeyState,
     profile_cipher::{ProfileCipher, ProfileCipherError},
     profile_name::ProfileName,
@@ -362,9 +361,16 @@ impl AccountManager {
         url: url::Url,
         aci_identity_store: &dyn IdentityKeyStore,
         pni_identity_store: &dyn IdentityKeyStore,
-        credentials: ServiceCredentials,
-        master_key: Option<MasterKey>,
+        secrets: ProvisioningSecrets,
     ) -> Result<(), ProvisioningError> {
+        let ProvisioningSecrets {
+            credentials,
+            master_key,
+            ephemeral_backup_key,
+            account_entropy_pool,
+            media_root_backup_key,
+        } = secrets;
+
         let query: HashMap<_, _> = url.query_pairs().collect();
         let ephemeral_id =
             query.get("uuid").ok_or(ProvisioningError::MissingUuid)?;
@@ -392,36 +398,37 @@ impl AccountManager {
 
         let provisioning_code = self.new_device_provisioning_code().await?;
 
+        // Same order as in Provisioning.proto for helping comparison.
         let msg = ProvisionMessage {
-            aci: credentials.aci.as_ref().map(|u| u.to_string()),
-            aci_binary: credentials.aci.map(|u| u.into_bytes().into()),
             aci_identity_key_public: Some(
                 aci_identity_key_pair.public_key().serialize().into_vec(),
             ),
             aci_identity_key_private: Some(
                 aci_identity_key_pair.private_key().serialize(),
             ),
-            number: Some(credentials.e164()),
             pni_identity_key_public: Some(
                 pni_identity_key_pair.public_key().serialize().into_vec(),
             ),
             pni_identity_key_private: Some(
                 pni_identity_key_pair.private_key().serialize(),
             ),
+            aci: credentials.aci.as_ref().map(|u| u.to_string()),
             pni: credentials.pni.as_ref().map(uuid::Uuid::to_string),
-            pni_binary: credentials.pni.map(|u| u.into_bytes().into()),
+            number: Some(credentials.e164()),
+            provisioning_code: Some(provisioning_code),
+            user_agent: None,
             profile_key: self.profile_key.as_ref().map(|x| x.bytes.to_vec()),
             // CURRENT is not exposed by prost :(
+            read_receipts: None,
             provisioning_version: Some(i32::from(
                 ProvisioningVersion::TabletSupport,
             ) as _),
-            provisioning_code: Some(provisioning_code),
-            read_receipts: None,
-            user_agent: None,
             master_key: master_key.map(|x| x.into()),
-            ephemeral_backup_key: None,
-            account_entropy_pool: None,
-            media_root_backup_key: None,
+            ephemeral_backup_key: ephemeral_backup_key.map(|k| k.to_vec()), // 32-bytes
+            account_entropy_pool: Some(account_entropy_pool.to_string()),
+            media_root_backup_key: media_root_backup_key.map(|k| k.to_vec()), // 32-bytes
+            aci_binary: credentials.aci.map(|u| u.into_bytes().into()),
+            pni_binary: credentials.pni.map(|u| u.into_bytes().into()),
         };
 
         let cipher = ProvisioningCipher::from_public(pub_key);

--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -24,6 +24,8 @@ use zkgroup::profiles::ProfileKey;
 
 use pipe::{ProvisioningPipe, ProvisioningStep};
 
+use crate::master_key::MasterKey;
+use crate::messagepipe::ServiceCredentials;
 use crate::prelude::ServiceError;
 use crate::push_service::linking::{
     LinkAccountAttributes, LinkCapabilities, LinkRequest, LinkResponse,
@@ -39,6 +41,14 @@ use crate::{
 pub use crate::proto::{
     ProvisionEnvelope, ProvisionMessage, ProvisioningVersion,
 };
+
+pub struct ProvisioningSecrets {
+    pub credentials: ServiceCredentials,
+    pub master_key: Option<MasterKey>,
+    pub ephemeral_backup_key: Option<[u8; 32]>,
+    pub account_entropy_pool: AccountEntropyPool,
+    pub media_root_backup_key: Option<[u8; 32]>,
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum ProvisioningError {


### PR DESCRIPTION
Linking another device requires master key and account entropy pool to be sent, so let's send them. Reordered the fields to proto file order, that makes this messier than it is. EBK and MRBK are still null-safe, apparently, and they require **a lot of** plumbing to get going, so have them as options now.

This raises the amount of parameters to 10 which means we probably should pass a struct instead...