### PR TITLE
Sender keys

### DIFF
--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -33,6 +33,7 @@ use crate::push_service::{
     AvatarWrite, HttpAuthOverride, SignalServiceResponse, DEFAULT_DEVICE_ID,
 };
 use crate::sender::OutgoingPushMessage;
+use crate::sender_key_store_ext::SenderKeyStoreExt;
 use crate::service_address::ServiceIdExt;
 use crate::session_store::SessionStoreExt;
 use crate::timestamp::TimestampExt as _;
@@ -693,7 +694,12 @@ impl AccountManager {
         R: Rng + CryptoRng,
         AciStore: PreKeysStore + SessionStoreExt,
         PniStore: PreKeysStore,
-        AciOrPni: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone,
+        AciOrPni: ProtocolStore
+            + SenderKeyStore
+            + SenderKeyStoreExt
+            + SessionStoreExt
+            + Sync
+            + Clone,
     >(
         &mut self,
         aci_protocol_store: &mut AciStore,

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -4,14 +4,14 @@ use aes::cipher::block_padding::{Iso7816, Padding};
 use base64::prelude::*;
 use libsignal_core::ServiceIdKind;
 use libsignal_protocol::{
-    group_decrypt, message_decrypt_prekey, message_decrypt_signal,
-    message_encrypt, process_sender_key_distribution_message,
-    sealed_sender_decrypt_to_usmc, sealed_sender_encrypt,
-    CiphertextMessageType, DeviceId, IdentityKeyStore, KyberPreKeyStore,
-    PlaintextContent, Pni, PreKeySignalMessage, PreKeyStore, ProtocolAddress,
-    ProtocolStore, PublicKey, SealedSenderDecryptionResult, SenderCertificate,
-    SenderKeyDistributionMessage, SenderKeyStore, ServiceId, SessionNotFound,
-    SessionStore, SessionUsabilityRequirements, SignalMessage,
+    group_decrypt, group_encrypt, message_decrypt_prekey,
+    message_decrypt_signal, message_encrypt,
+    process_sender_key_distribution_message, sealed_sender_decrypt_to_usmc,
+    sealed_sender_encrypt, CiphertextMessageType, DeviceId, IdentityKeyStore,
+    KyberPreKeyStore, PlaintextContent, Pni, PreKeySignalMessage, PreKeyStore,
+    ProtocolAddress, ProtocolStore, PublicKey, SealedSenderDecryptionResult,
+    SenderCertificate, SenderKeyDistributionMessage, SenderKeyStore, ServiceId,
+    SessionNotFound, SessionStore, SessionUsabilityRequirements, SignalMessage,
     SignalProtocolError, SignedPreKeyStore, Timestamp,
     UnidentifiedSenderMessageContent,
 };
@@ -718,6 +718,37 @@ fn strip_padding(contents: &mut Vec<u8>) -> Result<(), ServiceError> {
     let new_length = Iso7816::raw_unpad(contents)?.len();
     contents.resize(new_length, 0);
     Ok(())
+}
+
+/// Pad and group-encrypt `content` for the sender-key chain identified by
+/// (`sender`, `distribution_id`), returning the serialized
+/// `SenderKeyMessage` bytes.
+///
+/// The send-side counterpart of the receive path's `group_decrypt` →
+/// `strip_padding` (`Type::UnidentifiedSender` arm): padding the plaintext
+/// here is what makes that unconditional strip reversible. Both ends live in
+/// this module so the v3 ISO 7816 padding invariant is structural, not a
+/// convention enforced across modules (the bug class that produced universal
+/// `DecryptionErrorMessage`s on first send when the pad was missed).
+pub(crate) async fn encrypt_sender_key_message<R: Rng + CryptoRng>(
+    sender_key_store: &mut dyn SenderKeyStore,
+    sender: &ProtocolAddress,
+    distribution_id: Uuid,
+    content: &[u8],
+    csprng: &mut R,
+) -> Result<Vec<u8>, ServiceError> {
+    // SenderKey messages always use the v3 pad; sealed-sender receive strips
+    // unconditionally (see `Type::UnidentifiedSender`).
+    let padded = add_padding(3, content)?;
+    let skm = group_encrypt(
+        sender_key_store,
+        sender,
+        distribution_id,
+        &padded,
+        csprng,
+    )
+    .await?;
+    Ok(skm.as_ref().to_vec())
 }
 
 /// Equivalent of `SignalServiceCipher::getPreferredProtocolAddress`

--- a/src/content.rs
+++ b/src/content.rs
@@ -1,6 +1,8 @@
 use chrono::Utc;
 use libsignal_core::DeviceId;
-use libsignal_protocol::{Pni, ProtocolAddress, ServiceId};
+use libsignal_protocol::{
+    Pni, ProtocolAddress, SenderKeyDistributionMessage, ServiceId,
+};
 use prost::Message;
 use std::fmt;
 use uuid::Uuid;
@@ -138,7 +140,10 @@ impl fmt::Display for ContentBody {
             Self::CallMessage(_) => write!(f, "CallMessage"),
             Self::ReceiptMessage(_) => write!(f, "ReceiptMessage"),
             Self::TypingMessage(_) => write!(f, "TypingMessage"),
-            // Self::SenderKeyDistributionMessage(_) => write!(f, "SenderKeyDistributionMessage"),
+            #[allow(deprecated)]
+            Self::SenderKeyDistributionMessage(_) => {
+                write!(f, "SenderKeyDistributionMessage")
+            },
             Self::DecryptionErrorMessage(_) => {
                 write!(f, "DecryptionErrorMessage")
             },
@@ -157,7 +162,8 @@ pub enum ContentBody {
     CallMessage(CallMessage),
     ReceiptMessage(ReceiptMessage),
     TypingMessage(TypingMessage),
-    // SenderKeyDistributionMessage(SenderKeyDistributionMessage),
+    #[deprecated = "SKDMs are constructed as side-car during group message delivery"]
+    SenderKeyDistributionMessage(Vec<u8>),
     DecryptionErrorMessage(DecryptionErrorMessage),
     StoryMessage(StoryMessage),
     EditMessage(EditMessage),
@@ -190,6 +196,17 @@ impl ContentBody {
                 Content::DecryptionErrorMessage(msg.encode_to_vec())
             },
             Self::StoryMessage(msg) => Content::StoryMessage(msg),
+            #[allow(deprecated)]
+            Self::SenderKeyDistributionMessage(msg) => {
+                tracing::warn!(
+                    "manually constructed SenderKeyDistributionMessage"
+                );
+                return crate::proto::Content {
+                    content: None,
+                    sender_key_distribution_message: Some(msg),
+                    pni_signature_message: None,
+                };
+            },
             Self::EditMessage(msg) => Content::EditMessage(msg),
         };
         crate::proto::Content {
@@ -219,9 +236,14 @@ impl_from_for_content_body!(SynchronizeMessage(SyncMessage));
 impl_from_for_content_body!(CallMessage(CallMessage));
 impl_from_for_content_body!(ReceiptMessage(ReceiptMessage));
 impl_from_for_content_body!(TypingMessage(TypingMessage));
-// impl_from_for_content_body!(SenderKeyDistributionMessage(
-//     SenderKeyDistributionMessage
-// ));
+impl From<SenderKeyDistributionMessage> for ContentBody {
+    fn from(msg: SenderKeyDistributionMessage) -> Self {
+        // Pre-serialize at construction to keep into_proto infallible.
+        // .as_ref() returns the already-serialized bytes.
+        #[allow(deprecated)]
+        ContentBody::SenderKeyDistributionMessage(msg.as_ref().to_vec())
+    }
+}
 // impl_from_for_content_body!(DecryptionErrorMessage(DecryptionErrorMessage));
 impl_from_for_content_body!(StoryMessage(StoryMessage));
 impl_from_for_content_body!(EditMessage(EditMessage));

--- a/src/content.rs
+++ b/src/content.rs
@@ -1,8 +1,6 @@
 use chrono::Utc;
 use libsignal_core::DeviceId;
-use libsignal_protocol::{
-    Pni, ProtocolAddress, SenderKeyDistributionMessage, ServiceId,
-};
+use libsignal_protocol::{Pni, ProtocolAddress, ServiceId};
 use prost::Message;
 use std::fmt;
 use uuid::Uuid;
@@ -140,10 +138,6 @@ impl fmt::Display for ContentBody {
             Self::CallMessage(_) => write!(f, "CallMessage"),
             Self::ReceiptMessage(_) => write!(f, "ReceiptMessage"),
             Self::TypingMessage(_) => write!(f, "TypingMessage"),
-            #[allow(deprecated)]
-            Self::SenderKeyDistributionMessage(_) => {
-                write!(f, "SenderKeyDistributionMessage")
-            },
             Self::DecryptionErrorMessage(_) => {
                 write!(f, "DecryptionErrorMessage")
             },
@@ -162,8 +156,6 @@ pub enum ContentBody {
     CallMessage(CallMessage),
     ReceiptMessage(ReceiptMessage),
     TypingMessage(TypingMessage),
-    #[deprecated = "SKDMs are constructed as side-car during group message delivery"]
-    SenderKeyDistributionMessage(Vec<u8>),
     DecryptionErrorMessage(DecryptionErrorMessage),
     StoryMessage(StoryMessage),
     EditMessage(EditMessage),
@@ -196,23 +188,10 @@ impl ContentBody {
                 Content::DecryptionErrorMessage(msg.encode_to_vec())
             },
             Self::StoryMessage(msg) => Content::StoryMessage(msg),
-            #[allow(deprecated)]
-            Self::SenderKeyDistributionMessage(msg) => {
-                tracing::warn!(
-                    "manually constructed SenderKeyDistributionMessage"
-                );
-                return crate::proto::Content {
-                    content: None,
-                    sender_key_distribution_message: Some(msg),
-                    pni_signature_message: None,
-                };
-            },
             Self::EditMessage(msg) => Content::EditMessage(msg),
         };
         crate::proto::Content {
             content: Some(inner),
-            // TODO: handle SKDM; ideally this is also "tacked on" when needed,
-            // and not handled as a separate message.
             sender_key_distribution_message: None,
             // PNI signature gets added down the message sender stream
             pni_signature_message: None,
@@ -236,14 +215,6 @@ impl_from_for_content_body!(SynchronizeMessage(SyncMessage));
 impl_from_for_content_body!(CallMessage(CallMessage));
 impl_from_for_content_body!(ReceiptMessage(ReceiptMessage));
 impl_from_for_content_body!(TypingMessage(TypingMessage));
-impl From<SenderKeyDistributionMessage> for ContentBody {
-    fn from(msg: SenderKeyDistributionMessage) -> Self {
-        // Pre-serialize at construction to keep into_proto infallible.
-        // .as_ref() returns the already-serialized bytes.
-        #[allow(deprecated)]
-        ContentBody::SenderKeyDistributionMessage(msg.as_ref().to_vec())
-    }
-}
 // impl_from_for_content_body!(DecryptionErrorMessage(DecryptionErrorMessage));
 impl_from_for_content_body!(StoryMessage(StoryMessage));
 impl_from_for_content_body!(EditMessage(EditMessage));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod provisioning;
 pub mod push_service;
 pub mod receiver;
 pub mod sender;
+pub mod sender_key_store_ext;
 pub mod service_address;
 pub mod session_store;
 mod storage_service;
@@ -37,6 +38,7 @@ pub use crate::account_manager::{
     decrypt_device_name, encrypt_device_name, AccountManager, Profile,
     ProfileManagerError,
 };
+pub use crate::sender_key_store_ext::SenderKeyStoreExt;
 pub use crate::service_address::*;
 pub use crate::storage_service::{StorageService, StorageServiceError};
 
@@ -68,6 +70,7 @@ pub mod prelude {
         push_service::{PushService, ServiceError},
         receiver::MessageReceiver,
         sender::{MessageSender, MessageSenderError},
+        sender_key_store_ext::SenderKeyStoreExt,
         session_store::SessionStoreExt,
     };
     #[cfg(feature = "phonenumber")]

--- a/src/push_service/mod.rs
+++ b/src/push_service/mod.rs
@@ -3,11 +3,12 @@ use std::{sync::LazyLock, time::Duration};
 use crate::{
     configuration::{Endpoint, ServiceCredentials, SignalServers},
     prelude::ServiceConfiguration,
-    utils::serde_device_id_vec,
+    utils::{serde_device_id_vec, serde_service_id_vec},
     websocket::{SignalWebSocket, WebSocketType},
 };
 
 use libsignal_core::DeviceId;
+use libsignal_protocol::ServiceId;
 use protobuf::ProtobufResponseExt;
 use reqwest::{Method, RequestBuilder};
 use reqwest_websocket::Upgrade;
@@ -70,6 +71,18 @@ pub struct MismatchedDevices {
 pub struct StaleDevices {
     #[serde(with = "serde_device_id_vec")]
     pub stale_devices: Vec<DeviceId>,
+}
+
+/// `PUT /v1/messages/multi_recipient` success response.
+///
+/// Mirrors `SendMultiRecipientMessageResponse` on the server: the service
+/// identifiers in the request that do not correspond to registered users. Only
+/// populated when a group send endorsement token was supplied.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendMultiRecipientMessageResponse {
+    #[serde(default, with = "serde_service_id_vec")]
+    pub uuids404: Vec<ServiceId>,
 }
 
 #[derive(Clone)]
@@ -291,5 +304,56 @@ mod tests {
     fn serde_json_form_empty_vec() {
         // If we're trying to send and empty payload, serde_json must be able to make a Vec out of it
         assert!(serde_json::to_vec(b"").is_ok());
+    }
+
+    #[test]
+    fn multi_recipient_response_decodes_uuids404() {
+        use super::{
+            AccountMismatchedDevices, AccountStaleDevices,
+            SendMultiRecipientMessageResponse,
+        };
+        use libsignal_protocol::{Aci, ServiceId};
+
+        // Stories: no uuids404 array is sent.
+        let story: SendMultiRecipientMessageResponse =
+            serde_json::from_str("{}").unwrap();
+        assert!(story.uuids404.is_empty());
+
+        let aci = Aci::from(uuid::Uuid::nil());
+        let pni = libsignal_protocol::Pni::from(uuid::Uuid::from_u128(
+            0x1234_5678_1234_5678_1234_5678_1234_5678,
+        ));
+        let json = format!(
+            r#"{{"uuids404":["{}","{}"]}}"#,
+            aci.service_id_string(),
+            pni.service_id_string()
+        );
+        let resp: SendMultiRecipientMessageResponse =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(resp.uuids404.len(), 2);
+        assert_eq!(resp.uuids404[0], ServiceId::Aci(aci));
+        assert_eq!(resp.uuids404[1], ServiceId::Pni(pni));
+
+        // 409 / 410 bodies carry the same per-recipient sub-shape as the 1:1
+        // endpoints, wrapped per-account.
+        let mismatched: Vec<AccountMismatchedDevices> = serde_json::from_str(
+            &format!(
+                r#"[{{"uuid":"{}","devices":{{"missingDevices":[1,2],"extraDevices":[3]}}}}]"#,
+                aci.service_id_string()
+            ),
+        )
+        .unwrap();
+        assert_eq!(mismatched.len(), 1);
+        assert_eq!(mismatched[0].uuid, ServiceId::Aci(aci));
+        assert_eq!(mismatched[0].devices.missing_devices.len(), 2);
+        assert_eq!(mismatched[0].devices.extra_devices.len(), 1);
+
+        let stale: Vec<AccountStaleDevices> = serde_json::from_str(&format!(
+            r#"[{{"uuid":"{}","devices":{{"staleDevices":[5]}}}}]"#,
+            aci.service_id_string()
+        ))
+        .unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].devices.stale_devices.len(), 1);
     }
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -11,7 +11,7 @@ use rand::{rng, CryptoRng, Rng};
 use tracing::{debug, error, info, trace, warn};
 use tracing_futures::Instrument;
 use uuid::Uuid;
-use zkgroup::GROUP_IDENTIFIER_LEN;
+use zkgroup::{groups::GroupSendFullToken, GROUP_IDENTIFIER_LEN};
 
 use crate::{
     cipher::{get_preferred_protocol_address, ServiceCipher},
@@ -28,8 +28,10 @@ use crate::{
     push_service::*,
     service_address::ServiceIdExt,
     session_store::SessionStoreExt,
-    unidentified_access::UnidentifiedAccess,
-    utils::{serde_device_id, serde_service_id},
+    unidentified_access::{
+        CombinedUnidentifiedSenderAccessKeys, UnidentifiedAccess,
+    },
+    utils::{serde_device_id, serde_service_id, BASE64_RELAXED},
     websocket::{self, SignalWebSocket},
 };
 
@@ -68,6 +70,65 @@ pub struct SentMessage {
     pub used_identity_key: IdentityKey,
     pub unidentified: bool,
     pub needs_sync: bool,
+}
+
+/// Authorization for `PUT /v1/messages/multi_recipient`.
+///
+/// For non-story multi-recipient sends Signal requires **exactly one** of:
+/// - a combined unidentified-access key (the bitwise XOR of every
+///   recipient's 16-byte UAK), sent base64-encoded in the
+///   `Unidentified-Access-Key` header, or
+/// - a group-send endorsement full token, sent base64-encoded in the
+///   `Group-Send-Token` header.
+///
+/// Stories carry neither header; pass `None` for `access` in
+/// [`MultiRecipientMessagesRequest`] when `story` is `true`.
+#[derive(Clone)]
+pub enum MultiRecipientAccess {
+    /// Combined unidentified-access keys.
+    UnidentifiedAccessKey(CombinedUnidentifiedSenderAccessKeys),
+    /// A group-send endorsement token covering the recipients.
+    GroupSendToken(GroupSendFullToken),
+}
+
+impl MultiRecipientAccess {
+    /// `(header name, base64-encoded value)` for the access strategy.
+    pub(crate) fn header(&self) -> (&'static str, String) {
+        use base64::Engine;
+        match self {
+            MultiRecipientAccess::UnidentifiedAccessKey(keys) => {
+                ("Unidentified-Access-Key", BASE64_RELAXED.encode(keys.0))
+            },
+            MultiRecipientAccess::GroupSendToken(token) => (
+                "Group-Send-Token",
+                BASE64_RELAXED.encode(zkgroup::serialize(token)),
+            ),
+        }
+    }
+}
+
+/// Request to `PUT /v1/messages/multi_recipient`.
+///
+/// `payload` is the raw Sealed Sender v2 multi-recipient message produced by
+/// `libsignal_protocol::sealed_sender_multi_recipient_encrypt`.
+///
+/// `timestamp`/`online`/`urgent`/`story` mirror the server's query parameters.
+pub struct MultiRecipientMessagesRequest<'a> {
+    /// Sender's timestamp for the envelope.
+    pub timestamp: u64,
+    /// Deliver only to recipients that are online when the message is sent.
+    pub online: bool,
+    /// Whether the message should trigger push notifications.
+    pub urgent: bool,
+    /// Story message: access tokens are not checked and sending to
+    /// nonexistent recipients is permitted.
+    pub story: bool,
+    /// Raw Sealed Sender v2 multi-recipient payload
+    /// (`application/vnd.signal-messenger.mrm`).
+    pub payload: &'a [u8],
+    /// `None` for stories; otherwise [`MultiRecipientAccess::UnidentifiedAccessKey`]
+    /// xor [`MultiRecipientAccess::GroupSendToken`].
+    pub access: Option<MultiRecipientAccess>,
 }
 
 /// Attachment specification to be used for uploading.

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -738,9 +738,9 @@ where
         let mut skr_recipients: Vec<(ServiceId, &UnidentifiedAccess)> = vec![];
         for (recipient, unidentified_access) in recipients {
             let all_sessions = self
-                .recipient_has_all_device_sessions(recipient)
+                .collect_recipient_sessions(*recipient)
                 .await
-                .unwrap_or(false);
+                .is_ok_and(|s| s.is_some());
             if all_sessions {
                 mrm_recipients.push((*recipient, unidentified_access));
             } else {
@@ -1250,36 +1250,22 @@ where
             // session for each destination, so a missing session aborts the
             // multi-recipient path for the whole call (caller falls back to
             // 1:1 for the affected recipients).
-            let mut dest_addresses: Vec<ProtocolAddress> = vec![];
-            let mut dest_sessions: Vec<SessionRecord> = vec![];
-            let mut missing_session = false;
+            let mut dests: Vec<(ProtocolAddress, SessionRecord)> = vec![];
             for (recipient, _) in recipients {
-                let devices =
-                    self.enumerate_recipient_devices(recipient).await?;
-                for &device_id in &devices {
-                    let addr = recipient.to_protocol_address(device_id);
-                    match self.protocol_store.load_session(&addr).await? {
-                        Some(s) => {
-                            dest_addresses.push(addr);
-                            dest_sessions.push(s);
-                        },
-                        None => {
-                            tracing::debug!(
-                                %addr,
-                                "no session; deferring to 1:1 fallback"
-                            );
-                            missing_session = true;
-                            break;
-                        },
-                    }
-                }
-                if missing_session {
-                    break;
+                match self.collect_recipient_sessions(*recipient).await? {
+                    Some(sessions) => dests.extend(sessions),
+                    None => {
+                        tracing::debug!(
+                            ?recipient,
+                            "no sessions for all devices; deferring to 1:1 fallback"
+                        );
+                        return Err(MessageSenderError::NoMessagesToSend);
+                    },
                 }
             }
-            if missing_session {
-                return Err(MessageSenderError::NoMessagesToSend);
-            }
+
+            let (dest_addresses, dest_sessions): (Vec<_>, Vec<_>) =
+                dests.into_iter().unzip();
 
             let dest_refs: Vec<&ProtocolAddress> =
                 dest_addresses.iter().collect();
@@ -1592,22 +1578,28 @@ where
         Ok(devices)
     }
 
-    /// Whether every enumerated device of `recipient` has a loaded session.
+    /// Load the sessions of every enumerated device of `recipient`, or
+    /// `None` if any device lacks one.
+    ///
     /// Used to decide multi-recipient eligibility: a recipient without a
-    /// complete session set is routed to the 1:1 path, which establishes the
-    /// missing sessions.
-    async fn recipient_has_all_device_sessions(
+    /// complete session set is routed to the 1:1 path, which establishes
+    /// the missing sessions.
+    async fn collect_recipient_sessions(
         &self,
-        recipient: &ServiceId,
-    ) -> Result<bool, MessageSenderError> {
-        let devices = self.enumerate_recipient_devices(recipient).await?;
-        for &device_id in &devices {
-            let addr = recipient.to_protocol_address(device_id);
-            if self.protocol_store.load_session(&addr).await?.is_none() {
-                return Ok(false);
-            }
+        recipient: ServiceId,
+    ) -> Result<Option<Vec<(ProtocolAddress, SessionRecord)>>, MessageSenderError>
+    {
+        let devices = self.enumerate_recipient_devices(&recipient).await?;
+        let mut sessions = Vec::with_capacity(devices.len());
+        for device_id in devices {
+            let addr = recipient.to_protocol_address(device_id)?;
+            let Some(session) = self.protocol_store.load_session(&addr).await?
+            else {
+                return Ok(None);
+            };
+            sessions.push((addr, session));
         }
-        Ok(true)
+        Ok(Some(sessions))
     }
 
     /// For every recipient device that does not yet have our SKDM for

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -3,9 +3,11 @@ use std::{collections::HashSet, time::SystemTime};
 use chrono::prelude::*;
 use libsignal_core::{curve::CurveError, InvalidDeviceId};
 use libsignal_protocol::{
-    process_prekey_bundle, Aci, DeviceId, IdentityKey, IdentityKeyPair, Pni,
+    create_sender_key_distribution_message, process_prekey_bundle,
+    sealed_sender_encrypt_from_usmc, Aci, CiphertextMessageType, ContentHint,
+    DeviceId, IdentityKey, IdentityKeyPair, Pni, ProtocolAddress,
     ProtocolStore, SenderCertificate, SenderKeyStore, ServiceId,
-    SessionNotFound, SignalProtocolError,
+    SessionNotFound, SignalProtocolError, UnidentifiedSenderMessageContent,
 };
 use rand::{rng, CryptoRng, Rng};
 use tracing::{debug, error, info, trace, warn};
@@ -514,24 +516,17 @@ where
         result
     }
 
-    /// Send a message to the recipients in a group.
+    /// Fallback: send to a group recipient using legacy 1:1 encryption per device.
     ///
-    /// Recipients are a list of tuples, each containing:
-    /// - The recipient's address
-    /// - The recipient's unidentified access
-    /// - Whether the recipient requires a PNI signature
-    #[tracing::instrument(
-        skip(self, recipients, message),
-        fields(recipients = recipients.as_ref().len()),
-    )]
-    pub async fn send_message_to_group(
+    /// Used when the recipient does not support sealed sender or when the
+    /// sender-key path cannot be used for a specific recipient.
+    async fn send_message_to_group_legacy_1to1(
         &mut self,
         recipients: impl AsRef<[(ServiceId, Option<UnidentifiedAccess>, bool)]>,
-        message: impl Into<ContentBody>,
+        content_body: &ContentBody,
         timestamp: u64,
         online: bool,
     ) -> Vec<SendMessageResult> {
-        let content_body: ContentBody = message.into();
         let mut results = vec![];
 
         let mut needs_sync_in_results = false;
@@ -543,7 +538,7 @@ where
                 .try_send_message(
                     *recipient,
                     unidentified_access.as_ref(),
-                    &content_body,
+                    content_body,
                     timestamp,
                     *include_pni_signature,
                     online,
@@ -579,6 +574,150 @@ where
                         &sync_message,
                         timestamp,
                         false, // XXX: maybe the sync device does want a PNI signature?
+                        false,
+                    )
+                    .await
+                {
+                    error!(%error, "failed to send a synchronization message");
+                }
+            } else {
+                error!("could not create sync message from a group message")
+            }
+        }
+
+        results
+    }
+
+    /// Send a message to the recipients in a group using sender keys.
+    ///
+    /// Recipients are a list of tuples, each containing:
+    /// - The recipient's address
+    /// - The recipient's unidentified access
+    /// - Whether the recipient requires a PNI signature
+    ///
+    /// `distribution_id` identifies the sender-key chain for this group. The
+    /// caller is responsible for rotation (generate a new UUID on member leave
+    /// or safety-number change).
+    #[tracing::instrument(
+        skip(self, recipients, message),
+        fields(recipients = recipients.as_ref().len(), dist_id = %distribution_id),
+    )]
+    pub async fn send_message_to_group(
+        &mut self,
+        distribution_id: Uuid,
+        recipients: impl AsRef<[(ServiceId, Option<UnidentifiedAccess>, bool)]>,
+        message: impl Into<ContentBody>,
+        timestamp: u64,
+        online: bool,
+    ) -> Vec<SendMessageResult> {
+        let content_body: ContentBody = message.into();
+
+        // Share SKDMs with any devices that haven't received them yet.
+        // XXX Ideally, we *attach* the SKDM to the message-to-be-sent.
+        //     This is an ugly hack
+        if let Err(e) = self
+            .share_sender_key_if_needed(
+                distribution_id,
+                timestamp,
+                recipients.as_ref(),
+            )
+            .await
+        {
+            return vec![Err(e)];
+        }
+
+        // Encode the content once.
+        use prost::Message;
+        let content_bytes = content_body.clone().into_proto().encode_to_vec();
+
+        let sender_address = match self
+            .local_aci
+            .to_protocol_address(self.device_id)
+        {
+            Ok(addr) => addr,
+            Err(e) => return vec![Err(MessageSenderError::InvalidDeviceId(e))],
+        };
+        // Pad + group-encrypt once for the whole group, inside `cipher.rs` so
+        // the send-side padding invariant stays co-located with the receive
+        // path's `strip_padding` (`Type::UnidentifiedSender` arm). See D.4.
+        let mut rng = rng();
+        let skm_serialized = match crate::cipher::encrypt_sender_key_message(
+            &mut self.protocol_store,
+            &sender_address,
+            distribution_id,
+            &content_bytes,
+            &mut rng,
+        )
+        .await
+        {
+            Ok(bytes) => bytes,
+            Err(e) => return vec![Err(MessageSenderError::ServiceError(e))],
+        };
+
+        let mut results: Vec<SendMessageResult> = vec![];
+        let mut needs_sync_in_results = false;
+
+        for (recipient, unidentified_access, _include_pni_signature) in
+            recipients.as_ref()
+        {
+            let Some(unidentified) = unidentified_access else {
+                // Fall back to legacy 1:1 for this recipient (no sealed-sender
+                // capability).
+                let legacy_results = self
+                    .send_message_to_group_legacy_1to1(
+                        std::slice::from_ref(&(*recipient, None, false)),
+                        &content_body,
+                        timestamp,
+                        online,
+                    )
+                    .await;
+                if let Some(Ok(SentMessage { needs_sync, .. })) =
+                    legacy_results.first()
+                {
+                    if *needs_sync {
+                        needs_sync_in_results = true;
+                    }
+                }
+                results.extend(legacy_results);
+                continue;
+            };
+
+            let result = self
+                .send_sender_key_to_recipient(
+                    *recipient,
+                    unidentified,
+                    &skm_serialized,
+                    timestamp,
+                    online,
+                )
+                .await;
+
+            match result {
+                Ok(SentMessage { needs_sync, .. }) if needs_sync => {
+                    needs_sync_in_results = true;
+                },
+                _ => (),
+            };
+            results.push(result);
+        }
+
+        // Multi-device sync transcript (unchanged from the legacy path).
+        if needs_sync_in_results || self.is_multi_device().await {
+            if let Some(sync_message) = self
+                .create_multi_device_sent_transcript_content(
+                    None,
+                    content_body.clone(),
+                    timestamp,
+                    &results,
+                )
+            {
+                if let Err(error) = self
+                    .try_send_message(
+                        self.local_aci.into(),
+                        None,
+                        &sync_message,
+                        timestamp,
+                        false,
                         false,
                     )
                     .await
@@ -647,6 +786,219 @@ where
         .await?;
 
         Ok(())
+    }
+
+    /// Build per-device sealed-sender SenderKey messages for a single recipient
+    /// and send them via the sealed-sender path with the full retry loop.
+    async fn send_sender_key_to_recipient(
+        &mut self,
+        recipient: ServiceId,
+        unidentified_access: &UnidentifiedAccess,
+        skm_serialized: &[u8],
+        timestamp: u64,
+        online: bool,
+    ) -> SendMessageResult {
+        // Retry up to 4 times (matches try_send_message).
+        use base64::Engine;
+        for _ in 0..4u8 {
+            let devices = self.enumerate_recipient_devices(&recipient).await?;
+
+            let mut recipient_messages = vec![];
+            for &device_id in &devices {
+                let dest_address =
+                    match recipient.to_protocol_address(device_id) {
+                        Ok(addr) => addr,
+                        Err(_) => continue,
+                    };
+
+                let session_record = match self
+                    .protocol_store
+                    .load_session(&dest_address)
+                    .await?
+                {
+                    Some(s) => s,
+                    None => {
+                        tracing::debug!(
+                            "no session for {dest_address}; skipping sender-key send"
+                        );
+                        continue;
+                    },
+                };
+
+                let registration_id = match session_record
+                    .remote_registration_id()
+                {
+                    Ok(id) => id,
+                    Err(e) => {
+                        tracing::debug!(%e, "failed to get registration id for {dest_address}");
+                        continue;
+                    },
+                };
+
+                let usmc = match UnidentifiedSenderMessageContent::new(
+                    CiphertextMessageType::SenderKey,
+                    unidentified_access.certificate.clone(),
+                    skm_serialized.to_vec(),
+                    ContentHint::Resendable,
+                    None,
+                ) {
+                    Ok(u) => u,
+                    Err(e) => {
+                        tracing::debug!(%e, "failed to build USMC for {dest_address}");
+                        continue;
+                    },
+                };
+
+                let mut rng = rng();
+                let sealed_bytes = match sealed_sender_encrypt_from_usmc(
+                    &dest_address,
+                    &usmc,
+                    &self.protocol_store,
+                    &mut rng,
+                )
+                .await
+                {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::debug!(%e, "failed to sealed-sender-encrypt for {dest_address}");
+                        continue;
+                    },
+                };
+
+                use crate::proto::envelope::Type;
+                recipient_messages.push(OutgoingPushMessage {
+                    r#type: Type::UnidentifiedSender as u32,
+                    destination_device_id: device_id,
+                    destination_registration_id: registration_id,
+                    content: BASE64_RELAXED.encode(sealed_bytes),
+                });
+            }
+
+            if recipient_messages.is_empty() {
+                return Err(MessageSenderError::NoMessagesToSend);
+            }
+
+            let messages = OutgoingPushMessages {
+                destination: recipient,
+                timestamp,
+                messages: recipient_messages,
+                online,
+            };
+
+            let send = self
+                .unidentified_ws
+                .send_messages_unidentified(messages, unidentified_access)
+                .await;
+
+            match send {
+                Ok(SendMessageResponse { needs_sync }) => {
+                    let used_identity_key = self
+                        .protocol_store
+                        .get_identity(
+                            &recipient
+                                .to_protocol_address(*DEFAULT_DEVICE_ID)?,
+                        )
+                        .await?
+                        .ok_or(MessageSenderError::UntrustedIdentity {
+                            address: recipient,
+                        })?;
+                    return Ok(SentMessage {
+                        recipient,
+                        used_identity_key,
+                        unidentified: true,
+                        needs_sync,
+                    });
+                },
+                Err(ServiceError::MismatchedDevicesException(ref m)) => {
+                    tracing::debug!("{:?}", m);
+                    for extra_device_id in &m.extra_devices {
+                        tracing::debug!(
+                            "dropping session with device {}",
+                            extra_device_id
+                        );
+                        self.protocol_store
+                            .delete_service_addr_device_session(
+                                &recipient
+                                    .to_protocol_address(*extra_device_id)?,
+                            )
+                            .await?;
+                    }
+
+                    for missing_device_id in &m.missing_devices {
+                        tracing::debug!(
+                            "creating session with missing device {}",
+                            missing_device_id
+                        );
+                        let remote_address = recipient
+                            .to_protocol_address(*missing_device_id)?;
+                        let mut rng = rng();
+                        let pre_key = self
+                            .identified_ws
+                            .get_pre_key(&recipient, *missing_device_id)
+                            .await?;
+
+                        process_prekey_bundle(
+                            &remote_address,
+                            &self
+                                .local_aci
+                                .to_protocol_address(self.device_id)
+                                .expect("valid device id"),
+                            &mut self.protocol_store.clone(),
+                            &mut self.protocol_store.clone(),
+                            &pre_key,
+                            SystemTime::now(),
+                            &mut rng,
+                        )
+                        .await
+                        .map_err(|e| {
+                            error!("failed to create session: {}", e);
+                            MessageSenderError::UntrustedIdentity {
+                                address: recipient,
+                            }
+                        })?;
+                    }
+                    // Loop to rebuild messages with the updated sessions.
+                },
+                Err(ServiceError::StaleDevices(ref m)) => {
+                    tracing::debug!("{:?}", m);
+                    for extra_device_id in &m.stale_devices {
+                        tracing::debug!(
+                            "dropping session with device {}",
+                            extra_device_id
+                        );
+                        self.protocol_store
+                            .delete_service_addr_device_session(
+                                &recipient
+                                    .to_protocol_address(*extra_device_id)?,
+                            )
+                            .await?;
+                    }
+                    // Loop to rebuild messages.
+                },
+                Err(ServiceError::ProofRequiredError(ref p)) => {
+                    tracing::debug!("{:?}", p);
+                    return Err(MessageSenderError::ProofRequired {
+                        token: p.token.clone(),
+                        options: p.options.clone(),
+                    });
+                },
+                Err(ServiceError::NotFoundError) => {
+                    tracing::debug!("Not found when sending a message");
+                    return Err(MessageSenderError::NotFound {
+                        service_id: recipient,
+                    });
+                },
+                Err(e) => {
+                    tracing::debug!(
+                        "Default error handler for ws.send_messages: {}",
+                        e
+                    );
+                    return Err(MessageSenderError::ServiceError(e));
+                },
+            }
+        }
+
+        Err(MessageSenderError::MaximumRetriesLimitExceeded)
     }
 
     /// Send a message (`content`) to an address (`recipient`).
@@ -1008,6 +1360,93 @@ where
         Ok(devices)
     }
 
+    /// For every recipient device that does not yet have our SKDM for
+    /// `distribution_id`, build it (idempotent: libsignal creates the chain on
+    /// first call) and send it as an identified 1:1
+    /// `ContentBody::SenderKeyDistributionMessage`. Mark each device shared on
+    /// success.
+    #[tracing::instrument(skip(self, recipients), fields(recipients = recipients.as_ref().len(), dist_id = %distribution_id))]
+    async fn share_sender_key_if_needed(
+        &mut self,
+        distribution_id: Uuid,
+        timestamp: u64,
+        recipients: &[(ServiceId, Option<UnidentifiedAccess>, bool)],
+    ) -> Result<(), MessageSenderError> {
+        let sender_address =
+            self.local_aci.to_protocol_address(self.device_id)?;
+
+        // PNI signatures are an individual-send concern (matches Signal-Android's
+        // IndividualSendJob); the SKDM is sender-key infrastructure, so we don't
+        // attach one here even when the recipient needs one.
+        for (recipient, unidentified_access, _include_pni_signature) in
+            recipients
+        {
+            // `try_send_message` fans out to *every* device of the recipient
+            // (and creates sessions for any the server knows about but we
+            // don't). So we send at most ONE SKDM per recipient, not one per
+            // device — otherwise a D-device recipient gets the SKDM D times.
+            let devices = self.enumerate_recipient_devices(recipient).await?;
+            let mut needs_share = false;
+            for &device_id in &devices {
+                let recipient_address =
+                    match (*recipient).to_protocol_address(device_id) {
+                        Ok(a) => a,
+                        Err(_) => {
+                            needs_share = true;
+                            break;
+                        },
+                    };
+                if !self
+                    .protocol_store
+                    .is_sender_key_shared(distribution_id, &recipient_address)
+                    .await?
+                {
+                    needs_share = true;
+                }
+            }
+            if !needs_share {
+                continue;
+            }
+
+            let mut rng = rng();
+            let skdm = create_sender_key_distribution_message(
+                &sender_address,
+                distribution_id,
+                &mut self.protocol_store,
+                &mut rng,
+            )
+            .await?;
+
+            let body = ContentBody::from(skdm);
+            let _result = self
+                .try_send_message(
+                    *recipient,
+                    unidentified_access.as_ref(),
+                    &body,
+                    timestamp,
+                    false,
+                    false,
+                )
+                .await?;
+            // `try_send_message` may have established sessions with
+            // devices we didn't know about; re-enumerate so we mark
+            // the *complete* device set shared.
+            let devices_after =
+                self.enumerate_recipient_devices(recipient).await?;
+            for &device_id in &devices_after {
+                let recipient_address =
+                    (*recipient).to_protocol_address(device_id)?;
+                self.protocol_store
+                    .mark_sender_key_shared(distribution_id, &recipient_address)
+                    .await?;
+            }
+        }
+
+        // No SKDM sync transcript.
+
+        Ok(())
+    }
+
     // Equivalent with `getEncryptedMessages`
     #[tracing::instrument(
         level = "trace",
@@ -1253,5 +1692,50 @@ where
             })),
             ..SyncMessage::with_padding(&mut rng())
         }))
