### PR TITLE
fix: parse unsealed PlaintextContent envelopes in service cipher

### DIFF
--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -327,10 +327,13 @@ where
 
                     server_guid,
                 };
-                Plaintext {
-                    metadata,
-                    data: ciphertext.clone(),
-                }
+                // Unsealed envelope wrapping a PlaintextContent.
+                // Should contain a DecryptionErrorMessage.
+                let plaintext_content =
+                    PlaintextContent::try_from(&ciphertext[..])?;
+                let mut data = plaintext_content.body().to_vec();
+                strip_padding(&mut data)?;
+                Plaintext { metadata, data }
             },
             Type::Ciphertext => {
                 let sender = get_preferred_protocol_address(


### PR DESCRIPTION
The `Type::PlaintextContent` arm passed the raw wire bytes through as plaintext, leaving the `0xC0` identifier byte and ISO7816 padding attached, so the downstream Content `protobuf` decode always failed and the `DecryptionErrorMessage` inside was dropped. Peers asking for a session reset were never heard, leaving both sides stuck in a permanent decryption-failure loop.

Parse the envelope via `PlaintextContent::try_from` and strip the padding, matching what [bd585acc](https://github.com/whisperfish/libsignal-service-rs/pull/429) did for the sealed-sender path.

This is to address [issue 449](https://github.com/whisperfish/libsignal-service-rs/pull/429).

Full disclosure: I used AI in diagnosing and repairing this, but I have reviewed the code,  and have manually tested that it fixed my issue.