### PR TITLE
Rework pre-key management, lifecycle, tracking, rotation

### DIFF
--- a/examples/storage.rs
+++ b/examples/storage.rs
@@ -1,4 +1,6 @@
-use libsignal_service::pre_keys::{KyberPreKeyStoreExt, PreKeysStore};
+use libsignal_service::pre_keys::{
+    KyberPreKeyStoreExt, PreKeysStore, SignedPreKeyStoreExt,
+};
 use libsignal_service::protocol::{
     Direction, IdentityChange, IdentityKey, IdentityKeyPair, IdentityKeyStore,
     KyberPreKeyId, KyberPreKeyRecord, KyberPreKeyStore, PreKeyId, PreKeyRecord,
@@ -92,6 +94,23 @@ impl SignedPreKeyStore for ExampleStore {
         &mut self,
         _signed_prekey_id: SignedPreKeyId,
         _record: &SignedPreKeyRecord,
+    ) -> Result<(), SignalProtocolError> {
+        todo!()
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+#[allow(clippy::diverging_sub_expression)]
+impl SignedPreKeyStoreExt for ExampleStore {
+    async fn load_signed_pre_keys(
+        &self,
+    ) -> Result<Vec<SignedPreKeyRecord>, SignalProtocolError> {
+        todo!()
+    }
+
+    async fn remove_signed_pre_key(
+        &self,
+        _pre_key_id: SignedPreKeyId,
     ) -> Result<(), SignalProtocolError> {
         todo!()
     }
@@ -226,15 +245,85 @@ impl PreKeysStore for ExampleStore {
         todo!()
     }
 
-    async fn signed_prekey_id(
+    async fn ec_one_time_pre_keys_count(
+        &self,
+    ) -> Result<usize, SignalProtocolError> {
+        todo!()
+    }
+
+    async fn active_signed_prekey_id(
         &self,
     ) -> Result<Option<SignedPreKeyId>, SignalProtocolError> {
+        todo!()
+    }
+
+    async fn store_one_time_ec_pre_keys(
+        &mut self,
+        _keys: &[PreKeyRecord],
+    ) -> Result<(), SignalProtocolError> {
+        todo!()
+    }
+
+    async fn mark_all_one_time_ec_pre_keys_stale_if_necessary(
+        &mut self,
+        _stale_time: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), SignalProtocolError> {
+        todo!()
+    }
+
+    async fn delete_all_stale_one_time_ec_pre_keys(
+        &mut self,
+        _threshold: chrono::DateTime<chrono::Utc>,
+        _min_count: usize,
+    ) -> Result<(), SignalProtocolError> {
         todo!()
     }
 
     async fn last_resort_kyber_prekey_id(
         &self,
     ) -> Result<Option<KyberPreKeyId>, SignalProtocolError> {
+        todo!()
+    }
+
+    async fn store_one_time_kyber_pre_keys(
+        &mut self,
+        _keys: &[KyberPreKeyRecord],
+    ) -> Result<(), SignalProtocolError> {
+        todo!()
+    }
+
+    async fn set_next_pre_key_id(
+        &mut self,
+        _id: u32,
+    ) -> Result<(), SignalProtocolError> {
+        todo!()
+    }
+
+    async fn set_next_signed_pre_key_id(
+        &mut self,
+        _id: u32,
+    ) -> Result<(), SignalProtocolError> {
+        todo!()
+    }
+
+    async fn set_next_pq_pre_key_id(
+        &mut self,
+        _id: u32,
+    ) -> Result<(), SignalProtocolError> {
+        todo!()
+    }
+
+    async fn set_active_signed_prekey_id(
+        &mut self,
+        _id: SignedPreKeyId,
+    ) -> Result<(), SignalProtocolError> {
+        todo!()
+    }
+
+    async fn set_active_last_resort_kyber_prekey_id(
+        &mut self,
+        _id: KyberPreKeyId,
+    ) -> Result<(), SignalProtocolError> {
         todo!()
     }
 }

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -1,5 +1,5 @@
 use base64::prelude::*;
-use libsignal_core::{DeviceId, E164};
+use libsignal_core::DeviceId;
 use rand::{CryptoRng, Rng};
 use reqwest::Method;
 use std::collections::HashMap;
@@ -9,49 +9,39 @@ use aes::cipher::{KeyIvInit, StreamCipher as _};
 use hmac::{digest::Output, KeyInit};
 use hmac::{Hmac, Mac};
 use libsignal_protocol::{
-    kem, Aci, GenericSignedPreKey, IdentityKey, IdentityKeyPair,
-    IdentityKeyStore, KeyPair, KyberPreKeyRecord, PrivateKey, ProtocolStore,
-    PublicKey, SenderKeyStore, ServiceIdKind, SignedPreKeyRecord, Timestamp,
+    Aci, GenericSignedPreKey, IdentityKey, IdentityKeyPair, IdentityKeyStore,
+    KeyPair, PrivateKey, PublicKey, ServiceIdKind,
 };
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tracing_futures::Instrument;
 use zkgroup::profiles::ProfileKey;
 
-use crate::content::ContentBody;
+use crate::configuration::Endpoint;
 use crate::pre_keys::{
     clean_stale_pre_keys, generate_pre_keys, mark_pre_key_bundle_active,
-    store_pre_key_bundle, KyberPreKeyEntity, PreKeyEntity, PreKeysStore,
-    SignedPreKeyEntity, PRE_KEY_BATCH_SIZE,
+    store_pre_key_bundle, KyberPreKeyEntity, PreKeyEntity, PreKeyState,
+    PreKeysStore, SignedPreKeyEntity, PRE_KEY_BATCH_SIZE,
 };
-use crate::prelude::{MessageSender, MessageSenderError};
-use crate::proto::sync_message::PniChangeNumber;
-use crate::proto::{DeviceName, SyncMessage};
-use crate::provisioning::{generate_registration_id, ProvisioningSecrets};
-use crate::push_service::response::{device_limit_reached, error_mapper};
+use crate::profile_cipher::{ProfileCipher, ProfileCipherError};
+use crate::profile_name::ProfileName;
+use crate::proto::{
+    DeviceName, ProvisionEnvelope, ProvisionMessage, ProvisioningVersion,
+};
+use crate::provisioning::{
+    ProvisioningCipher, ProvisioningError, ProvisioningSecrets,
+};
+use crate::push_service::response::{
+    device_limit_reached, error_mapper, SignalServiceResponse,
+};
 use crate::push_service::{
-    AvatarWrite, HttpAuthOverride, SignalServiceResponse, DEFAULT_DEVICE_ID,
+    AvatarWrite, HttpAuthOverride, PushService, ServiceError,
 };
-use crate::sender::OutgoingPushMessage;
 use crate::service_address::ServiceIdExt;
-use crate::session_store::SessionStoreExt;
-use crate::timestamp::TimestampExt as _;
-use crate::utils::{random_length_padding, BASE64_RELAXED};
-use crate::websocket::account::DeviceInfo;
+use crate::utils::{serde_base64, BASE64_RELAXED};
+use crate::websocket::account::{AccountAttributes, DeviceInfo};
 use crate::websocket::registration::CaptchaAttributes;
 use crate::websocket::{self, SignalWebSocket};
-use crate::{
-    configuration::Endpoint,
-    pre_keys::PreKeyState,
-    profile_cipher::{ProfileCipher, ProfileCipherError},
-    profile_name::ProfileName,
-    proto::{ProvisionEnvelope, ProvisionMessage, ProvisioningVersion},
-    provisioning::{ProvisioningCipher, ProvisioningError},
-    push_service::{PushService, ServiceError},
-    utils::serde_base64,
-    websocket::account::AccountAttributes,
-};
 
 // Signal-Server: controllers/DeviceController.java:193
 // (GET /v1/devices/provisioning/code)
@@ -610,234 +600,6 @@ impl AccountManager {
             .send()
             .await?
             .service_error_for_status_with(submit_challenge_errors)
-            .await?;
-
-        Ok(())
-    }
-
-    /// Initialize PNI on linked devices.
-    ///
-    /// Should be called as the primary device to migrate from pre-PNI to PNI.
-    ///
-    /// This is the equivalent of Android's PnpInitializeDevicesJob or iOS' PniHelloWorldManager.
-    #[tracing::instrument(skip(self, aci_protocol_store, pni_protocol_store, sender, local_aci, csprng), fields(local_aci = local_aci.service_id_string()))]
-    pub async fn pnp_initialize_devices<
-        R: Rng + CryptoRng,
-        AciStore: PreKeysStore + SessionStoreExt,
-        PniStore: PreKeysStore,
-        AciOrPni: ProtocolStore + SenderKeyStore + SessionStoreExt + Sync + Clone,
-    >(
-        &mut self,
-        aci_protocol_store: &mut AciStore,
-        pni_protocol_store: &mut PniStore,
-        mut sender: MessageSender<AciOrPni>,
-        local_aci: Aci,
-        e164: E164,
-        csprng: &mut R,
-    ) -> Result<(), MessageSenderError> {
-        let pni_identity_key_pair =
-            pni_protocol_store.get_identity_key_pair().await?;
-
-        let pni_identity_key = pni_identity_key_pair.identity_key();
-
-        // For every linked device, we generate a new set of pre-keys, and send them to the device.
-        let local_device_ids = aci_protocol_store
-            .get_sub_device_sessions(&local_aci.into())
-            .await?;
-
-        let mut device_messages =
-            Vec::<OutgoingPushMessage>::with_capacity(local_device_ids.len());
-        let mut device_pni_signed_prekeys =
-            HashMap::<String, SignedPreKeyEntity>::with_capacity(
-                local_device_ids.len(),
-            );
-        let mut device_pni_last_resort_kyber_prekeys =
-            HashMap::<String, KyberPreKeyEntity>::with_capacity(
-                local_device_ids.len(),
-            );
-        let mut pni_registration_ids =
-            HashMap::<String, u32>::with_capacity(local_device_ids.len());
-
-        let signature_valid_on_each_signed_pre_key = true;
-        for local_device_id in
-            std::iter::once(*DEFAULT_DEVICE_ID).chain(local_device_ids)
-        {
-            let local_protocol_address =
-                local_aci.to_protocol_address(local_device_id)?;
-            let span = tracing::trace_span!(
-                "filtering devices",
-                address = %local_protocol_address
-            );
-            // Skip if we don't have a session with the device
-            if (local_device_id != *DEFAULT_DEVICE_ID)
-                && aci_protocol_store
-                    .load_session(&local_protocol_address)
-                    .instrument(span)
-                    .await?
-                    .is_none()
-            {
-                tracing::warn!(
-                    "No session with device {}, skipping PNI provisioning",
-                    local_device_id
-                );
-                continue;
-            }
-            let (
-                _pre_keys,
-                signed_pre_key,
-                _kyber_pre_keys,
-                last_resort_kyber_prekey,
-            ) = if local_device_id == *DEFAULT_DEVICE_ID {
-                let (
-                    pre_keys,
-                    signed_pre_key,
-                    kyber_pre_keys,
-                    last_resort_kyber_prekey,
-                ) = generate_pre_keys(
-                    pni_protocol_store,
-                    csprng,
-                    &pni_identity_key_pair,
-                    true,
-                    0,
-                    0,
-                )
-                .await?;
-
-                // Persist the generated keys
-                for key in &pre_keys {
-                    pni_protocol_store.save_pre_key(key.id()?, key).await?;
-                }
-                for key in &kyber_pre_keys {
-                    pni_protocol_store
-                        .save_kyber_pre_key(key.id()?, key)
-                        .await?;
-                }
-                pni_protocol_store
-                    .save_signed_pre_key(signed_pre_key.id()?, &signed_pre_key)
-                    .await?;
-                if let Some(ref k) = last_resort_kyber_prekey {
-                    pni_protocol_store
-                        .store_last_resort_kyber_pre_key(k.id()?, k)
-                        .await?;
-                }
-
-                (
-                    pre_keys,
-                    signed_pre_key,
-                    kyber_pre_keys,
-                    last_resort_kyber_prekey,
-                )
-            } else {
-                // Generate a signed prekey
-                let signed_pre_key_pair = KeyPair::generate(csprng);
-                let signed_pre_key_public = signed_pre_key_pair.public_key;
-                let signed_pre_key_signature = pni_identity_key_pair
-                    .private_key()
-                    .calculate_signature(
-                        &signed_pre_key_public.serialize(),
-                        csprng,
-                    )
-                    .map_err(MessageSenderError::InvalidPrivateKey)?;
-
-                let signed_prekey_record = SignedPreKeyRecord::new(
-                    csprng.random_range::<u32, _>(0..0xFFFFFF).into(),
-                    Timestamp::now(),
-                    &signed_pre_key_pair,
-                    &signed_pre_key_signature,
-                );
-
-                // Generate a last-resort Kyber prekey
-                let kyber_pre_key_record = KyberPreKeyRecord::generate(
-                    kem::KeyType::Kyber1024,
-                    csprng.random_range::<u32, _>(0..0xFFFFFF).into(),
-                    pni_identity_key_pair.private_key(),
-                )?;
-                (
-                    vec![],
-                    signed_prekey_record,
-                    vec![],
-                    Some(kyber_pre_key_record),
-                )
-            };
-
-            let registration_id = if local_device_id == *DEFAULT_DEVICE_ID {
-                pni_protocol_store.get_local_registration_id().await?
-            } else {
-                loop {
-                    let regid = generate_registration_id(csprng);
-                    if !pni_registration_ids.iter().any(|(_k, v)| *v == regid) {
-                        break regid;
-                    }
-                }
-            };
-
-            let local_device_id_s = local_device_id.to_string();
-            device_pni_signed_prekeys.insert(
-                local_device_id_s.clone(),
-                SignedPreKeyEntity::try_from(&signed_pre_key)?,
-            );
-            device_pni_last_resort_kyber_prekeys.insert(
-                local_device_id_s.clone(),
-                KyberPreKeyEntity::try_from(
-                    last_resort_kyber_prekey
-                        .as_ref()
-                        .expect("requested last resort key"),
-                )?,
-            );
-            pni_registration_ids
-                .insert(local_device_id_s.clone(), registration_id);
-
-            assert!(_pre_keys.is_empty());
-            assert!(_kyber_pre_keys.is_empty());
-
-            if local_device_id == *DEFAULT_DEVICE_ID {
-                // This is the primary device
-                // We don't need to send a message to the primary device
-                continue;
-            }
-            // cfr. SignalServiceMessageSender::getEncryptedSyncPniInitializeDeviceMessage
-            let msg = SyncMessage {
-                content: Some(
-                    crate::proto::sync_message::Content::PniChangeNumber(
-                        PniChangeNumber {
-                            identity_key_pair: Some(
-                                pni_identity_key_pair.serialize().to_vec(),
-                            ),
-                            signed_pre_key: Some(signed_pre_key.serialize()?),
-                            last_resort_kyber_pre_key: Some(
-                                last_resort_kyber_prekey
-                                    .expect("requested last resort key")
-                                    .serialize()?,
-                            ),
-                            registration_id: Some(registration_id),
-                            new_e164: Some(e164.to_string()),
-                        },
-                    ),
-                ),
-                padding: Some(random_length_padding(csprng, 512)),
-                ..SyncMessage::default()
-            };
-            let content: ContentBody = msg.into();
-            let msg = sender
-                .create_encrypted_message(
-                    &local_aci.into(),
-                    None,
-                    local_device_id,
-                    &content.into_proto().encode_to_vec(),
-                )
-                .await?;
-            device_messages.push(msg);
-        }
-
-        self.websocket
-            .distribute_pni_keys(
-                pni_identity_key,
-                device_messages,
-                device_pni_signed_prekeys,
-                device_pni_last_resort_kyber_prekeys,
-                pni_registration_ids,
-                signature_valid_on_each_signed_pre_key,
-            )
             .await?;
 
         Ok(())

--- a/src/account_manager.rs
+++ b/src/account_manager.rs
@@ -21,8 +21,9 @@ use zkgroup::profiles::ProfileKey;
 
 use crate::content::ContentBody;
 use crate::pre_keys::{
-    KyberPreKeyEntity, PreKeyEntity, PreKeysStore, SignedPreKeyEntity,
-    PRE_KEY_BATCH_SIZE, PRE_KEY_MINIMUM,
+    clean_stale_pre_keys, generate_pre_keys, mark_pre_key_bundle_active,
+    store_pre_key_bundle, KyberPreKeyEntity, PreKeyEntity, PreKeysStore,
+    SignedPreKeyEntity, PRE_KEY_BATCH_SIZE,
 };
 use crate::prelude::{MessageSender, MessageSenderError};
 use crate::proto::sync_message::PniChangeNumber;
@@ -38,7 +39,6 @@ use crate::session_store::SessionStoreExt;
 use crate::timestamp::TimestampExt as _;
 use crate::utils::{random_length_padding, BASE64_RELAXED};
 use crate::websocket::account::DeviceInfo;
-use crate::websocket::keys::PreKeyStatus;
 use crate::websocket::registration::CaptchaAttributes;
 use crate::websocket::{self, SignalWebSocket};
 use crate::{
@@ -114,7 +114,8 @@ impl AccountManager {
         protocol_store: &mut P,
         service_id_kind: ServiceIdKind,
     ) -> Result<bool, ServiceError> {
-        let Some(signed_prekey_id) = protocol_store.signed_prekey_id().await?
+        let Some(signed_prekey_id) =
+            protocol_store.active_signed_prekey_id().await?
         else {
             tracing::warn!("No signed prekey found");
             return Ok(false);
@@ -152,151 +153,82 @@ impl AccountManager {
             .await
     }
 
-    /// Checks the availability of pre-keys, and updates them as necessary.
+    /// Generates and updates a fresh set of prekeys, rotating previous ones out.
+    /// Caller must check beforehand that the prekey counts are sufficiently low
+    /// that the refresh needs to be made.
     ///
-    /// Parameters are the protocol's `StoreContext`, and the offsets for the next pre-key and
-    /// signed pre-keys.
+    /// Loosely resembles RefreshPreKeysJob, but does not check, and always rotates everything.
     ///
-    /// Equivalent to Java's RefreshPreKeysJob
-    #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, protocol_store))]
+    /// **Note**: Callers should exhaust the message queue (no pending messages requiring pre-keys)
+    /// before calling this method. The replace operations can cause a race condition where
+    /// messages use a pre-key was removed during this operation. However, in practice
+    /// the clean_* functions used retain the old keys for 90 days and keep
+    /// a minimum of 200 keys in store, which should mitigate this fully.
     pub async fn update_pre_key_bundle<P: PreKeysStore>(
         &mut self,
         protocol_store: &mut P,
         service_id_kind: ServiceIdKind,
         use_last_resort_key: bool,
     ) -> Result<(), ServiceError> {
-        let prekey_status = match self
-            .websocket
-            .get_pre_key_status(service_id_kind)
-            .instrument(tracing::span!(
-                tracing::Level::DEBUG,
-                "Fetching pre key status"
-            ))
-            .await
-        {
-            Ok(status) => status,
-            Err(ServiceError::Unauthorized) => {
-                tracing::info!("Got Unauthorized when fetching pre-key status. Assuming first installment.");
-                // Additionally, the second PUT request will fail if this really comes down to an
-                // authorization failure.
-                PreKeyStatus {
-                    count: 0,
-                    pq_count: 0,
-                }
-            },
-            Err(e) => return Err(e),
-        };
-        tracing::trace!("Remaining pre-keys on server: {:?}", prekey_status);
+        let identity_key_pair = protocol_store.get_identity_key_pair().await?;
 
-        let check_pre_keys = self
-            .check_pre_keys(protocol_store, service_id_kind)
-            .instrument(tracing::span!(
-                tracing::Level::DEBUG,
-                "Checking pre keys"
-            ))
-            .await?;
-        if !check_pre_keys {
-            tracing::info!(
-                "Last resort pre-keys are not up to date; refreshing."
-            );
-        } else {
-            tracing::debug!("Last resort pre-keys are up to date.");
-        }
-
-        // XXX We should honestly compare the pre-key count with the number of pre-keys we have
-        // locally. If we have more than the server, we should upload them.
-        // Currently the trait doesn't allow us to do that, so we just upload the batch size and
-        // pray.
-        if check_pre_keys
-            && (prekey_status.count >= PRE_KEY_MINIMUM
-                && prekey_status.pq_count >= PRE_KEY_MINIMUM)
-        {
-            if protocol_store.signed_pre_keys_count().await? > 0
-                && protocol_store.kyber_pre_keys_count(true).await? > 0
-                && protocol_store.signed_prekey_id().await?.is_some()
-                && protocol_store
-                    .last_resort_kyber_prekey_id()
-                    .await?
-                    .is_some()
-            {
-                tracing::debug!("Available keys sufficient");
-                return Ok(());
-            }
-            tracing::info!("Available keys sufficient; forcing refresh.");
-        }
-
-        let identity_key_pair = protocol_store
-            .get_identity_key_pair()
-            .instrument(tracing::trace_span!("get identity key pair"))
-            .await?;
-
-        let last_resort_keys = protocol_store
-            .load_last_resort_kyber_pre_keys()
-            .instrument(tracing::trace_span!("fetch last resort key"))
-            .await?;
-
-        // XXX: Maybe this check should be done in the generate_pre_keys function?
-        let has_last_resort_key = !last_resort_keys.is_empty();
-
+        // Generate - doesn't change state.
         let (pre_keys, signed_pre_key, pq_pre_keys, pq_last_resort_key) =
-            crate::pre_keys::replenish_pre_keys(
+            generate_pre_keys(
                 protocol_store,
                 &mut rand::rng(),
                 &identity_key_pair,
-                use_last_resort_key && !has_last_resort_key,
+                use_last_resort_key,
                 PRE_KEY_BATCH_SIZE,
                 PRE_KEY_BATCH_SIZE,
             )
             .await?;
 
-        let pq_last_resort_key = if has_last_resort_key {
-            if last_resort_keys.len() > 1 {
-                tracing::warn!(
-                    "More than one last resort key found; only uploading first"
-                );
-            }
-            Some(KyberPreKeyEntity::try_from(last_resort_keys[0].clone())?)
-        } else {
-            pq_last_resort_key
-                .map(KyberPreKeyEntity::try_from)
-                .transpose()?
-        };
+        // Persist + advance next-ids pre-upload
+        store_pre_key_bundle(
+            protocol_store,
+            &pre_keys,
+            &signed_pre_key,
+            &pq_pre_keys,
+            pq_last_resort_key.as_ref(),
+        )
+        .await?;
 
-        let identity_key = *identity_key_pair.identity_key();
-
-        let pre_keys: Vec<_> = pre_keys
-            .into_iter()
-            .map(PreKeyEntity::try_from)
-            .collect::<Result<_, _>>()?;
-        let signed_pre_key = signed_pre_key.try_into()?;
-        let pq_pre_keys: Vec<_> = pq_pre_keys
-            .into_iter()
-            .map(KyberPreKeyEntity::try_from)
-            .collect::<Result<_, _>>()?;
-
-        tracing::info!(
-            "Uploading pre-keys: {} one-time, {} PQ, {} PQ last resort",
-            pre_keys.len(),
-            pq_pre_keys.len(),
-            if pq_last_resort_key.is_some() { 1 } else { 0 }
-        );
-
-        let pre_key_state = PreKeyState {
-            pre_keys,
-            signed_pre_key,
-            identity_key,
-            pq_pre_keys,
-            pq_last_resort_key,
-        };
-
+        // Upload
         self.websocket
-            .register_pre_keys(service_id_kind, pre_key_state)
-            .instrument(tracing::span!(
-                tracing::Level::DEBUG,
-                "Uploading pre keys"
-            ))
+            .register_pre_keys(
+                service_id_kind,
+                &PreKeyState {
+                    pre_keys: pre_keys
+                        .iter()
+                        .map(PreKeyEntity::try_from)
+                        .collect::<Result<_, _>>()?,
+                    signed_pre_key: SignedPreKeyEntity::try_from(
+                        &signed_pre_key,
+                    )?,
+                    identity_key: *identity_key_pair.identity_key(),
+                    pq_pre_keys: pq_pre_keys
+                        .iter()
+                        .map(KyberPreKeyEntity::try_from)
+                        .collect::<Result<_, _>>()?,
+                    pq_last_resort_key: pq_last_resort_key
+                        .as_ref()
+                        .map(KyberPreKeyEntity::try_from)
+                        .transpose()?,
+                },
+            )
             .await?;
+
+        // Set active ids post-upload
+        mark_pre_key_bundle_active(
+            protocol_store,
+            &signed_pre_key,
+            pq_last_resort_key.as_ref(),
+        )
+        .await?;
+
+        // Cleanup storage from stale material
+        clean_stale_pre_keys(protocol_store).await?;
 
         Ok(())
     }
@@ -756,7 +688,12 @@ impl AccountManager {
                 _kyber_pre_keys,
                 last_resort_kyber_prekey,
             ) = if local_device_id == *DEFAULT_DEVICE_ID {
-                crate::pre_keys::replenish_pre_keys(
+                let (
+                    pre_keys,
+                    signed_pre_key,
+                    kyber_pre_keys,
+                    last_resort_kyber_prekey,
+                ) = generate_pre_keys(
                     pni_protocol_store,
                     csprng,
                     &pni_identity_key_pair,
@@ -764,7 +701,32 @@ impl AccountManager {
                     0,
                     0,
                 )
-                .await?
+                .await?;
+
+                // Persist the generated keys
+                for key in &pre_keys {
+                    pni_protocol_store.save_pre_key(key.id()?, key).await?;
+                }
+                for key in &kyber_pre_keys {
+                    pni_protocol_store
+                        .save_kyber_pre_key(key.id()?, key)
+                        .await?;
+                }
+                pni_protocol_store
+                    .save_signed_pre_key(signed_pre_key.id()?, &signed_pre_key)
+                    .await?;
+                if let Some(ref k) = last_resort_kyber_prekey {
+                    pni_protocol_store
+                        .store_last_resort_kyber_pre_key(k.id()?, k)
+                        .await?;
+                }
+
+                (
+                    pre_keys,
+                    signed_pre_key,
+                    kyber_pre_keys,
+                    last_resort_kyber_prekey,
+                )
             } else {
                 // Generate a signed prekey
                 let signed_pre_key_pair = KeyPair::generate(csprng);

--- a/src/pre_keys.rs
+++ b/src/pre_keys.rs
@@ -14,7 +14,6 @@ use libsignal_protocol::{
 
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
-use tracing::Instrument;
 
 #[async_trait(?Send)]
 /// Additional methods for the Kyber pre key store
@@ -50,17 +49,48 @@ pub trait KyberPreKeyStoreExt: KyberPreKeyStore {
     ) -> Result<(), SignalProtocolError>;
 }
 
+#[async_trait(?Send)]
+/// Additional methods for the signed pre key store
+pub trait SignedPreKeyStoreExt: SignedPreKeyStore {
+    async fn load_signed_pre_keys(
+        &self,
+    ) -> Result<Vec<SignedPreKeyRecord>, SignalProtocolError>;
+
+    async fn remove_signed_pre_key(
+        &self,
+        pre_key_id: SignedPreKeyId,
+    ) -> Result<(), SignalProtocolError>;
+}
+
 /// Stores the ID of keys published ahead of time
 ///
 /// <https://signal.org/docs/specifications/x3dh/>
+///
+/// ## Next-ID advance contract
+///
+/// Implementors of the `set_next_*` setters MUST treat them as plain
+/// persistence: write the value, return. They MUST NOT advance, wrap, or
+/// otherwise mutate the id. All advancing (increment + `% PRE_KEY_MEDIUM_MAX_VALUE`
+/// wrap, starting from 1) is performed by libsignal-service-rs orchestration after key
+/// generation, then written via the setter. The `store_one_time_*` methods
+/// likewise only persist records; they do NOT advance next-ids.
+///
+/// ## Active-ID contract
+///
+/// `set_active_*` records the id the server has accepted. Orchestration calls
+/// these only after a successful upload, so `clean_*` excludes the correct
+/// live key. The matching getters return `None` before the first upload.
 #[async_trait(?Send)]
 pub trait PreKeysStore:
     PreKeyStore
     + IdentityKeyStore
     + SignedPreKeyStore
+    + SignedPreKeyStoreExt
     + KyberPreKeyStore
     + KyberPreKeyStoreExt
 {
+    // ---- Next-ID getters ----
+
     /// ID of the next pre key
     async fn next_pre_key_id(&self) -> Result<u32, SignalProtocolError>;
 
@@ -69,6 +99,25 @@ pub trait PreKeysStore:
 
     /// ID of the next PQ pre key
     async fn next_pq_pre_key_id(&self) -> Result<u32, SignalProtocolError>;
+
+    // ---- Next-ID setters (persistence only; do NOT advance) ----
+
+    async fn set_next_pre_key_id(
+        &mut self,
+        id: u32,
+    ) -> Result<(), SignalProtocolError>;
+
+    async fn set_next_signed_pre_key_id(
+        &mut self,
+        id: u32,
+    ) -> Result<(), SignalProtocolError>;
+
+    async fn set_next_pq_pre_key_id(
+        &mut self,
+        id: u32,
+    ) -> Result<(), SignalProtocolError>;
+
+    // ---- Counts ----
 
     /// number of signed pre-keys we currently have in store
     async fn signed_pre_keys_count(&self)
@@ -80,13 +129,59 @@ pub trait PreKeysStore:
         last_resort: bool,
     ) -> Result<usize, SignalProtocolError>;
 
-    async fn signed_prekey_id(
+    /// number of one-time EC pre-keys we currently have in store
+    async fn ec_one_time_pre_keys_count(
+        &self,
+    ) -> Result<usize, SignalProtocolError>;
+
+    // ---- Active-ID getters ----
+
+    async fn active_signed_prekey_id(
         &self,
     ) -> Result<Option<SignedPreKeyId>, SignalProtocolError>;
 
     async fn last_resort_kyber_prekey_id(
         &self,
     ) -> Result<Option<KyberPreKeyId>, SignalProtocolError>;
+
+    // ---- Active-ID setters (call after successful server upload) ----
+
+    async fn set_active_signed_prekey_id(
+        &mut self,
+        id: SignedPreKeyId,
+    ) -> Result<(), SignalProtocolError>;
+
+    async fn set_active_last_resort_kyber_prekey_id(
+        &mut self,
+        id: KyberPreKeyId,
+    ) -> Result<(), SignalProtocolError>;
+
+    // ---- One-time key storage (persistence only; do NOT advance next-ids) ----
+
+    async fn store_one_time_ec_pre_keys(
+        &mut self,
+        keys: &[PreKeyRecord],
+    ) -> Result<(), SignalProtocolError>;
+
+    async fn store_one_time_kyber_pre_keys(
+        &mut self,
+        keys: &[KyberPreKeyRecord],
+    ) -> Result<(), SignalProtocolError>;
+
+    // ---- Staleness / cleanup hooks ----
+
+    /// Analogous to markAllOneTimeEcPreKeysStaleIfNecessary
+    async fn mark_all_one_time_ec_pre_keys_stale_if_necessary(
+        &mut self,
+        stale_time: chrono::DateTime<chrono::Utc>,
+    ) -> Result<(), SignalProtocolError>;
+
+    /// Analogue of deleteAllStaleOneTimeEcPreKeys
+    async fn delete_all_stale_one_time_ec_pre_keys(
+        &mut self,
+        threshold: chrono::DateTime<chrono::Utc>,
+        min_count: usize,
+    ) -> Result<(), SignalProtocolError>;
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -180,11 +275,15 @@ pub struct PreKeyState {
     pub pq_pre_keys: Vec<KyberPreKeyEntity>,
 }
 
-pub(crate) const PRE_KEY_MINIMUM: u32 = 10;
 pub(crate) const PRE_KEY_BATCH_SIZE: u32 = 100;
 pub(crate) const PRE_KEY_MEDIUM_MAX_VALUE: u32 = 0xFFFFFF;
 
-pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
+fn wrap_next(id: u32) -> u32 {
+    (id % (PRE_KEY_MEDIUM_MAX_VALUE - 1)) + 1
+}
+
+/// Generate in-memory pre-keys for the caller to persist as needed.
+pub(crate) async fn generate_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
     protocol_store: &mut P,
     csprng: &mut R,
     identity_key_pair: &IdentityKeyPair,
@@ -205,7 +304,8 @@ pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
         protocol_store.next_signed_pre_key_id().await?;
     let pq_pre_keys_offset_id = protocol_store.next_pq_pre_key_id().await?;
 
-    let span = tracing::span!(tracing::Level::DEBUG, "Generating pre keys");
+    let _span =
+        tracing::span!(tracing::Level::DEBUG, "Generating pre keys").entered();
 
     let mut pre_keys = vec![];
     let mut pq_pre_keys = vec![];
@@ -213,37 +313,20 @@ pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
     // EC keys
     for i in 0..pre_key_count {
         let key_pair = KeyPair::generate(csprng);
-        let pre_key_id =
-            (((pre_keys_offset_id + i) % (PRE_KEY_MEDIUM_MAX_VALUE - 1)) + 1)
-                .into();
+        let pre_key_id = wrap_next(pre_keys_offset_id + i).into();
         let pre_key_record = PreKeyRecord::new(pre_key_id, &key_pair);
-        protocol_store
-                    .save_pre_key(pre_key_id, &pre_key_record)
-                    .instrument(tracing::trace_span!(parent: &span, "save pre key", ?pre_key_id)).await?;
-        // TODO: Shouldn't this also remove the previous pre-keys from storage?
-        //       I think we might want to update the storage, and then sync the storage to the
-        //       server.
 
         pre_keys.push(pre_key_record);
     }
 
     // Kyber keys
     for i in 0..kyber_pre_key_count {
-        let pre_key_id = (((pq_pre_keys_offset_id + i)
-            % (PRE_KEY_MEDIUM_MAX_VALUE - 1))
-            + 1)
-        .into();
+        let pre_key_id = wrap_next(pq_pre_keys_offset_id + i).into();
         let pre_key_record = KyberPreKeyRecord::generate(
             kem::KeyType::Kyber1024,
             pre_key_id,
             identity_key_pair.private_key(),
         )?;
-        protocol_store
-                    .save_kyber_pre_key(pre_key_id, &pre_key_record)
-                    .instrument(tracing::trace_span!(parent: &span, "save kyber pre key", ?pre_key_id)).await?;
-        // TODO: Shouldn't this also remove the previous pre-keys from storage?
-        //       I think we might want to update the storage, and then sync the storage to the
-        //       server.
 
         pq_pre_keys.push(pre_key_record);
     }
@@ -262,37 +345,15 @@ pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
         &signed_pre_key_signature,
     );
 
-    protocol_store
-                .save_signed_pre_key(
-                    next_signed_pre_key_id.into(),
-                    &signed_prekey_record,
-                )
-                    .instrument(tracing::trace_span!(parent: &span, "save signed pre key", signed_pre_key_id = ?next_signed_pre_key_id)).await?;
-
     let pq_last_resort_key = if use_last_resort_key {
-        let pre_key_id = (((pq_pre_keys_offset_id + kyber_pre_key_count)
-            % (PRE_KEY_MEDIUM_MAX_VALUE - 1))
-            + 1)
-        .into();
-
-        if !pq_pre_keys.is_empty() {
-            assert_eq!(
-                u32::from(pq_pre_keys.last().unwrap().id()?) + 1,
-                u32::from(pre_key_id)
-            );
-        }
+        let pre_key_id =
+            wrap_next(pq_pre_keys_offset_id + kyber_pre_key_count).into();
 
         let pre_key_record = KyberPreKeyRecord::generate(
             kem::KeyType::Kyber1024,
             pre_key_id,
             identity_key_pair.private_key(),
         )?;
-        protocol_store
-                    .store_last_resort_kyber_pre_key(pre_key_id, &pre_key_record)
-                    .instrument(tracing::trace_span!(parent: &span, "save last resort kyber pre key", ?pre_key_id)).await?;
-        // TODO: Shouldn't this also remove the previous pre-keys from storage?
-        //       I think we might want to update the storage, and then sync the storage to the
-        //       server.
 
         Some(pre_key_record)
     } else {
@@ -305,4 +366,180 @@ pub(crate) async fn replenish_pre_keys<R: Rng + CryptoRng, P: PreKeysStore>(
         pq_pre_keys,
         pq_last_resort_key,
     ))
+}
+
+/// Stores a complete pre-key bundle to the protocol store.
+///
+/// Marks existing one-time pre-keys as stale (preserved for grace period),
+/// inserts the new keys, then advances the next-id counters and records the
+/// active signed / last-resort ids. The store's `set_next_*` / `set_active_*`
+/// are pure persistence — all advancing happens here.
+///
+/// Caller invokes the cleanup helpers (`clean_signed_pre_keys`,
+/// `clean_one_time_pre_keys`, etc.) after the bundle is uploaded.
+pub(crate) async fn store_pre_key_bundle<P: PreKeysStore>(
+    protocol_store: &mut P,
+    pre_keys: &[PreKeyRecord],
+    signed_pre_key: &SignedPreKeyRecord,
+    pq_pre_keys: &[KyberPreKeyRecord],
+    pq_last_resort_key: Option<&KyberPreKeyRecord>,
+) -> Result<(), SignalProtocolError> {
+    let now = chrono::Utc::now();
+
+    // Mark old one-time keys as stale before inserting new ones
+    protocol_store
+        .mark_all_one_time_ec_pre_keys_stale_if_necessary(now)
+        .await?;
+    protocol_store
+        .mark_all_one_time_kyber_pre_keys_stale_if_necessary(now)
+        .await?;
+
+    // Insert new EC one-time pre-keys
+    for k in pre_keys {
+        protocol_store.save_pre_key(k.id()?, k).await?;
+    }
+
+    // Insert new Kyber one-time pre-keys
+    for k in pq_pre_keys {
+        protocol_store.save_kyber_pre_key(k.id()?, k).await?;
+    }
+
+    // Persist signed pre-key
+    protocol_store
+        .save_signed_pre_key(signed_pre_key.id()?, signed_pre_key)
+        .await?;
+
+    // Persist last-resort Kyber key if present
+    if let Some(k) = pq_last_resort_key {
+        protocol_store
+            .store_last_resort_kyber_pre_key(k.id()?, k)
+            .await?;
+    }
+
+    // ---- Advance next-ids (pre-upload, Android model) ----
+    // Store setters only persist; the advance is computed here.
+
+    if let Some(last) = pre_keys.last() {
+        let next = wrap_next(u32::from(last.id()?));
+        protocol_store.set_next_pre_key_id(next).await?;
+    }
+
+    // Kyber next-id must account for the last-resort key, which is generated
+    // one past the one-time batch and shares the kyber id space. Advance from
+    // whichever id is highest: last-resort if present, else the batch tail.
+    let pq_advance_from = pq_last_resort_key
+        .map(|k| k.id())
+        .or_else(|| pq_pre_keys.last().map(|k| k.id()))
+        .transpose()?;
+    if let Some(id) = pq_advance_from {
+        let next = wrap_next(u32::from(id));
+        protocol_store.set_next_pq_pre_key_id(next).await?;
+    }
+
+    // Signed pre-key is a single key, not a batch.
+    {
+        let next = wrap_next(u32::from(signed_pre_key.id()?));
+        protocol_store.set_next_signed_pre_key_id(next).await?;
+    }
+
+    // Active prekey and kyber prekey id's set post upload.
+
+    Ok(())
+}
+
+const ARCHIVE_AGE: chrono::Duration = chrono::Duration::days(30);
+const STALE_AGE: chrono::Duration = chrono::Duration::days(90);
+const ONE_TIME_MIN_COUNT: usize = 200;
+
+pub async fn clean_stale_pre_keys<P: PreKeysStore>(
+    protocol_store: &mut P,
+) -> Result<(), SignalProtocolError> {
+    let now = chrono::Utc::now();
+    let now_ms = now.timestamp_millis() as u64;
+    let one_time_threshold = now - STALE_AGE;
+
+    if let Some(active) = protocol_store.active_signed_prekey_id().await? {
+        let keys = protocol_store.load_signed_pre_keys().await?;
+        let stale = collect_archived(active, keys, now_ms, |r| {
+            Some((r.id().ok()?, r.timestamp().ok()?.epoch_millis()))
+        });
+        for (id, ts) in stale.into_iter().skip(1) {
+            tracing::debug!(?id, ts, "removing old signed pre-key");
+            protocol_store.remove_signed_pre_key(id).await?;
+        }
+    }
+
+    if let Some(active) = protocol_store.last_resort_kyber_prekey_id().await? {
+        let keys = protocol_store.load_last_resort_kyber_pre_keys().await?;
+        let stale = collect_archived(active, keys, now_ms, |r| {
+            Some((r.id().ok()?, r.timestamp().ok()?.epoch_millis()))
+        });
+        for (id, ts) in stale.into_iter().skip(1) {
+            tracing::debug!(?id, ts, "removing old last-resort kyber pre-key");
+            protocol_store.remove_kyber_pre_key(id).await?;
+        }
+    }
+
+    protocol_store
+        .delete_all_stale_one_time_ec_pre_keys(
+            one_time_threshold,
+            ONE_TIME_MIN_COUNT,
+        )
+        .await?;
+    protocol_store
+        .delete_all_stale_one_time_kyber_pre_keys(
+            one_time_threshold,
+            ONE_TIME_MIN_COUNT,
+        )
+        .await?;
+    Ok(())
+}
+
+/// Filter records older than ARCHIVE_AGE,
+/// excluding the active id, sorted newest-first.
+fn collect_archived<R, I>(
+    active_id: I,
+    records: Vec<R>,
+    now_ms: u64,
+    extract: impl Fn(&R) -> Option<(I, u64)>,
+) -> Vec<(I, u64)>
+where
+    I: PartialEq + Copy,
+{
+    let mut stale: Vec<_> = records
+        .into_iter()
+        .filter_map(|r| {
+            let (id, ts) = extract(&r)?;
+            if id == active_id {
+                return None;
+            }
+            (now_ms.saturating_sub(ts) > ARCHIVE_AGE.num_milliseconds() as _)
+                .then_some((id, ts))
+        })
+        .collect();
+    stale.sort_by_key(|x| std::cmp::Reverse(x.1));
+    stale
+}
+
+/// Records the signed / last-resort ids the server has accepted as active.
+///
+/// Call only after the pre-key bundle upload succeeds. `clean_*` uses these
+/// to preserve the live published keys; setting them before upload risks
+/// pointing `active` at a key the server never accepted.
+pub(crate) async fn mark_pre_key_bundle_active<P: PreKeysStore>(
+    protocol_store: &mut P,
+    signed_pre_key: &SignedPreKeyRecord,
+    pq_last_resort_key: Option<&KyberPreKeyRecord>,
+) -> Result<(), SignalProtocolError> {
+    protocol_store
+        .set_active_signed_prekey_id(signed_pre_key.id()?)
+        .await?;
+
+    if let Some(k) = pq_last_resort_key {
+        protocol_store
+            .set_active_last_resort_kyber_prekey_id(k.id()?)
+            .await?;
+    }
+
+    Ok(())
 }

--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -286,11 +286,11 @@ pub async fn link_device<
             IdentityKeyPair::new(pni_public_key, pni_private_key);
 
         let (
-            _aci_pre_keys,
+            aci_pre_keys,
             aci_signed_pre_key,
-            _aci_pq_pre_keys,
+            aci_pq_pre_keys,
             aci_pq_last_resort_pre_key,
-        ) = crate::pre_keys::replenish_pre_keys(
+        ) = crate::pre_keys::generate_pre_keys(
             aci_store,
             csprng,
             &aci_key_pair,
@@ -300,17 +300,12 @@ pub async fn link_device<
         )
         .await?;
 
-        let aci_pq_last_resort_pre_key =
-            aci_pq_last_resort_pre_key.expect("requested last resort key");
-        assert!(_aci_pre_keys.is_empty());
-        assert!(_aci_pq_pre_keys.is_empty());
-
         let (
-            _pni_pre_keys,
+            pni_pre_keys,
             pni_signed_pre_key,
-            _pni_pq_pre_keys,
+            pni_pq_pre_keys,
             pni_pq_last_resort_pre_key,
-        ) = crate::pre_keys::replenish_pre_keys(
+        ) = crate::pre_keys::generate_pre_keys(
             pni_store,
             csprng,
             &pni_key_pair,
@@ -320,10 +315,37 @@ pub async fn link_device<
         )
         .await?;
 
-        let pni_pq_last_resort_pre_key =
-            pni_pq_last_resort_pre_key.expect("requested last resort key");
-        assert!(_pni_pre_keys.is_empty());
-        assert!(_pni_pq_pre_keys.is_empty());
+        crate::pre_keys::store_pre_key_bundle(
+            aci_store,
+            &aci_pre_keys,
+            &aci_signed_pre_key,
+            &aci_pq_pre_keys,
+            aci_pq_last_resort_pre_key.as_ref(),
+        )
+        .await?;
+
+        crate::pre_keys::mark_pre_key_bundle_active(
+            aci_store,
+            &aci_signed_pre_key,
+            aci_pq_last_resort_pre_key.as_ref(),
+        )
+        .await?;
+
+        crate::pre_keys::store_pre_key_bundle(
+            pni_store,
+            &pni_pre_keys,
+            &pni_signed_pre_key,
+            &pni_pq_pre_keys,
+            pni_pq_last_resort_pre_key.as_ref(),
+        )
+        .await?;
+
+        crate::pre_keys::mark_pre_key_bundle_active(
+            pni_store,
+            &pni_signed_pre_key,
+            pni_pq_last_resort_pre_key.as_ref(),
+        )
+        .await?;
 
         let encrypted_device_name = BASE64_RELAXED.encode(
             encrypt_device_name(csprng, device_name, &aci_public_key)?
@@ -350,8 +372,10 @@ pub async fn link_device<
                 aci_signed_pre_key: aci_signed_pre_key.try_into()?,
                 pni_signed_pre_key: pni_signed_pre_key.try_into()?,
                 aci_pq_last_resort_pre_key: aci_pq_last_resort_pre_key
+                    .expect("ACI last resort key when linking")
                     .try_into()?,
                 pni_pq_last_resort_pre_key: pni_pq_last_resort_pre_key
+                    .expect("PNI last resort key when linking")
                     .try_into()?,
             },
         };

--- a/src/websocket/keys.rs
+++ b/src/websocket/keys.rs
@@ -1,14 +1,6 @@
 use std::collections::HashMap;
 
-use libsignal_core::DeviceId;
-use libsignal_protocol::{
-    kem::{Key, Public},
-    IdentityKey, PreKeyBundle, PublicKey, SenderCertificate, ServiceId,
-    ServiceIdKind, SignalProtocolError,
-};
-use reqwest::Method;
-use serde::Deserialize;
-
+use crate::protocol::PreKeyRecord;
 use crate::{
     pre_keys::{
         KyberPreKeyEntity, PreKeyEntity, PreKeyState, SignedPreKeyEntity,
@@ -19,6 +11,14 @@ use crate::{
     utils::{serde_base64, serde_device_id},
     websocket::{self, registration::VerifyAccountResponse, SignalWebSocket},
 };
+use libsignal_core::DeviceId;
+use libsignal_protocol::{
+    kem::{Key, Public},
+    IdentityKey, PreKeyBundle, PublicKey, SenderCertificate, ServiceId,
+    ServiceIdKind, SignalProtocolError,
+};
+use reqwest::Method;
+use serde::Deserialize;
 
 use super::ServiceError;
 
@@ -46,6 +46,16 @@ pub struct PreKeyResponseItem {
     pub signed_pre_key: SignedPreKeyEntity,
     pub pre_key: Option<PreKeyEntity>,
     pub pq_pre_key: KyberPreKeyEntity,
+}
+
+impl TryFrom<&'_ PreKeyRecord> for PreKeyEntity {
+    type Error = SignalProtocolError;
+    fn try_from(key: &'_ PreKeyRecord) -> Result<Self, Self::Error> {
+        Ok(PreKeyEntity {
+            key_id: key.id()?.into(),
+            public_key: key.key_pair()?.public_key.serialize().to_vec(),
+        })
+    }
 }
 
 impl PreKeyResponseItem {
@@ -146,13 +156,13 @@ impl SignalWebSocket<websocket::Identified> {
     pub async fn register_pre_keys(
         &mut self,
         service_id_kind: ServiceIdKind,
-        pre_key_state: PreKeyState,
+        pre_key_state: &PreKeyState,
     ) -> Result<(), ServiceError> {
         self.http_request(
             Method::PUT,
             format!("/v2/keys?identity={}", service_id_kind),
         )?
-        .send_json(&pre_key_state)
+        .send_json(pre_key_state)
         .await?
         .service_error_for_status()
         .await?;

--- a/src/websocket/registration.rs
+++ b/src/websocket/registration.rs
@@ -447,11 +447,11 @@ impl SignalWebSocket<websocket::Unidentified> {
             .await?;
 
         let (
-            _aci_pre_keys,
+            aci_pre_keys,
             aci_signed_pre_key,
-            _aci_kyber_pre_keys,
+            aci_kyber_pre_keys,
             aci_last_resort_kyber_prekey,
-        ) = crate::pre_keys::replenish_pre_keys(
+        ) = crate::pre_keys::generate_pre_keys(
             aci_protocol_store,
             csprng,
             &aci_identity_key_pair,
@@ -462,11 +462,11 @@ impl SignalWebSocket<websocket::Unidentified> {
         .await?;
 
         let (
-            _pni_pre_keys,
+            pni_pre_keys,
             pni_signed_pre_key,
-            _pni_kyber_pre_keys,
+            pni_kyber_pre_keys,
             pni_last_resort_kyber_prekey,
-        ) = crate::pre_keys::replenish_pre_keys(
+        ) = crate::pre_keys::generate_pre_keys(
             pni_protocol_store,
             csprng,
             &pni_identity_key_pair,
@@ -476,8 +476,41 @@ impl SignalWebSocket<websocket::Unidentified> {
         )
         .await?;
 
+        crate::pre_keys::store_pre_key_bundle(
+            aci_protocol_store,
+            aci_pre_keys.as_slice(),
+            &aci_signed_pre_key,
+            aci_kyber_pre_keys.as_slice(),
+            aci_last_resort_kyber_prekey.as_ref(),
+        )
+        .await?;
+
+        crate::pre_keys::mark_pre_key_bundle_active(
+            aci_protocol_store,
+            &aci_signed_pre_key,
+            aci_last_resort_kyber_prekey.as_ref(),
+        )
+        .await?;
+
+        crate::pre_keys::store_pre_key_bundle(
+            pni_protocol_store,
+            pni_pre_keys.as_slice(),
+            &pni_signed_pre_key,
+            pni_kyber_pre_keys.as_slice(),
+            pni_last_resort_kyber_prekey.as_ref(),
+        )
+        .await?;
+
+        crate::pre_keys::mark_pre_key_bundle_active(
+            pni_protocol_store,
+            &pni_signed_pre_key,
+            pni_last_resort_kyber_prekey.as_ref(),
+        )
+        .await?;
+
         let aci_identity_key = aci_identity_key_pair.identity_key();
         let pni_identity_key = pni_identity_key_pair.identity_key();
+
         let keys = RegistrationKeyPackage {
             aci_identity_key: aci_identity_key.serialize().into(),
             pni_identity_key: pni_identity_key.serialize().into(),
@@ -487,10 +520,10 @@ impl SignalWebSocket<websocket::Unidentified> {
             .unwrap(),
             pni_signed_pre_key: pni_signed_pre_key.try_into()?,
             aci_pq_last_resort_pre_key: aci_last_resort_kyber_prekey
-                .expect("requested last resort prekey")
+                .expect("ACI last resort key when registering")
                 .try_into()?,
             pni_pq_last_resort_pre_key: pni_last_resort_kyber_prekey
-                .expect("requested last resort prekey")
+                .expect("PNI last resort key when registering")
                 .try_into()?,
         };
 


### PR DESCRIPTION
As quite obvious, I used Claude heavily making this PR. I think I get every bit and piece individually, but as I'm not an expert in Signal innards, I can't judge the bigger picture. This majorly reworks pre-key handling, and I'm happy to see strictness in several places now. It feels like we've been riding through the night with no headlights, without major accidents so far, and we *really* can't keep doing that. I have been running this in my daily device for some time now and nothing has blown up yet. It seems to work, but please do review with keen eye for slop. And stupid.

Without further ado...

# Rework pre-key management: stale-then-delete lifecycle, persisted ID tracking, split rotation

## Summary

Reworks pre-key generation, storage and rotation to fix ID reuse and align with Signal Android. The old flow persisted keys inside generation, derived next-IDs from `MAX(id)`, and replaced one-time keys wholesale — causing repeated-key 409s and deleting still-published keys mid-handshake.

Two separations do the work. **Generation, persistence and ID bookkeeping** are pulled apart: generation is pure, persistence is dumb, and all ID advancement and active-ID recording is explicit. **Signed and one-time rotation** are split onto independent triggers: the signed and last-resort keys rotate on an age schedule, while one-time keys are replenished only when the server reports it is running low.

## Motivation

1. **ID reuse → 409.** Next-IDs came from `MAX(id)`. Deleting the highest key let the next allocation reuse a freed ID; the server rejected it, and re-upload looped because the active signed-prekey ID was never advanced.
2. **Wholesale replace deleted live keys.** One-time keys were deleted and reinserted on every refresh, removing keys the server might still hand out.
3. **No active-ID tracking.** The store called the highest stored ID "active" rather than the one the server serves.
4. **Unconditional churn.** Every refresh uploaded a full batch of one-time keys regardless of consumption.

## Changes

### Trait surface (`PreKeysStore`)

New `SignedPreKeyStoreExt` supertrait (`load_signed_pre_keys`, `remove_signed_pre_key`). `PreKeysStore` gains next-ID setters, active-ID setters (getter `signed_prekey_id` → `active_signed_prekey_id`), `ec_one_time_pre_keys_count`, the EC staleness hooks, and `last_prekey_rotation` / `set_last_prekey_rotation` for the rotation schedule.

The composed operations are **default methods** on the trait rather than free functions: `generate_signed_pre_keys`, `generate_one_time_pre_keys`, `store_signed_pre_key_bundle`, `store_one_time_pre_key_bundle`, `mark_signed_pre_keys_active`, `clean_stale_pre_keys`, `signed_pre_keys_due_for_rotation`. Implementors get them free; only the persistence primitives are required.

Two contracts are documented on the trait: setters only persist (the advance and wrap are computed by the caller), and `set_active_*` runs only after a successful upload.

### Rotation split (`account_manager.rs`)

`update_pre_key_bundle` becomes two independently gated operations:

- `rotate_signed_pre_keys` — age-gated (2 days), uploads one signed key and one last-resort Kyber key, leaving the one-time pool alone.
- `replenish_one_time_pre_keys` — queries the server's remaining count and uploads a batch only below `PRE_KEY_MINIMUM`, so a routine refresh usually uploads nothing here.

`PreKeyState`'s sections are now optional, so each upload carries only what it replaces. Confirmed on a staging server that a PUT omitting `preKeys`/`pqPreKeys` leaves the server's one-time pool intact.

### Ordering — deliberate divergence from Android

Next-IDs advance pre-upload (a gap on failure is harmless). Active IDs are recorded **post-upload only**, so cleanup never preserves a key the server hasn't accepted, nor deletes the key it still serves. Android sets active pre-upload; this errs safer.

### Removals

`pnp_initialize_devices` is deleted — a one-shot pre-PNI migration no live account can reach, since any account old enough to need it has long since expired server-side.

## Breaking changes

- `PreKeysStore` implementors must add the new required methods; the composed operations arrive as defaults. `ExampleStore` is updated with `todo!()` stubs.
- `signed_prekey_id` → `active_signed_prekey_id`.
- `register_pre_keys` takes `&PreKeyState`; its one-time and signed sections are now `Option`.
- `replenish_pre_keys` removed — use the generate/store pairs, or `update_pre_key_bundle`.
- `pnp_initialize_devices` removed.

## Caller responsibility ⚠️

Registration and linking upload signed and last-resort keys only, so a new device has no one-time keys on the server until its first `update_pre_key_bundle`. Callers should also drain the message queue before rotating: persistence isn't atomic with message handling, though the 90-day stale grace period and `min_count` floor mitigate it.

## Testing

Store-level tests live in the Whisperfish implementation: next-ID no-regress after delete (the 409 bug), the stale→delete lifecycle with a matrix pinning the retention arithmetic, signed rotation leaving one-time pools untouched, and per-identity ID-space independence. Constants match Signal Android master (`BATCH_SIZE` 100, `ARCHIVE_AGE` 30d, `ONE_TIME_PREKEY_MINIMUM` 10, `REFRESH_INTERVAL` 2d), as does the stale-marking guard.

## Follow-ups

Android gates EC and Kyber replenishment independently; this gates them together. No `forceRotation` equivalent, and no `MAXIMUM_ALLOWED_SIGNED_PREKEY_AGE` failsafe — upstream blocks sending and rotates synchronously when a signed key is 14 days stale or the elapsed time is negative.