+    }
+
+    /// Handle an inbound `DecryptionErrorMessage` for sender-key recovery.
+    ///
+    /// When `ratchet_key` is `None`, the failure was a `SenderKeyMessage`
+    /// decryption (a `DecryptionErrorMessage` built from a `SenderKeyMessage`
+    /// carries no ratchet key). In that case we clear all shared sender-key
+    /// state for `sender`, so the next group send re-distributes the SKDM
+    /// and re-sends the payload to them.
+    ///
+    /// When `ratchet_key` is `Some`, the failure was a 1:1 `Whisper`/`PreKey`
+    /// message; that's session-recovery territory, not sender keys, and this
+    /// method is a no-op for it.
+    ///
+    /// This does NOT reset the 1:1 session.
+    ///
+    /// `error` is the *proto* `DecryptionErrorMessage` (as received on the wire
+    /// and surfaced via `ContentBody::DecryptionErrorMessage`); we re-derive
+    /// the `libsignal_protocol` type to inspect `ratchet_key`.
+    #[tracing::instrument(skip(self))]
+    pub async fn handle_decryption_error_message(
+        &mut self,
+        error: &crate::proto::DecryptionErrorMessage,
+        sender: &ProtocolAddress,
+    ) -> Result<(), MessageSenderError> {
+        use prost::Message as _;
+        let bytes = error.encode_to_vec();
+        let crypto_error =
+            libsignal_protocol::DecryptionErrorMessage::try_from(&bytes[..])
+                .map_err(MessageSenderError::ProtocolError)?;
+        if crypto_error.ratchet_key().is_some() {
+            tracing::trace!(
+                ?sender,
+                "DecryptionErrorMessage has a ratchet key; 1:1 session recovery, not sender keys"
+            );
+            return Ok(());
+        }
+        tracing::info!(
+            ?sender,
+            "SenderKey DecryptionErrorMessage from; clearing shared state so next send re-shares"
+        );
+        self.protocol_store
+            .clear_sender_key_shared_for_address(sender)
+            .await?;
+        Ok(())
     }
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -26,6 +26,7 @@ use crate::{
         AttachmentPointer, SyncMessage,
     },
     push_service::*,
+    sender_key_store_ext::SenderKeyStoreExt,
     service_address::ServiceIdExt,
     session_store::SessionStoreExt,
     unidentified_access::{
@@ -223,7 +224,12 @@ pub struct EncryptedMessages {
 
 impl<S> MessageSender<S>
 where
-    S: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone,
+    S: ProtocolStore
+        + SenderKeyStore
+        + SenderKeyStoreExt
+        + SessionStoreExt
+        + Sync
+        + Clone,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -966,20 +972,15 @@ where
         })
     }
 
-    // Equivalent with `getEncryptedMessages`
-    #[tracing::instrument(
-        level = "trace",
-        skip(self, unidentified_access, content),
-        fields(unidentified_access = unidentified_access.is_some(), recipient = recipient.service_id_string()),
-    )]
-    async fn create_encrypted_messages(
-        &mut self,
+    /// Enumerate all known devices for a recipient, always including the primary
+    /// device, never including the local sender device.
+    ///
+    /// Mirrors Java's group-send device enumeration: the local device is excluded
+    /// because we never need to send to ourselves.
+    async fn enumerate_recipient_devices(
+        &self,
         recipient: &ServiceId,
-        unidentified_access: Option<&SenderCertificate>,
-        content: &[u8],
-    ) -> Result<Option<EncryptedMessages>, MessageSenderError> {
-        let mut messages = vec![];
-
+    ) -> Result<HashSet<DeviceId>, MessageSenderError> {
         let mut devices: HashSet<DeviceId> = self
             .protocol_store
             .get_sub_device_sessions(recipient)
@@ -1003,6 +1004,25 @@ where
                 }
             },
         };
+
+        Ok(devices)
+    }
+
+    // Equivalent with `getEncryptedMessages`
+    #[tracing::instrument(
+        level = "trace",
+        skip(self, unidentified_access, content),
+        fields(unidentified_access = unidentified_access.is_some(), recipient = recipient.service_id_string()),
+    )]
+    async fn create_encrypted_messages(
+        &mut self,
+        recipient: &ServiceId,
+        unidentified_access: Option<&SenderCertificate>,
+        content: &[u8],
+    ) -> Result<Option<EncryptedMessages>, MessageSenderError> {
+        let mut messages = vec![];
+
+        let devices = self.enumerate_recipient_devices(recipient).await?;
 
         for device_id in devices {
             trace!("sending message to device {}", device_id);

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -828,6 +828,61 @@ where
         }
     }
 
+    /// Repair sessions with a recipient's devices after a server-reported
+    /// device mismatch (`MismatchedDevicesException`/`StaleDevices`): drop
+    /// sessions for devices the server does not expect (`extra_devices`)
+    /// and establish sessions with devices we did not know about
+    /// (`missing_devices`), so the caller can rebuild and retry the send.
+    async fn repair_recipient_sessions(
+        &mut self,
+        recipient: ServiceId,
+        extra_devices: &[DeviceId],
+        missing_devices: &[DeviceId],
+    ) -> Result<(), MessageSenderError> {
+        for device_id in extra_devices {
+            tracing::debug!("dropping session with device {}", device_id);
+            self.protocol_store
+                .delete_service_addr_device_session(
+                    &recipient.to_protocol_address(*device_id)?,
+                )
+                .await?;
+        }
+
+        let mut rng = rng();
+
+        for device_id in missing_devices {
+            tracing::debug!(
+                "creating session with missing device {}",
+                device_id
+            );
+            let remote_address = recipient.to_protocol_address(*device_id)?;
+            let pre_key = self
+                .identified_ws
+                .get_pre_key(&recipient, *device_id)
+                .await?;
+
+            process_prekey_bundle(
+                &remote_address,
+                &self
+                    .local_aci
+                    .to_protocol_address(self.device_id)
+                    .expect("valid device id"),
+                &mut self.protocol_store.clone(),
+                &mut self.protocol_store,
+                &pre_key,
+                SystemTime::now(),
+                &mut rng,
+            )
+            .await
+            .map_err(|e| {
+                error!(%e, ?recipient, "failed to create session");
+                MessageSenderError::UntrustedIdentity { address: recipient }
+            })?;
+        }
+
+        Ok(())
+    }
+
     /// Handle the `Err` arm of a websocket send, shared by the sender-key and
     /// 1:1 send retry loops. Performs session bookkeeping for
     /// `MismatchedDevicesException`/`StaleDevices` so the caller can rebuild and
@@ -840,66 +895,22 @@ where
         match err {
             ServiceError::MismatchedDevicesException(ref m) => {
                 tracing::debug!("{:?}", m);
-                for extra_device_id in &m.extra_devices {
-                    tracing::debug!(
-                        "dropping session with device {}",
-                        extra_device_id
-                    );
-                    self.protocol_store
-                        .delete_service_addr_device_session(
-                            &recipient.to_protocol_address(*extra_device_id)?,
-                        )
-                        .await?;
-                }
-
-                for missing_device_id in &m.missing_devices {
-                    tracing::debug!(
-                        "creating session with missing device {}",
-                        missing_device_id
-                    );
-                    let remote_address =
-                        recipient.to_protocol_address(*missing_device_id)?;
-                    let mut rng = rng();
-                    let pre_key = self
-                        .identified_ws
-                        .get_pre_key(&recipient, *missing_device_id)
-                        .await?;
-
-                    process_prekey_bundle(
-                        &remote_address,
-                        &self
-                            .local_aci
-                            .to_protocol_address(self.device_id)
-                            .expect("valid device id"),
-                        &mut self.protocol_store.clone(),
-                        &mut self.protocol_store,
-                        &pre_key,
-                        SystemTime::now(),
-                        &mut rng,
-                    )
-                    .await
-                    .map_err(|e| {
-                        error!("failed to create session: {}", e);
-                        MessageSenderError::UntrustedIdentity {
-                            address: recipient,
-                        }
-                    })?;
-                }
+                self.repair_recipient_sessions(
+                    recipient,
+                    &m.extra_devices,
+                    &m.missing_devices,
+                )
+                .await?;
                 Ok(SendRecovery::Retry)
             },
             ServiceError::StaleDevices(ref m) => {
                 tracing::debug!("{:?}", m);
-                for extra_device_id in &m.stale_devices {
-                    tracing::debug!(
-                        "dropping session with device {}",
-                        extra_device_id
-                    );
-                    self.protocol_store
-                        .delete_service_addr_device_session(
-                            &recipient.to_protocol_address(*extra_device_id)?,
-                        )
-                        .await?;
-                }
+                self.repair_recipient_sessions(
+                    recipient,
+                    &m.stale_devices,
+                    &[],
+                )
+                .await?;
                 Ok(SendRecovery::Retry)
             },
             ServiceError::ProofRequiredError(ref p) => {
@@ -941,49 +952,18 @@ where
         match err {
             ServiceError::MultiRecipientMismatchedDevices(accounts) => {
                 for account in &accounts {
-                    let recipient = account.uuid;
                     tracing::debug!(
-                        ?recipient,
+                        ?account.uuid,
                         extra = ?account.devices.extra_devices,
                         missing = ?account.devices.missing_devices,
                         "multi-recipient mismatched devices",
                     );
-                    for extra_device_id in &account.devices.extra_devices {
-                        self.protocol_store
-                            .delete_service_addr_device_session(
-                                &recipient
-                                    .to_protocol_address(*extra_device_id)?,
-                            )
-                            .await?;
-                    }
-                    for missing_device_id in &account.devices.missing_devices {
-                        let remote_address = recipient
-                            .to_protocol_address(*missing_device_id)?;
-                        let mut rng = rng();
-                        let pre_key = self
-                            .identified_ws
-                            .get_pre_key(&recipient, *missing_device_id)
-                            .await?;
-                        process_prekey_bundle(
-                            &remote_address,
-                            &self
-                                .local_aci
-                                .to_protocol_address(self.device_id)
-                                .expect("valid device id"),
-                            &mut self.protocol_store.clone(),
-                            &mut self.protocol_store,
-                            &pre_key,
-                            SystemTime::now(),
-                            &mut rng,
-                        )
-                        .await
-                        .map_err(|e| {
-                            error!(%e, ?recipient, "failed to create session");
-                            MessageSenderError::UntrustedIdentity {
-                                address: recipient,
-                            }
-                        })?;
-                    }
+                    self.repair_recipient_sessions(
+                        account.uuid,
+                        &account.devices.extra_devices,
+                        &account.devices.missing_devices,
+                    )
+                    .await?;
                 }
                 Ok(SendRecovery::Retry)
             },
@@ -994,15 +974,12 @@ where
                         stale = ?account.devices.stale_devices,
                         "multi-recipient stale devices",
                     );
-                    for stale_device_id in &account.devices.stale_devices {
-                        self.protocol_store
-                            .delete_service_addr_device_session(
-                                &account
-                                    .uuid
-                                    .to_protocol_address(*stale_device_id)?,
-                            )
-                            .await?;
-                    }
+                    self.repair_recipient_sessions(
+                        account.uuid,
+                        &account.devices.stale_devices,
+                        &[],
+                    )
+                    .await?;
                 }
                 Ok(SendRecovery::Retry)
             },

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -221,7 +221,13 @@ pub enum ThreadIdentifier {
 #[derive(Debug)]
 pub struct EncryptedMessages {
     messages: Vec<OutgoingPushMessage>,
-    used_identity_key: IdentityKey,
+}
+
+/// Outcome of attempting to recover from a send error: retry the loop, or
+/// give up and propagate.
+enum SendRecovery {
+    Retry,
+    Terminal(MessageSenderError),
 }
 
 impl<S> MessageSender<S>
@@ -788,6 +794,145 @@ where
         Ok(())
     }
 
+    /// Handle the `Err` arm of a websocket send, shared by the sender-key and
+    /// 1:1 send retry loops. Performs session bookkeeping for
+    /// `MismatchedDevicesException`/`StaleDevices` so the caller can rebuild and
+    /// retry; all other errors are terminal.
+    async fn recover_from_send_error(
+        &mut self,
+        recipient: ServiceId,
+        err: ServiceError,
+    ) -> Result<SendRecovery, MessageSenderError> {
+        match err {
+            ServiceError::MismatchedDevicesException(ref m) => {
+                tracing::debug!("{:?}", m);
+                for extra_device_id in &m.extra_devices {
+                    tracing::debug!(
+                        "dropping session with device {}",
+                        extra_device_id
+                    );
+                    self.protocol_store
+                        .delete_service_addr_device_session(
+                            &recipient.to_protocol_address(*extra_device_id)?,
+                        )
+                        .await?;
+                }
+
+                for missing_device_id in &m.missing_devices {
+                    tracing::debug!(
+                        "creating session with missing device {}",
+                        missing_device_id
+                    );
+                    let remote_address =
+                        recipient.to_protocol_address(*missing_device_id)?;
+                    let mut rng = rng();
+                    let pre_key = self
+                        .identified_ws
+                        .get_pre_key(&recipient, *missing_device_id)
+                        .await?;
+
+                    process_prekey_bundle(
+                        &remote_address,
+                        &self
+                            .local_aci
+                            .to_protocol_address(self.device_id)
+                            .expect("valid device id"),
+                        &mut self.protocol_store.clone(),
+                        &mut self.protocol_store,
+                        &pre_key,
+                        SystemTime::now(),
+                        &mut rng,
+                    )
+                    .await
+                    .map_err(|e| {
+                        error!("failed to create session: {}", e);
+                        MessageSenderError::UntrustedIdentity {
+                            address: recipient,
+                        }
+                    })?;
+                }
+                Ok(SendRecovery::Retry)
+            },
+            ServiceError::StaleDevices(ref m) => {
+                tracing::debug!("{:?}", m);
+                for extra_device_id in &m.stale_devices {
+                    tracing::debug!(
+                        "dropping session with device {}",
+                        extra_device_id
+                    );
+                    self.protocol_store
+                        .delete_service_addr_device_session(
+                            &recipient.to_protocol_address(*extra_device_id)?,
+                        )
+                        .await?;
+                }
+                Ok(SendRecovery::Retry)
+            },
+            ServiceError::ProofRequiredError(ref p) => {
+                tracing::debug!("{:?}", p);
+                Ok(SendRecovery::Terminal(MessageSenderError::ProofRequired {
+                    token: p.token.clone(),
+                    options: p.options.clone(),
+                }))
+            },
+            ServiceError::NotFoundError => {
+                tracing::debug!("Not found when sending a message");
+                Ok(SendRecovery::Terminal(MessageSenderError::NotFound {
+                    service_id: recipient,
+                }))
+            },
+            e => {
+                tracing::debug!(
+                    "Default error handler for ws.send_messages: {}",
+                    e
+                );
+                Ok(SendRecovery::Terminal(MessageSenderError::ServiceError(e)))
+            },
+        }
+    }
+
+    /// Dispatch a built `OutgoingPushMessages` to the websocket, via the
+    /// unidentified channel when `unidentified_access` is supplied, else the
+    /// identified channel.
+    async fn dispatch_outgoing(
+        &mut self,
+        messages: OutgoingPushMessages,
+        unidentified_access: Option<&UnidentifiedAccess>,
+    ) -> Result<SendMessageResponse, ServiceError> {
+        if let Some(unidentified) = unidentified_access {
+            tracing::debug!("sending via unidentified");
+            self.unidentified_ws
+                .send_messages_unidentified(messages, unidentified)
+                .await
+        } else {
+            tracing::debug!("sending identified");
+            self.identified_ws.send_messages(messages).await
+        }
+    }
+
+    /// Build the `SentMessage` result after a successful dispatch, looking up
+    /// the recipient's identity key on the default device.
+    async fn build_sent_message(
+        &mut self,
+        recipient: ServiceId,
+        unidentified: bool,
+        needs_sync: bool,
+    ) -> Result<SentMessage, MessageSenderError> {
+        let used_identity_key = self
+            .protocol_store
+            .get_identity(&recipient.to_protocol_address(*DEFAULT_DEVICE_ID)?)
+            .await?
+            .ok_or(MessageSenderError::UntrustedIdentity {
+                address: recipient,
+            })?;
+        Ok(SentMessage {
+            recipient,
+            used_identity_key,
+            unidentified,
+            needs_sync,
+        })
+    }
+
     /// Build per-device sealed-sender SenderKey messages for a single recipient
     /// and send them via the sealed-sender path with the full retry loop.
     async fn send_sender_key_to_recipient(
@@ -798,202 +943,161 @@ where
         timestamp: u64,
         online: bool,
     ) -> SendMessageResult {
-        // Retry up to 4 times (matches try_send_message).
         use base64::Engine;
-        for _ in 0..4u8 {
-            let devices = self.enumerate_recipient_devices(&recipient).await?;
 
-            let mut recipient_messages = vec![];
-            for &device_id in &devices {
-                let dest_address =
-                    match recipient.to_protocol_address(device_id) {
-                        Ok(addr) => addr,
-                        Err(_) => continue,
+        self.send_with_retries(
+            recipient,
+            Some(unidentified_access),
+            timestamp,
+            online,
+            // Sender-key payloads ride the unidentified (sealed-sender)
+            // channel only; there is no identified fallback for them.
+            false,
+            async |sender, _certificate| {
+                let devices = sender
+                    .enumerate_recipient_devices(&recipient)
+                    .await?;
+
+                let mut recipient_messages = vec![];
+                for &device_id in &devices {
+                    let dest_address =
+                        match recipient.to_protocol_address(device_id) {
+                            Ok(addr) => addr,
+                            Err(_) => continue,
+                        };
+
+                    let session_record = sender
+                        .protocol_store
+                        .load_session(&dest_address)
+                        .await?;
+                    let session_record = match session_record {
+                        Some(s) => s,
+                        None => {
+                            tracing::debug!(
+                                "no session for {dest_address}; skipping sender-key send"
+                            );
+                            continue;
+                        },
                     };
 
-                let session_record = match self
-                    .protocol_store
-                    .load_session(&dest_address)
-                    .await?
-                {
-                    Some(s) => s,
-                    None => {
-                        tracing::debug!(
-                            "no session for {dest_address}; skipping sender-key send"
-                        );
-                        continue;
-                    },
-                };
+                    let registration_id =
+                        match session_record.remote_registration_id() {
+                            Ok(id) => id,
+                            Err(e) => {
+                                tracing::debug!(%e, "failed to get registration id for {dest_address}");
+                                continue;
+                            },
+                        };
 
-                let registration_id = match session_record
-                    .remote_registration_id()
-                {
-                    Ok(id) => id,
-                    Err(e) => {
-                        tracing::debug!(%e, "failed to get registration id for {dest_address}");
-                        continue;
-                    },
-                };
+                    let usmc = match UnidentifiedSenderMessageContent::new(
+                        CiphertextMessageType::SenderKey,
+                        unidentified_access.certificate.clone(),
+                        skm_serialized.to_vec(),
+                        ContentHint::Resendable,
+                        None,
+                    ) {
+                        Ok(u) => u,
+                        Err(e) => {
+                            tracing::debug!(%e, "failed to build USMC for {dest_address}");
+                            continue;
+                        },
+                    };
 
-                let usmc = match UnidentifiedSenderMessageContent::new(
-                    CiphertextMessageType::SenderKey,
-                    unidentified_access.certificate.clone(),
-                    skm_serialized.to_vec(),
-                    ContentHint::Resendable,
-                    None,
-                ) {
-                    Ok(u) => u,
-                    Err(e) => {
-                        tracing::debug!(%e, "failed to build USMC for {dest_address}");
-                        continue;
-                    },
-                };
-
-                let mut rng = rng();
-                let sealed_bytes = match sealed_sender_encrypt_from_usmc(
-                    &dest_address,
-                    &usmc,
-                    &self.protocol_store,
-                    &mut rng,
-                )
-                .await
-                {
-                    Ok(b) => b,
-                    Err(e) => {
-                        tracing::debug!(%e, "failed to sealed-sender-encrypt for {dest_address}");
-                        continue;
-                    },
-                };
-
-                use crate::proto::envelope::Type;
-                recipient_messages.push(OutgoingPushMessage {
-                    r#type: Type::UnidentifiedSender as u32,
-                    destination_device_id: device_id,
-                    destination_registration_id: registration_id,
-                    content: BASE64_RELAXED.encode(sealed_bytes),
-                });
-            }
-
-            if recipient_messages.is_empty() {
-                return Err(MessageSenderError::NoMessagesToSend);
-            }
-
-            let messages = OutgoingPushMessages {
-                destination: recipient,
-                timestamp,
-                messages: recipient_messages,
-                online,
-            };
-
-            let send = self
-                .unidentified_ws
-                .send_messages_unidentified(messages, unidentified_access)
-                .await;
-
-            match send {
-                Ok(SendMessageResponse { needs_sync }) => {
-                    let used_identity_key = self
-                        .protocol_store
-                        .get_identity(
-                            &recipient
-                                .to_protocol_address(*DEFAULT_DEVICE_ID)?,
-                        )
-                        .await?
-                        .ok_or(MessageSenderError::UntrustedIdentity {
-                            address: recipient,
-                        })?;
-                    return Ok(SentMessage {
-                        recipient,
-                        used_identity_key,
-                        unidentified: true,
-                        needs_sync,
-                    });
-                },
-                Err(ServiceError::MismatchedDevicesException(ref m)) => {
-                    tracing::debug!("{:?}", m);
-                    for extra_device_id in &m.extra_devices {
-                        tracing::debug!(
-                            "dropping session with device {}",
-                            extra_device_id
-                        );
-                        self.protocol_store
-                            .delete_service_addr_device_session(
-                                &recipient
-                                    .to_protocol_address(*extra_device_id)?,
-                            )
-                            .await?;
-                    }
-
-                    for missing_device_id in &m.missing_devices {
-                        tracing::debug!(
-                            "creating session with missing device {}",
-                            missing_device_id
-                        );
-                        let remote_address = recipient
-                            .to_protocol_address(*missing_device_id)?;
-                        let mut rng = rng();
-                        let pre_key = self
-                            .identified_ws
-                            .get_pre_key(&recipient, *missing_device_id)
-                            .await?;
-
-                        process_prekey_bundle(
-                            &remote_address,
-                            &self
-                                .local_aci
-                                .to_protocol_address(self.device_id)
-                                .expect("valid device id"),
-                            &mut self.protocol_store.clone(),
-                            &mut self.protocol_store.clone(),
-                            &pre_key,
-                            SystemTime::now(),
+                    let mut rng = rng();
+                    let sealed_bytes =
+                        match sealed_sender_encrypt_from_usmc(
+                            &dest_address,
+                            &usmc,
+                            &sender.protocol_store,
                             &mut rng,
                         )
                         .await
-                        .map_err(|e| {
-                            error!("failed to create session: {}", e);
-                            MessageSenderError::UntrustedIdentity {
-                                address: recipient,
-                            }
-                        })?;
-                    }
-                    // Loop to rebuild messages with the updated sessions.
-                },
-                Err(ServiceError::StaleDevices(ref m)) => {
-                    tracing::debug!("{:?}", m);
-                    for extra_device_id in &m.stale_devices {
-                        tracing::debug!(
-                            "dropping session with device {}",
-                            extra_device_id
-                        );
-                        self.protocol_store
-                            .delete_service_addr_device_session(
-                                &recipient
-                                    .to_protocol_address(*extra_device_id)?,
-                            )
-                            .await?;
-                    }
-                    // Loop to rebuild messages.
-                },
-                Err(ServiceError::ProofRequiredError(ref p)) => {
-                    tracing::debug!("{:?}", p);
-                    return Err(MessageSenderError::ProofRequired {
-                        token: p.token.clone(),
-                        options: p.options.clone(),
+                        {
+                            Ok(b) => b,
+                            Err(e) => {
+                                tracing::debug!(%e, "failed to sealed-sender-encrypt for {dest_address}");
+                                continue;
+                            },
+                        };
+
+                    use crate::proto::envelope::Type;
+                    recipient_messages.push(OutgoingPushMessage {
+                        r#type: Type::UnidentifiedSender as u32,
+                        destination_device_id: device_id,
+                        destination_registration_id: registration_id,
+                        content: BASE64_RELAXED.encode(sealed_bytes),
                     });
+                }
+
+                if recipient_messages.is_empty() {
+                    return Err(MessageSenderError::NoMessagesToSend);
+                }
+                Ok(recipient_messages)
+            },
+        )
+        .await
+    }
+
+    /// Send the messages built by `make_messages` to a single recipient,
+    /// retrying up to 4 times on recoverable errors (`recover_from_send_error`
+    /// repairs server-reported device discrepancies and retries).
+    /// `make_messages` runs on every attempt because recovery may change the
+    /// session set.
+    ///
+    /// When `allow_unidentified_downgrade` is set and the send fails with
+    /// `Unauthorized`, the send is retried over the identified channel; the
+    /// builder's certificate argument then reads `None`.
+    async fn send_with_retries(
+        &mut self,
+        recipient: ServiceId,
+        mut unidentified_access: Option<&UnidentifiedAccess>,
+        timestamp: u64,
+        online: bool,
+        allow_unidentified_downgrade: bool,
+        mut make_messages: impl AsyncFnMut(
+            &mut Self,
+            Option<&SenderCertificate>,
+        ) -> Result<
+            Vec<OutgoingPushMessage>,
+            MessageSenderError,
+        >,
+    ) -> SendMessageResult {
+        for _ in 0..4u8 {
+            let messages = make_messages(
+                self,
+                unidentified_access.map(|x| &x.certificate),
+            )
+            .await?;
+            let messages = OutgoingPushMessages {
+                destination: recipient,
+                timestamp,
+                messages,
+                online,
+            };
+
+            match self.dispatch_outgoing(messages, unidentified_access).await {
+                Ok(SendMessageResponse { needs_sync }) => {
+                    tracing::debug!("message sent!");
+                    return self
+                        .build_sent_message(
+                            recipient,
+                            unidentified_access.is_some(),
+                            needs_sync,
+                        )
+                        .await;
                 },
-                Err(ServiceError::NotFoundError) => {
-                    tracing::debug!("Not found when sending a message");
-                    return Err(MessageSenderError::NotFound {
-                        service_id: recipient,
-                    });
+                Err(ServiceError::Unauthorized)
+                    if allow_unidentified_downgrade
+                        && unidentified_access.is_some() =>
+                {
+                    tracing::trace!("unauthorized error using unidentified; retry over identified");
+                    unidentified_access = None;
                 },
                 Err(e) => {
-                    tracing::debug!(
-                        "Default error handler for ws.send_messages: {}",
-                        e
-                    );
-                    return Err(MessageSenderError::ServiceError(e));
+                    match self.recover_from_send_error(recipient, e).await? {
+                        SendRecovery::Retry => {},
+                        SendRecovery::Terminal(err) => return Err(err),
+                    }
                 },
             }
         }
@@ -1010,7 +1114,7 @@ where
     async fn try_send_message(
         &mut self,
         recipient: ServiceId,
-        mut unidentified_access: Option<&UnidentifiedAccess>,
+        unidentified_access: Option<&UnidentifiedAccess>,
         content_body: &ContentBody,
         timestamp: u64,
         include_pni_signature: bool,
@@ -1027,146 +1131,30 @@ where
 
         let content_bytes = content.encode_to_vec();
 
-        let mut rng = rng();
-
-        for _ in 0..4u8 {
-            let Some(EncryptedMessages {
-                messages,
-                used_identity_key,
-            }) = self
-                .create_encrypted_messages(
-                    &recipient,
-                    unidentified_access.map(|x| &x.certificate),
-                    &content_bytes,
-                )
-                .await?
-            else {
-                // this can happen for example when a device is primary, without any secondaries
-                // and we send a message to ourselves (which is only a SyncMessage { sent: ... })
-                // addressed to self
-                return Err(MessageSenderError::NoMessagesToSend);
-            };
-
-            let messages = OutgoingPushMessages {
-                destination: recipient,
-                timestamp,
-                messages,
-                online,
-            };
-
-            let send = if let Some(unidentified) = &unidentified_access {
-                tracing::debug!("sending via unidentified");
-                self.unidentified_ws
-                    .send_messages_unidentified(messages, unidentified)
-                    .await
-            } else {
-                tracing::debug!("sending identified");
-                self.identified_ws.send_messages(messages).await
-            };
-
-            match send {
-                Ok(SendMessageResponse { needs_sync }) => {
-                    tracing::debug!("message sent!");
-                    return Ok(SentMessage {
-                        recipient,
-                        used_identity_key,
-                        unidentified: unidentified_access.is_some(),
-                        needs_sync,
-                    });
-                },
-                Err(ServiceError::Unauthorized)
-                    if unidentified_access.is_some() =>
-                {
-                    tracing::trace!("unauthorized error using unidentified; retry over identified");
-                    unidentified_access = None;
-                },
-                Err(ServiceError::MismatchedDevicesException(ref m)) => {
-                    tracing::debug!("{:?}", m);
-                    for extra_device_id in &m.extra_devices {
-                        tracing::debug!(
-                            "dropping session with device {}",
-                            extra_device_id
-                        );
-                        self.protocol_store
-                            .delete_service_addr_device_session(
-                                &recipient
-                                    .to_protocol_address(*extra_device_id)?,
-                            )
-                            .await?;
-                    }
-
-                    for missing_device_id in &m.missing_devices {
-                        tracing::debug!(
-                            "creating session with missing device {}",
-                            missing_device_id
-                        );
-                        let remote_address = recipient
-                            .to_protocol_address(*missing_device_id)?;
-                        let pre_key = self
-                            .identified_ws
-                            .get_pre_key(&recipient, *missing_device_id)
-                            .await?;
-
-                        process_prekey_bundle(
-                            &remote_address,
-                            &self
-                                .local_aci
-                                .to_protocol_address(self.device_id)
-                                .expect("valid device id"),
-                            &mut self.protocol_store.clone(),
-                            &mut self.protocol_store,
-                            &pre_key,
-                            SystemTime::now(),
-                            &mut rng,
-                        )
-                        .await
-                        .map_err(|e| {
-                            error!("failed to create session: {}", e);
-                            MessageSenderError::UntrustedIdentity {
-                                address: recipient,
-                            }
-                        })?;
-                    }
-                },
-                Err(ServiceError::StaleDevices(ref m)) => {
-                    tracing::debug!("{:?}", m);
-                    for extra_device_id in &m.stale_devices {
-                        tracing::debug!(
-                            "dropping session with device {}",
-                            extra_device_id
-                        );
-                        self.protocol_store
-                            .delete_service_addr_device_session(
-                                &recipient
-                                    .to_protocol_address(*extra_device_id)?,
-                            )
-                            .await?;
-                    }
-                },
-                Err(ServiceError::ProofRequiredError(ref p)) => {
-                    tracing::debug!("{:?}", p);
-                    return Err(MessageSenderError::ProofRequired {
-                        token: p.token.clone(),
-                        options: p.options.clone(),
-                    });
-                },
-                Err(ServiceError::UnregisteredRecipient) => {
-                    tracing::debug!(?recipient, "recipient is not registered");
-                    return Err(MessageSenderError::NotFound {
-                        service_id: recipient,
-                    });
-                },
-                Err(e) => {
-                    tracing::debug!(
-                        "Default error handler for ws.send_messages: {}",
-                        e
-                    );
-                    return Err(MessageSenderError::ServiceError(e));
-                },
-            }
-        }
-
-        Err(MessageSenderError::MaximumRetriesLimitExceeded)
+        self.send_with_retries(
+            recipient,
+            unidentified_access,
+            timestamp,
+            online,
+            true,
+            async |sender, certificate| {
+                let Some(EncryptedMessages { messages, .. }) = sender
+                    .create_encrypted_messages(
+                        &recipient,
+                        certificate,
+                        &content_bytes,
+                    )
+                    .await?
+                else {
+                    // this can happen for example when a device is primary, without any secondaries
+                    // and we send a message to ourselves (which is only a SyncMessage { sent: ... })
+                    // addressed to self
+                    return Err(MessageSenderError::NoMessagesToSend);
+                };
+                Ok(messages)
+            },
+        )
+        .await
     }
 
     /// Upload contact details to the CDN and send a sync message
@@ -1518,18 +1506,7 @@ where
         if messages.is_empty() {
             Ok(None)
         } else {
-            Ok(Some(EncryptedMessages {
-                messages,
-                used_identity_key: self
-                    .protocol_store
-                    .get_identity(
-                        &recipient.to_protocol_address(*DEFAULT_DEVICE_ID),
-                    )
-                    .await?
-                    .ok_or(MessageSenderError::UntrustedIdentity {
-                        address: *recipient,
-                    })?,
-            }))
+            Ok(Some(EncryptedMessages { messages }))
         }
     }
 

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -4,10 +4,11 @@ use chrono::prelude::*;
 use libsignal_core::{curve::CurveError, InvalidDeviceId};
 use libsignal_protocol::{
     create_sender_key_distribution_message, process_prekey_bundle,
-    sealed_sender_encrypt_from_usmc, Aci, CiphertextMessageType, ContentHint,
-    DeviceId, IdentityKey, IdentityKeyPair, Pni, ProtocolAddress,
-    ProtocolStore, SenderCertificate, SenderKeyStore, ServiceId,
-    SessionNotFound, SignalProtocolError, UnidentifiedSenderMessageContent,
+    sealed_sender_encrypt_from_usmc, sealed_sender_multi_recipient_encrypt,
+    Aci, CiphertextMessageType, ContentHint, DeviceId, IdentityKey,
+    IdentityKeyPair, Pni, ProtocolAddress, ProtocolStore, SenderCertificate,
+    SenderKeyStore, ServiceId, SessionNotFound, SessionRecord,
+    SignalProtocolError, UnidentifiedSenderMessageContent,
 };
 use rand::{rng, CryptoRng, Rng};
 use tracing::{debug, error, info, trace, warn};
@@ -522,78 +523,6 @@ where
         result
     }
 
-    /// Fallback: send to a group recipient using legacy 1:1 encryption per device.
-    ///
-    /// Used when the recipient does not support sealed sender or when the
-    /// sender-key path cannot be used for a specific recipient.
-    async fn send_message_to_group_legacy_1to1(
-        &mut self,
-        recipients: impl AsRef<[(ServiceId, Option<UnidentifiedAccess>, bool)]>,
-        content_body: &ContentBody,
-        timestamp: u64,
-        online: bool,
-    ) -> Vec<SendMessageResult> {
-        let mut results = vec![];
-
-        let mut needs_sync_in_results = false;
-
-        for (recipient, unidentified_access, include_pni_signature) in
-            recipients.as_ref()
-        {
-            let result = self
-                .try_send_message(
-                    *recipient,
-                    unidentified_access.as_ref(),
-                    content_body.clone().into_proto(),
-                    timestamp,
-                    *include_pni_signature,
-                    online,
-                )
-                .await;
-
-            match result {
-                Ok(SentMessage { needs_sync, .. }) if needs_sync => {
-                    needs_sync_in_results = true;
-                },
-                _ => (),
-            };
-
-            results.push(result);
-        }
-
-        // we only need to send a synchronization message once
-        if needs_sync_in_results || self.is_multi_device().await {
-            if let Some(sync_message) = self
-                .create_multi_device_sent_transcript_content(
-                    None,
-                    content_body.clone(),
-                    timestamp,
-                    &results,
-                )
-            {
-                // Note: the result of sending a sync message is not included in results
-                // See Signal Android `SignalServiceMessageSender.java:2817`
-                if let Err(error) = self
-                    .try_send_message(
-                        self.local_aci.into(),
-                        None,
-                        sync_message.into_proto(),
-                        timestamp,
-                        false, // XXX: maybe the sync device does want a PNI signature?
-                        false,
-                    )
-                    .await
-                {
-                    error!(%error, "failed to send a synchronization message");
-                }
-            } else {
-                error!("could not create sync message from a group message")
-            }
-        }
-
-        results
-    }
-
     /// Send a message to the recipients in a group using sender keys.
     ///
     /// Recipients are a list of tuples, each containing:
@@ -660,80 +589,61 @@ where
             Err(e) => return vec![Err(MessageSenderError::ServiceError(e))],
         };
 
-        let mut results: Vec<SendMessageResult> = vec![];
-        let mut needs_sync_in_results = false;
+        let recipients_ref = recipients.as_ref();
+        // Recipients with unidentified access go through the sealed-sender
+        // sender-key paths; the rest fall back to identified 1:1 sends.
+        let sealed: Vec<(ServiceId, &UnidentifiedAccess)> = recipients_ref
+            .iter()
+            .filter_map(|(r, ua, _)| ua.as_ref().map(|a| (*r, a)))
+            .collect();
 
-        for (recipient, unidentified_access, _include_pni_signature) in
-            recipients.as_ref()
+        let mut results: Vec<SendMessageResult> = match self
+            .send_sender_key_payload(
+                &sealed,
+                &skm_serialized,
+                timestamp,
+                online,
+            )
+            .await
         {
-            let Some(unidentified) = unidentified_access else {
-                // Fall back to legacy 1:1 for this recipient (no sealed-sender
-                // capability).
-                let legacy_results = self
-                    .send_message_to_group_legacy_1to1(
-                        std::slice::from_ref(&(*recipient, None, false)),
-                        &content_body,
-                        timestamp,
-                        online,
-                    )
-                    .await;
-                if let Some(Ok(SentMessage { needs_sync, .. })) =
-                    legacy_results.first()
-                {
-                    if *needs_sync {
-                        needs_sync_in_results = true;
-                    }
-                }
-                results.extend(legacy_results);
-                continue;
-            };
+            Ok(results) => results,
+            Err(e) => return vec![Err(e)],
+        };
 
-            let result = self
-                .send_sender_key_to_recipient(
+        for (recipient, _, include_pni_signature) in
+            recipients_ref.iter().filter(|(_, ua, _)| ua.is_none())
+        {
+            // Identified 1:1 fallback, which also establishes missing sessions.
+            results.push(
+                self.try_send_message(
                     *recipient,
-                    unidentified,
-                    &skm_serialized,
+                    None,
+                    content_body.clone().into_proto(),
                     timestamp,
+                    *include_pni_signature,
                     online,
                 )
-                .await;
-
-            match result {
-                Ok(SentMessage { needs_sync, .. }) if needs_sync => {
-                    needs_sync_in_results = true;
-                },
-                _ => (),
-            };
-            results.push(result);
+                .await,
+            );
         }
 
-        // Multi-device sync transcript (unchanged from the legacy path).
-        if needs_sync_in_results || self.is_multi_device().await {
-            if let Some(sync_message) = self
-                .create_multi_device_sent_transcript_content(
-                    None,
-                    content_body.clone(),
-                    timestamp,
-                    &results,
-                )
-            {
-                if let Err(error) = self
-                    .try_send_message(
-                        self.local_aci.into(),
-                        None,
-                        sync_message.into_proto(),
-                        timestamp,
-                        false,
-                        false,
-                    )
-                    .await
-                {
-                    error!(%error, "failed to send a synchronization message");
-                }
-            } else {
-                error!("could not create sync message from a group message")
-            }
-        }
+        // we only need to send a synchronization message once
+        let needs_sync = results.iter().any(|r| {
+            matches!(
+                r,
+                Ok(SentMessage {
+                    needs_sync: true,
+                    ..
+                })
+            )
+        });
+        self.send_group_sent_transcript(
+            &content_body,
+            timestamp,
+            &results,
+            needs_sync,
+        )
+        .await;
 
         results
     }
@@ -792,6 +702,130 @@ where
         .await?;
 
         Ok(())
+    }
+
+    /// Sealed-sender half of [`send_message_to_group`]: send the group's
+    /// `SenderKeyMessage` (wrapped in one shared `usmc`) to the recipients
+    /// that have unidentified access, through a single multi-recipient
+    /// request when every recipient has sessions for all devices, and
+    /// per-recipient sealed sends otherwise.
+    async fn send_sender_key_payload(
+        &mut self,
+        recipients: &[(ServiceId, &UnidentifiedAccess)],
+        skm_serialized: &[u8],
+        timestamp: u64,
+        online: bool,
+    ) -> Result<Vec<SendMessageResult>, MessageSenderError> {
+        if recipients.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // The USMC depends only on the SKM and our certificate, not on the
+        // recipient; build it once and share it across both send paths below.
+        let usmc = Self::build_group_usmc(
+            &recipients[0].1.certificate,
+            skm_serialized,
+        )?;
+
+        let mut results = vec![];
+
+        // Recipients with a session for every enumerated device go through
+        // the single multi-recipient request; the rest fall back to
+        // per-recipient sends (which also establish missing sessions). A
+        // store error during the check degrades to the fallback, where it
+        // surfaces as a proper per-recipient error.
+        let mut mrm_recipients: Vec<(ServiceId, &UnidentifiedAccess)> = vec![];
+        let mut skr_recipients: Vec<(ServiceId, &UnidentifiedAccess)> = vec![];
+        for (recipient, unidentified_access) in recipients {
+            let all_sessions = self
+                .recipient_has_all_device_sessions(recipient)
+                .await
+                .unwrap_or(false);
+            if all_sessions {
+                mrm_recipients.push((*recipient, unidentified_access));
+            } else {
+                skr_recipients.push((*recipient, unidentified_access));
+            }
+        }
+
+        if !mrm_recipients.is_empty() {
+            match self
+                .send_message_to_group_multi_recipient(
+                    &mrm_recipients,
+                    &usmc,
+                    timestamp,
+                    online,
+                )
+                .await
+            {
+                Ok(mrm_results) => results.extend(mrm_results),
+                Err(e) => {
+                    tracing::warn!(
+                        %e,
+                        "multi-recipient send failed; falling back to 1:1"
+                    );
+                    skr_recipients.append(&mut mrm_recipients);
+                },
+            }
+        }
+
+        for (recipient, unidentified_access) in skr_recipients {
+            results.push(
+                self.send_sender_key_to_recipient(
+                    recipient,
+                    unidentified_access,
+                    &usmc,
+                    timestamp,
+                    online,
+                )
+                .await,
+            );
+        }
+
+        Ok(results)
+    }
+
+    /// Send the multi-device `Sent` transcript for a group send: when the
+    /// server requested a sync or we are multi-device, mirror the results as
+    /// a `Sent` `SyncMessage` to our own devices. Transcript-send failures
+    /// are logged, not propagated: the group message itself was delivered.
+    async fn send_group_sent_transcript(
+        &mut self,
+        content_body: &ContentBody,
+        timestamp: u64,
+        results: &[SendMessageResult],
+        needs_sync: bool,
+    ) {
+        if !(needs_sync || self.is_multi_device().await) {
+            return;
+        }
+
+        let Some(sync_message) = self
+            .create_multi_device_sent_transcript_content(
+                None,
+                content_body.clone(),
+                timestamp,
+                results,
+            )
+        else {
+            error!("could not create sync message from a group message");
+            return;
+        };
+        // Note: the result of sending a sync message is not included in results
+        // See Signal Android `SignalServiceMessageSender.java:2817`
+        if let Err(error) = self
+            .try_send_message(
+                self.local_aci.into(),
+                None,
+                sync_message.into_proto(),
+                timestamp,
+                false, // XXX: maybe the sync device does want a PNI signature?
+                false,
+            )
+            .await
+        {
+            error!(%error, "failed to send a synchronization message");
+        }
     }
 
     /// Handle the `Err` arm of a websocket send, shared by the sender-key and
@@ -891,6 +925,104 @@ where
         }
     }
 
+    /// Multi-recipient counterpart of [`recover_from_send_error`] for
+    /// `PUT /v1/messages/multi_recipient`, whose `409`/`410` carry per-account
+    /// device lists ([`MultiRecipientMismatchedDevices`] /
+    /// [`MultiRecipientStaleDevices`]).
+    ///
+    /// Deletes extra/stale sessions and establishes sessions for missing
+    /// devices across all reported accounts, so the caller can re-gather
+    /// sessions and retry the whole encrypt+send. Other errors are terminal;
+    /// per-recipient 404s arrive in the 200 body (`uuids404`), not here.
+    async fn recover_from_multi_recipient_send_error(
+        &mut self,
+        err: ServiceError,
+    ) -> Result<SendRecovery, MessageSenderError> {
+        match err {
+            ServiceError::MultiRecipientMismatchedDevices(accounts) => {
+                for account in &accounts {
+                    let recipient = account.uuid;
+                    tracing::debug!(
+                        ?recipient,
+                        extra = ?account.devices.extra_devices,
+                        missing = ?account.devices.missing_devices,
+                        "multi-recipient mismatched devices",
+                    );
+                    for extra_device_id in &account.devices.extra_devices {
+                        self.protocol_store
+                            .delete_service_addr_device_session(
+                                &recipient
+                                    .to_protocol_address(*extra_device_id)?,
+                            )
+                            .await?;
+                    }
+                    for missing_device_id in &account.devices.missing_devices {
+                        let remote_address = recipient
+                            .to_protocol_address(*missing_device_id)?;
+                        let mut rng = rng();
+                        let pre_key = self
+                            .identified_ws
+                            .get_pre_key(&recipient, *missing_device_id)
+                            .await?;
+                        process_prekey_bundle(
+                            &remote_address,
+                            &self
+                                .local_aci
+                                .to_protocol_address(self.device_id)
+                                .expect("valid device id"),
+                            &mut self.protocol_store.clone(),
+                            &mut self.protocol_store,
+                            &pre_key,
+                            SystemTime::now(),
+                            &mut rng,
+                        )
+                        .await
+                        .map_err(|e| {
+                            error!(%e, ?recipient, "failed to create session");
+                            MessageSenderError::UntrustedIdentity {
+                                address: recipient,
+                            }
+                        })?;
+                    }
+                }
+                Ok(SendRecovery::Retry)
+            },
+            ServiceError::MultiRecipientStaleDevices(accounts) => {
+                for account in &accounts {
+                    tracing::debug!(
+                        ?account.uuid,
+                        stale = ?account.devices.stale_devices,
+                        "multi-recipient stale devices",
+                    );
+                    for stale_device_id in &account.devices.stale_devices {
+                        self.protocol_store
+                            .delete_service_addr_device_session(
+                                &account
+                                    .uuid
+                                    .to_protocol_address(*stale_device_id)?,
+                            )
+                            .await?;
+                    }
+                }
+                Ok(SendRecovery::Retry)
+            },
+            ServiceError::ProofRequiredError(ref p) => {
+                tracing::debug!("multi-recipient proof required: {:?}", p);
+                Ok(SendRecovery::Terminal(MessageSenderError::ProofRequired {
+                    token: p.token.clone(),
+                    options: p.options.clone(),
+                }))
+            },
+            e => {
+                tracing::debug!(
+                    "Default error handler for multi-recipient send: {}",
+                    e
+                );
+                Ok(SendRecovery::Terminal(MessageSenderError::ServiceError(e)))
+            },
+        }
+    }
+
     /// Dispatch a built `OutgoingPushMessages` to the websocket, via the
     /// unidentified channel when `unidentified_access` is supplied, else the
     /// identified channel.
@@ -933,13 +1065,14 @@ where
         })
     }
 
-    /// Build per-device sealed-sender SenderKey messages for a single recipient
-    /// and send them via the sealed-sender path with the full retry loop.
+    /// Send the sender-key payload (pre-wrapped in `usmc`) to a single
+    /// recipient, sealed-sender encrypted per device, with the full retry
+    /// loop.
     async fn send_sender_key_to_recipient(
         &mut self,
         recipient: ServiceId,
         unidentified_access: &UnidentifiedAccess,
-        skm_serialized: &[u8],
+        usmc: &UnidentifiedSenderMessageContent,
         timestamp: u64,
         online: bool,
     ) -> SendMessageResult {
@@ -989,25 +1122,11 @@ where
                             },
                         };
 
-                    let usmc = match UnidentifiedSenderMessageContent::new(
-                        CiphertextMessageType::SenderKey,
-                        unidentified_access.certificate.clone(),
-                        skm_serialized.to_vec(),
-                        ContentHint::Resendable,
-                        None,
-                    ) {
-                        Ok(u) => u,
-                        Err(e) => {
-                            tracing::debug!(%e, "failed to build USMC for {dest_address}");
-                            continue;
-                        },
-                    };
-
                     let mut rng = rng();
                     let sealed_bytes =
                         match sealed_sender_encrypt_from_usmc(
                             &dest_address,
-                            &usmc,
+                            usmc,
                             &sender.protocol_store,
                             &mut rng,
                         )
@@ -1095,6 +1214,155 @@ where
                 },
                 Err(e) => {
                     match self.recover_from_send_error(recipient, e).await? {
+                        SendRecovery::Retry => {},
+                        SendRecovery::Terminal(err) => return Err(err),
+                    }
+                },
+            }
+        }
+
+        Err(MessageSenderError::MaximumRetriesLimitExceeded)
+    }
+
+    /// Wrap a serialized `SenderKeyMessage` in a `Resendable`-hinted
+    /// `UnidentifiedSenderMessageContent` signed by `certificate`.
+    ///
+    /// The USMC depends only on the SKM and the sender certificate, so one is
+    /// shared across all recipients of a send.
+    fn build_group_usmc(
+        certificate: &SenderCertificate,
+        skm_serialized: &[u8],
+    ) -> Result<UnidentifiedSenderMessageContent, MessageSenderError> {
+        UnidentifiedSenderMessageContent::new(
+            CiphertextMessageType::SenderKey,
+            certificate.clone(),
+            skm_serialized.to_vec(),
+            ContentHint::Resendable,
+            None,
+        )
+        .map_err(MessageSenderError::ProtocolError)
+    }
+
+    /// Deliver the sender-key payload to `recipients` via a single
+    /// `PUT /v1/messages/multi_recipient` request.
+    ///
+    /// All recipients must have supplied [`UnidentifiedAccess`] and have
+    /// sessions for every enumerated device; recipients without a UAK or with
+    /// missing sessions are routed to the 1:1 fallback by the caller.
+    ///
+    /// Returns `Err` for failures that abort the whole batch (session load,
+    /// encryption, terminal send error); the caller falls those
+    /// recipients back to the 1:1 path. On success each recipient maps to an
+    /// [`SentMessage`], with unregistered recipients (the 200 body's
+    /// `uuids404`) surfaced as [`MessageSenderError::NotFound`].
+    ///
+    /// On `409`/`410` the server reports per-account device deltas, handled by
+    /// [`recover_from_multi_recipient_send_error`]; the whole encrypt+send is
+    /// retried (matching the per-recipient loops' 4 attempts).
+    async fn send_message_to_group_multi_recipient(
+        &mut self,
+        recipients: &[(ServiceId, &UnidentifiedAccess)],
+        usmc: &UnidentifiedSenderMessageContent,
+        timestamp: u64,
+        online: bool,
+    ) -> Result<Vec<SendMessageResult>, MessageSenderError> {
+        for _ in 0..4u8 {
+            // Gather (address, session) for every enumerated device of every
+            // recipient. `enumerate_recipient_devices` excludes the local
+            // device; `sealed_sender_multi_recipient_encrypt` requires a
+            // session for each destination, so a missing session aborts the
+            // multi-recipient path for the whole call (caller falls back to
+            // 1:1 for the affected recipients).
+            let mut dest_addresses: Vec<ProtocolAddress> = vec![];
+            let mut dest_sessions: Vec<SessionRecord> = vec![];
+            let mut missing_session = false;
+            for (recipient, _) in recipients {
+                let devices =
+                    self.enumerate_recipient_devices(recipient).await?;
+                for &device_id in &devices {
+                    let addr = recipient.to_protocol_address(device_id);
+                    match self.protocol_store.load_session(&addr).await? {
+                        Some(s) => {
+                            dest_addresses.push(addr);
+                            dest_sessions.push(s);
+                        },
+                        None => {
+                            tracing::debug!(
+                                %addr,
+                                "no session; deferring to 1:1 fallback"
+                            );
+                            missing_session = true;
+                            break;
+                        },
+                    }
+                }
+                if missing_session {
+                    break;
+                }
+            }
+            if missing_session {
+                return Err(MessageSenderError::NoMessagesToSend);
+            }
+
+            let dest_refs: Vec<&ProtocolAddress> =
+                dest_addresses.iter().collect();
+            let session_refs: Vec<&SessionRecord> =
+                dest_sessions.iter().collect();
+
+            let mut rng = rng();
+            let payload = sealed_sender_multi_recipient_encrypt(
+                &dest_refs,
+                &session_refs,
+                std::iter::empty::<ServiceId>(),
+                usmc,
+                &self.protocol_store,
+                &mut rng,
+            )
+            .await?;
+
+            let keys: Vec<&Vec<u8>> =
+                recipients.iter().map(|(_, a)| &a.key).collect();
+            let combined =
+                CombinedUnidentifiedSenderAccessKeys::from_access_keys(keys);
+            let request = MultiRecipientMessagesRequest {
+                timestamp,
+                online,
+                urgent: true,
+                story: false,
+                payload: &payload,
+                access: Some(MultiRecipientAccess::UnidentifiedAccessKey(
+                    combined,
+                )),
+            };
+
+            match self
+                .unidentified_ws
+                .send_multi_recipient_messages(request)
+                .await
+            {
+                Ok(response) => {
+                    let not_found: HashSet<ServiceId> =
+                        response.uuids404.into_iter().collect();
+                    let mut results = Vec::with_capacity(recipients.len());
+                    for (recipient, _) in recipients {
+                        if not_found.contains(recipient) {
+                            results.push(Err(MessageSenderError::NotFound {
+                                service_id: *recipient,
+                            }));
+                            continue;
+                        }
+                        let used_identity_key = self
+                            .build_sent_message(*recipient, true, false)
+                            .await?;
+                        results.push(Ok(used_identity_key));
+                    }
+                    return Ok(results);
+                },
+                Err(e) => {
+                    match self
+                        .recover_from_multi_recipient_send_error(e)
+                        .await?
+                    {
                         SendRecovery::Retry => {},
                         SendRecovery::Terminal(err) => return Err(err),
                     }
@@ -1345,6 +1613,24 @@ where
         };
 
         Ok(devices)
+    }
+
+    /// Whether every enumerated device of `recipient` has a loaded session.
+    /// Used to decide multi-recipient eligibility: a recipient without a
+    /// complete session set is routed to the 1:1 path, which establishes the
+    /// missing sessions.
+    async fn recipient_has_all_device_sessions(
+        &self,
+        recipient: &ServiceId,
+    ) -> Result<bool, MessageSenderError> {
+        let devices = self.enumerate_recipient_devices(recipient).await?;
+        for &device_id in &devices {
+            let addr = recipient.to_protocol_address(device_id);
+            if self.protocol_store.load_session(&addr).await?.is_none() {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 
     /// For every recipient device that does not yet have our SKDM for

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -456,7 +456,7 @@ where
                     .try_send_message(
                         *recipient,
                         None,
-                        &sync_message,
+                        sync_message.into_proto(),
                         timestamp,
                         include_pni_signature,
                         online,
@@ -480,7 +480,7 @@ where
             .try_send_message(
                 *recipient,
                 unidentified_access,
-                &content_body,
+                content_body.clone().into_proto(),
                 timestamp,
                 include_pni_signature,
                 online,
@@ -510,7 +510,7 @@ where
                 self.try_send_message(
                     self.local_aci.into(),
                     None,
-                    &body,
+                    body.into_proto(),
                     timestamp,
                     false,
                     false,
@@ -544,7 +544,7 @@ where
                 .try_send_message(
                     *recipient,
                     unidentified_access.as_ref(),
-                    content_body,
+                    content_body.clone().into_proto(),
                     timestamp,
                     *include_pni_signature,
                     online,
@@ -577,7 +577,7 @@ where
                     .try_send_message(
                         self.local_aci.into(),
                         None,
-                        &sync_message,
+                        sync_message.into_proto(),
                         timestamp,
                         false, // XXX: maybe the sync device does want a PNI signature?
                         false,
@@ -721,7 +721,7 @@ where
                     .try_send_message(
                         self.local_aci.into(),
                         None,
-                        &sync_message,
+                        sync_message.into_proto(),
                         timestamp,
                         false,
                         false,
@@ -784,7 +784,7 @@ where
         self.try_send_message(
             *recipient,
             unidentified_access,
-            &content_body,
+            content_body.into_proto(),
             Utc::now().timestamp_millis() as u64,
             false,
             false,
@@ -1108,14 +1108,14 @@ where
     /// Send a message (`content`) to an address (`recipient`).
     #[tracing::instrument(
         level = "trace",
-        skip(self, unidentified_access, content_body, recipient),
+        skip(self, unidentified_access, content, recipient),
         fields(unidentified_access = unidentified_access.is_some(), recipient = recipient.service_id_string()),
     )]
     async fn try_send_message(
         &mut self,
         recipient: ServiceId,
         unidentified_access: Option<&UnidentifiedAccess>,
-        content_body: &ContentBody,
+        mut content: crate::proto::Content,
         timestamp: u64,
         include_pni_signature: bool,
         online: bool,
@@ -1124,7 +1124,6 @@ where
 
         use prost::Message;
 
-        let mut content = content_body.clone().into_proto();
         if include_pni_signature {
             content.pni_signature_message = Some(self.create_pni_signature()?);
         }
@@ -1252,7 +1251,7 @@ where
         sync: impl Into<SyncMessage>,
     ) -> Result<(), MessageSenderError> {
         if self.is_multi_device().await {
-            let content = sync.into().into();
+            let content: ContentBody = sync.into().into();
             let timestamp = Utc::now().timestamp_millis() as u64;
             debug!(
                 "sending multi-device sync message with content {content:?}"
@@ -1260,7 +1259,7 @@ where
             self.try_send_message(
                 self.local_aci.into(),
                 None,
-                &content,
+                content.into_proto(),
                 timestamp,
                 false,
                 false,
@@ -1350,9 +1349,8 @@ where
 
     /// For every recipient device that does not yet have our SKDM for
     /// `distribution_id`, build it (idempotent: libsignal creates the chain on
-    /// first call) and send it as an identified 1:1
-    /// `ContentBody::SenderKeyDistributionMessage`. Mark each device shared on
-    /// success.
+    /// first call) and send it as a wire-only `proto::Content` with the SKDM
+    /// attached. Mark each device shared on success.
     #[tracing::instrument(skip(self, recipients), fields(recipients = recipients.as_ref().len(), dist_id = %distribution_id))]
     async fn share_sender_key_if_needed(
         &mut self,
@@ -1405,12 +1403,16 @@ where
             )
             .await?;
 
-            let body = ContentBody::from(skdm);
+            let content = crate::proto::Content {
+                content: None,
+                sender_key_distribution_message: Some(skdm.as_ref().to_vec()),
+                pni_signature_message: None,
+            };
             let _result = self
                 .try_send_message(
                     *recipient,
                     unidentified_access.as_ref(),
-                    &body,
+                    content,
                     timestamp,
                     false,
                     false,

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -550,16 +550,22 @@ where
         // Share SKDMs with any devices that haven't received them yet.
         // XXX Ideally, we *attach* the SKDM to the message-to-be-sent.
         //     This is an ugly hack
-        if let Err(e) = self
+        //
+        // Recipients whose SKDM cannot be delivered are excluded from the
+        // send below instead of failing the whole group: the sender-key
+        // payload is undecryptable without the SKDM, but all other
+        // recipients should still receive the message.
+        let skdm_failures = self
             .share_sender_key_if_needed(
                 distribution_id,
                 timestamp,
                 recipients.as_ref(),
             )
-            .await
-        {
-            return vec![Err(e)];
-        }
+            .await;
+        let skdm_failed: HashSet<ServiceId> =
+            skdm_failures.iter().map(|(r, _)| *r).collect();
+        let mut results: Vec<SendMessageResult> =
+            skdm_failures.into_iter().map(|(_, e)| Err(e)).collect();
 
         // Encode the content once.
         use prost::Message;
@@ -594,10 +600,14 @@ where
         // sender-key paths; the rest fall back to identified 1:1 sends.
         let sealed: Vec<(ServiceId, &UnidentifiedAccess)> = recipients_ref
             .iter()
+            .filter(|(r, ua, _)| ua.is_some() && !skdm_failed.contains(r))
             .filter_map(|(r, ua, _)| ua.as_ref().map(|a| (*r, a)))
             .collect();
 
-        let mut results: Vec<SendMessageResult> = match self
+        // Sealed-sender stage: build the shared USMC + SenderKeyMessage once
+        // and fan out. A wholesale failure is pushed as one more error result;
+        // the identified fallback loop below still runs.
+        match self
             .send_sender_key_payload(
                 &sealed,
                 &skm_serialized,
@@ -606,12 +616,16 @@ where
             )
             .await
         {
-            Ok(results) => results,
-            Err(e) => return vec![Err(e)],
-        };
+            Ok(payload_results) => results.extend(payload_results),
+            Err(e) => {
+                tracing::warn!(error = %e, "sender-key payload send failed wholesale; identified recipients still attempted");
+                results.push(Err(e));
+            },
+        }
 
-        for (recipient, _, include_pni_signature) in
-            recipients_ref.iter().filter(|(_, ua, _)| ua.is_none())
+        for (recipient, _, include_pni_signature) in recipients_ref
+            .iter()
+            .filter(|(r, ua, _)| ua.is_none() && !skdm_failed.contains(r))
         {
             // Identified 1:1 fallback, which also establishes missing sessions.
             results.push(
@@ -1606,15 +1620,38 @@ where
     /// `distribution_id`, build it (idempotent: libsignal creates the chain on
     /// first call) and send it as a wire-only `proto::Content` with the SKDM
     /// attached. Mark each device shared on success.
+    ///
+    /// Never aborts the fan-out: a recipient whose SKDM cannot be delivered
+    /// (e.g. an untrusted identity, or an unknown device set) is returned as a
+    /// failure entry so the caller can exclude it from the sender-key payload —
+    /// that payload is undecryptable without the SKDM — while the remaining
+    /// recipients still receive the group message.
     #[tracing::instrument(skip(self, recipients), fields(recipients = recipients.as_ref().len(), dist_id = %distribution_id))]
     async fn share_sender_key_if_needed(
         &mut self,
         distribution_id: Uuid,
         timestamp: u64,
         recipients: &[(ServiceId, Option<UnidentifiedAccess>, bool)],
-    ) -> Result<(), MessageSenderError> {
-        let sender_address =
-            self.local_aci.to_protocol_address(self.device_id)?;
+    ) -> Vec<(ServiceId, MessageSenderError)> {
+        let sender_address = match self
+            .local_aci
+            .to_protocol_address(self.device_id)
+        {
+            Ok(addr) => addr,
+            Err(e) => {
+                // Our own address resolution failed: no recipient can be
+                // shared with, so fail them all.
+                tracing::error!(error = %e, "cannot resolve own sender address; failing SKDM for all recipients");
+                return recipients
+                    .iter()
+                    .map(|(r, _, _)| {
+                        (*r, MessageSenderError::InvalidDeviceId(e.clone()))
+                    })
+                    .collect();
+            },
+        };
+
+        let mut failures = Vec::<(ServiceId, MessageSenderError)>::new();
 
         // PNI signatures are an individual-send concern (matches Signal-Android's
         // IndividualSendJob); the SKDM is sender-key infrastructure, so we don't
@@ -1626,7 +1663,17 @@ where
             // (and creates sessions for any the server knows about but we
             // don't). So we send at most ONE SKDM per recipient, not one per
             // device — otherwise a D-device recipient gets the SKDM D times.
-            let devices = self.enumerate_recipient_devices(recipient).await?;
+            let devices = match self
+                .enumerate_recipient_devices(recipient)
+                .await
+            {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::warn!(recipient = %recipient.service_id_string(), error = %e, "could not enumerate recipient devices; excluding recipient from this group send");
+                    failures.push((*recipient, e));
+                    continue;
+                },
+            };
             let mut needs_share = false;
             for &device_id in &devices {
                 let recipient_address =
@@ -1637,11 +1684,12 @@ where
                             break;
                         },
                     };
-                if !self
+                let shared = self
                     .protocol_store
                     .is_sender_key_shared(distribution_id, &recipient_address)
-                    .await?
-                {
+                    .await
+                    .unwrap_or(false);
+                if !shared {
                     needs_share = true;
                 }
             }
@@ -1650,20 +1698,28 @@ where
             }
 
             let mut rng = rng();
-            let skdm = create_sender_key_distribution_message(
+            let skdm = match create_sender_key_distribution_message(
                 &sender_address,
                 distribution_id,
                 &mut self.protocol_store,
                 &mut rng,
             )
-            .await?;
+            .await
+            {
+                Ok(skdm) => skdm,
+                Err(e) => {
+                    tracing::warn!(recipient = %recipient.service_id_string(), error = %e, "could not build SKDM; excluding recipient from this group send");
+                    failures.push((*recipient, e.into()));
+                    continue;
+                },
+            };
 
             let content = crate::proto::Content {
                 content: None,
                 sender_key_distribution_message: Some(skdm.as_ref().to_vec()),
                 pni_signature_message: None,
             };
-            let _result = self
+            if let Err(e) = self
                 .try_send_message(
                     *recipient,
                     unidentified_access.as_ref(),
@@ -1672,24 +1728,44 @@ where
                     false,
                     false,
                 )
-                .await?;
+                .await
+            {
+                tracing::warn!(recipient = %recipient.service_id_string(), error = %e, "could not deliver SKDM; excluding recipient from this group send");
+                failures.push((*recipient, e));
+                continue;
+            }
             // `try_send_message` may have established sessions with
             // devices we didn't know about; re-enumerate so we mark
             // the *complete* device set shared.
-            let devices_after =
-                self.enumerate_recipient_devices(recipient).await?;
+            let devices_after = match self
+                .enumerate_recipient_devices(recipient)
+                .await
+            {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::warn!(recipient = %recipient.service_id_string(), error = %e, "SKDM delivered, but device re-enumeration failed; not marking shared (next send re-shares)");
+                    continue;
+                },
+            };
             for &device_id in &devices_after {
-                let recipient_address =
-                    (*recipient).to_protocol_address(device_id)?;
-                self.protocol_store
+                let Ok(recipient_address) =
+                    (*recipient).to_protocol_address(device_id)
+                else {
+                    continue;
+                };
+                if let Err(e) = self
+                    .protocol_store
                     .mark_sender_key_shared(distribution_id, &recipient_address)
-                    .await?;
+                    .await
+                {
+                    tracing::warn!(error = %e, "failed to mark sender key shared; next send re-shares");
+                }
             }
         }
 
         // No SKDM sync transcript.
 
-        Ok(())
+        failures
     }
 
     // Equivalent with `getEncryptedMessages`

--- a/src/sender_key_store_ext.rs
+++ b/src/sender_key_store_ext.rs
@@ -33,4 +33,10 @@ pub trait SenderKeyStoreExt: SenderKeyStore {
         &mut self,
         distribution_id: Uuid,
     ) -> Result<(), SignalProtocolError>;
+
+    /// Clear the shared mark for ALL distribution_ids for `recipient`.
+    async fn clear_sender_key_shared_for_address(
+        &mut self,
+        recipient: &ProtocolAddress,
+    ) -> Result<(), SignalProtocolError>;
 }

--- a/src/sender_key_store_ext.rs
+++ b/src/sender_key_store_ext.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+use libsignal_protocol::{
+    ProtocolAddress, SenderKeyStore, SignalProtocolError,
+};
+use uuid::Uuid;
+
+/// Additional functions for managing per-recipient sender-key "shared" state.
+#[async_trait(?Send)]
+pub trait SenderKeyStoreExt: SenderKeyStore {
+    /// Check whether a given distribution_id was marked as shared to a given recipient.
+    async fn is_sender_key_shared(
+        &self,
+        distribution_id: Uuid,
+        recipient: &ProtocolAddress,
+    ) -> Result<bool, SignalProtocolError>;
+
+    /// Mark `distribution_id` as having been shared with `recipient`.
+    async fn mark_sender_key_shared(
+        &mut self,
+        distribution_id: Uuid,
+        recipient: &ProtocolAddress,
+    ) -> Result<(), SignalProtocolError>;
+
+    /// Clear the shared mark for `distribution_id` + `recipient`.
+    async fn clear_sender_key_shared(
+        &mut self,
+        distribution_id: Uuid,
+        recipient: &ProtocolAddress,
+    ) -> Result<(), SignalProtocolError>;
+
+    /// Clear the shared mark for ALL recipients of `distribution_id`.
+    async fn clear_all_sender_key_shared(
+        &mut self,
+        distribution_id: Uuid,
+    ) -> Result<(), SignalProtocolError>;
+}

--- a/src/session_store.rs
+++ b/src/session_store.rs
@@ -4,7 +4,10 @@ use libsignal_protocol::{
     ProtocolAddress, ServiceId, SessionStore, SignalProtocolError,
 };
 
-use crate::{content::ServiceError, push_service::DEFAULT_DEVICE_ID};
+use crate::{
+    content::ServiceError, push_service::DEFAULT_DEVICE_ID,
+    service_address::ServiceIdExt,
+};
 
 /// This is additional functions required to handle
 /// session deletion. It might be a candidate for inclusion into
@@ -18,6 +21,40 @@ pub trait SessionStoreExt: SessionStore {
         &self,
         name: &ServiceId,
     ) -> Result<Vec<DeviceId>, SignalProtocolError>;
+
+    /// All `(ProtocolAddress, SessionRecord)` pairs with active sessions for the
+    /// given recipients, including each recipient's default device when a session
+    /// exists for it. Mirrors Java's `getAllAddressesWithActiveSessions`.
+    ///
+    /// Default implementation iterates recipients via `get_sub_device_sessions` and
+    /// `load_session`, skipping default-device entry when no session exists.
+    async fn get_addresses_with_active_sessions(
+        &self,
+        recipients: &[ServiceId],
+    ) -> Result<
+        std::collections::HashMap<
+            ProtocolAddress,
+            libsignal_protocol::SessionRecord,
+        >,
+        SignalProtocolError,
+    > {
+        let mut out = std::collections::HashMap::new();
+        for recipient in recipients {
+            let mut device_ids =
+                self.get_sub_device_sessions(recipient).await?;
+            device_ids.push(*DEFAULT_DEVICE_ID);
+            for device_id in device_ids {
+                let addr =
+                    (*recipient).to_protocol_address(device_id).map_err(
+                        |e| SignalProtocolError::InvalidArgument(e.to_string()),
+                    )?;
+                if let Some(record) = self.load_session(&addr).await? {
+                    out.insert(addr, record);
+                }
+            }
+        }
+        Ok(out)
+    }
 
     /// Remove a session record for a recipient ID + device ID tuple.
     async fn delete_session(

--- a/src/unidentified_access.rs
+++ b/src/unidentified_access.rs
@@ -5,3 +5,60 @@ pub struct UnidentifiedAccess {
     pub key: Vec<u8>,
     pub certificate: SenderCertificate,
 }
+
+/// Bitwise XOR of the 16-byte unidentified access keys for every recipient
+/// of a multi-recipient sealed-sender message.
+///
+/// Mirrors the server's `CombinedUnidentifiedSenderAccessKeys`, which is base64-
+/// encoded into the `Unidentified-Access-Key` header of
+/// `PUT /v1/messages/multi_recipient`.
+///
+/// Construct with [`CombinedUnidentifiedSenderAccessKeys::from_access_keys`]
+/// from the per-recipient [`UnidentifiedAccess::key`]s; round-trips losslessly
+/// for an empty recipient set (yields the all-zero key).
+#[derive(Clone, Copy)]
+pub struct CombinedUnidentifiedSenderAccessKeys(pub [u8; 16]);
+
+impl CombinedUnidentifiedSenderAccessKeys {
+    /// XOR every `UnidentifiedAccess::key` (`UNIDENTIFIED_ACCESS_KEY_LENGTH`
+    /// of 16 bytes each) into a single combined access key.
+    pub fn from_access_keys<'a>(
+        keys: impl IntoIterator<Item = &'a Vec<u8>>,
+    ) -> Self {
+        let mut combined = [0u8; 16];
+        for key in keys {
+            for (acc, b) in combined.iter_mut().zip(key.iter().take(16)) {
+                *acc ^= *b;
+            }
+        }
+        Self(combined)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn combined_access_key_xors_recipients() {
+        let a = vec![0u8; 16];
+        let b = (0..16).collect::<Vec<u8>>();
+        let c = vec![0xff; 16];
+
+        let combined =
+            CombinedUnidentifiedSenderAccessKeys::from_access_keys([
+                &a, &b, &c,
+            ]);
+        // a XOR b XOR c == b XOR c (a is zero)
+        let expected: [u8; 16] = std::array::from_fn(|i| b[i] ^ c[i]);
+        assert_eq!(combined.0, expected);
+    }
+
+    #[test]
+    fn combined_access_key_empty_is_zero() {
+        let combined = CombinedUnidentifiedSenderAccessKeys::from_access_keys(
+            std::iter::empty::<&Vec<u8>>(),
+        );
+        assert_eq!(combined.0, [0u8; 16]);
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -526,6 +526,44 @@ pub mod serde_service_id {
     }
 }
 
+/// Serde adapter for a `Vec<ServiceId>` represented as a JSON array of
+/// service-id strings (the wire form used by Signal's multi-recipient endpoints;
+/// see `SendMultiRecipientMessageResponse.uuids404`).
+pub mod serde_service_id_vec {
+    use libsignal_protocol::ServiceId;
+    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(
+        ids: &Vec<ServiceId>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(ids.len()))?;
+        for id in ids {
+            seq.serialize_element(&id.service_id_string())?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<Vec<ServiceId>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<String>::deserialize(deserializer)?
+            .into_iter()
+            .map(|s| {
+                ServiceId::parse_from_service_id_string(&s).ok_or_else(|| {
+                    serde::de::Error::custom("invalid service ID string")
+                })
+            })
+            .collect()
+    }
+}
+
 pub mod serde_aci {
     use libsignal_core::Aci;
     use serde::{Deserialize, Deserializer, Serializer};

--- a/src/websocket/request.rs
+++ b/src/websocket/request.rs
@@ -52,6 +52,17 @@ impl WebSocketRequestMessageBuilder {
         Ok(self.header("content-type", "application/json").request)
     }
 
+    /// Attach a raw body (e.g. the Sealed Sender v2 multi-recipient MRM
+    /// payload) with an explicit `Content-Type` header.
+    pub fn body(
+        mut self,
+        content_type: &str,
+        body: Vec<u8>,
+    ) -> WebSocketRequestMessage {
+        self.request.body = Some(body);
+        self.header("content-type", content_type).request
+    }
+
     pub fn build(self) -> WebSocketRequestMessage {
         self.request
     }

--- a/src/websocket/sender.rs
+++ b/src/websocket/sender.rs
@@ -1,6 +1,9 @@
 use crate::{
-    push_service::response::error_mapper,
-    sender::{OutgoingPushMessages, SendMessageResponse},
+    push_service::{response::error_mapper, SendMultiRecipientMessageResponse},
+    sender::{
+        MultiRecipientMessagesRequest, OutgoingPushMessages,
+        SendMessageResponse,
+    },
     unidentified_access::UnidentifiedAccess,
     utils::BASE64_RELAXED,
 };
@@ -27,7 +30,6 @@ error_mapper! {
 // Signal-Server: controllers/MessageController.java:466
 // (PUT /v1/messages/multi_recipient)
 error_mapper! {
-    #[allow(dead_code)]
     put_multi_recipient_messages_errors:
         // 409: mismatched devices, MessageController.java:670
         CONFLICT => MultiRecipientMismatchedDevices(Vec<crate::push_service::AccountMismatchedDevices>),
@@ -38,6 +40,13 @@ error_mapper! {
         // 428: proof required, MessageController.java:638
         PRECONDITION_REQUIRED => ProofRequiredError(crate::push_service::ProofRequired),
 }
+
+/// Media type for the Sealed Sender v2 multi-recipient payload.
+///
+/// Matches `MultiRecipientMessageProvider.MEDIA_TYPE` on the server. Only the
+/// raw bytes (as produced by `libsignal_protocol::sealed_sender_multi_recipient_encrypt`)
+/// are sent; the server re-parses and fans out per recipient.
+const MULTI_RECIPIENT_MEDIA_TYPE: &str = "application/vnd.signal-messenger.mrm";
 
 impl<C: WebSocketType> SignalWebSocket<C> {
     pub async fn send_messages(
@@ -69,5 +78,59 @@ impl<C: WebSocketType> SignalWebSocket<C> {
             )
             .json(&messages)?;
         self.request_json_with(request, put_messages_errors).await
+    }
+}
+
+/// `PUT /v1/messages/multi_recipient`: deliver a single Sealed Sender v2
+/// multi-recipient payload to all of its recipients.
+///
+/// The body content type is [`MULTI_RECIPIENT_MEDIA_TYPE`] and the body is
+/// the raw bytes returned by `libsignal_protocol::sealed_sender_multi_recipient_encrypt`
+/// — the server re-parses the multi-recipient message and fans it out per
+/// recipient.
+///
+/// Multi-recipient sends are *unauthenticated* (the access header authorizes
+/// delivery), mirroring libsignal's `send_multi_recipient_message` on the
+/// unauth chat connection and Android's unauth `messageApi.sendGroupMessage`.
+///
+/// `request.access` sets the authorization header per the
+/// [`MultiRecipientAccess`] variant; pass `None` for stories. The 200
+/// response lists any group-send-endorsement recipients the server could not
+/// resolve as registered users.
+///
+/// `409`/`410` become [`ServiceError::MultiRecipientMismatchedDevices`] /
+/// [`ServiceError::MultiRecipientStaleDevices`] respectively, rather than
+/// the single-recipient variants decoded by
+/// [`SignalWebSocket::send_messages`].
+impl SignalWebSocket<Unidentified> {
+    pub async fn send_multi_recipient_messages(
+        &mut self,
+        request: MultiRecipientMessagesRequest<'_>,
+    ) -> Result<SendMultiRecipientMessageResponse, ServiceError> {
+        let MultiRecipientMessagesRequest {
+            timestamp,
+            online,
+            urgent,
+            story,
+            payload,
+            access,
+        } = request;
+
+        // Match the query-parameter form used by the Java client
+        // (GROUP_MESSAGE_PATH /v1/messages/multi_recipient?ts=...&online=...&urgent=...&story=...).
+        let path = format!(
+            "/v1/messages/multi_recipient?ts={timestamp}&online={online}&urgent={urgent}&story={story}"
+        );
+
+        let mut builder = WebSocketRequestMessage::new(Method::PUT).path(path);
+        if let Some(access) = access.as_ref() {
+            let (name, value) = access.header();
+            builder = builder.header(name, value);
+        }
+        let request =
+            builder.body(MULTI_RECIPIENT_MEDIA_TYPE, payload.to_vec());
+
+        self.request_json_with(request, put_multi_recipient_messages_errors)
+            .await
     }
 }


### PR DESCRIPTION
Still requires #451 for true efficiency gains, but this implements sender-side sender keys. Tested working, but I still need a few passes through the code to get rid of the "vibes".