### PR TITLE
refactor(sender): extract repair_recipient_sessions from 409/410 handling

### DIFF
--- a/src/sender.rs
+++ b/src/sender.rs
@@ -608,8 +608,6 @@ where
 
         let content_bytes = content.encode_to_vec();
 
-        let mut rng = rng();
-
         for _ in 0..4u8 {
             let Some(EncryptedMessages {
                 messages,
@@ -663,66 +661,21 @@ where
                 },
                 Err(ServiceError::MismatchedDevicesException(ref m)) => {
                     tracing::debug!("{:?}", m);
-                    for extra_device_id in &m.extra_devices {
-                        tracing::debug!(
-                            "dropping session with device {}",
-                            extra_device_id
-                        );
-                        self.protocol_store
-                            .delete_service_addr_device_session(
-                                &recipient
-                                    .to_protocol_address(*extra_device_id)?,
-                            )
-                            .await?;
-                    }
-
-                    for missing_device_id in &m.missing_devices {
-                        tracing::debug!(
-                            "creating session with missing device {}",
-                            missing_device_id
-                        );
-                        let remote_address = recipient
-                            .to_protocol_address(*missing_device_id)?;
-                        let pre_key = self
-                            .identified_ws
-                            .get_pre_key(&recipient, *missing_device_id)
-                            .await?;
-
-                        process_prekey_bundle(
-                            &remote_address,
-                            &self
-                                .local_aci
-                                .to_protocol_address(self.device_id)
-                                .expect("valid device id"),
-                            &mut self.protocol_store.clone(),
-                            &mut self.protocol_store,
-                            &pre_key,
-                            SystemTime::now(),
-                            &mut rng,
-                        )
-                        .await
-                        .map_err(|e| {
-                            error!("failed to create session: {}", e);
-                            MessageSenderError::UntrustedIdentity {
-                                address: recipient,
-                            }
-                        })?;
-                    }
+                    self.repair_recipient_sessions(
+                        recipient,
+                        &m.extra_devices,
+                        &m.missing_devices,
+                    )
+                    .await?;
                 },
                 Err(ServiceError::StaleDevices(ref m)) => {
                     tracing::debug!("{:?}", m);
-                    for extra_device_id in &m.stale_devices {
-                        tracing::debug!(
-                            "dropping session with device {}",
-                            extra_device_id
-                        );
-                        self.protocol_store
-                            .delete_service_addr_device_session(
-                                &recipient
-                                    .to_protocol_address(*extra_device_id)?,
-                            )
-                            .await?;
-                    }
+                    self.repair_recipient_sessions(
+                        recipient,
+                        &m.stale_devices,
+                        &[],
+                    )
+                    .await?;
                 },
                 Err(ServiceError::ProofRequiredError(ref p)) => {
                     tracing::debug!("{:?}", p);
@@ -748,6 +701,61 @@ where
         }
 
         Err(MessageSenderError::MaximumRetriesLimitExceeded)
+    }
+
+    /// Repair sessions with a recipient's devices after a server-reported
+    /// device mismatch (`MismatchedDevicesException`/`StaleDevices`): drop
+    /// sessions for devices the server does not expect (`extra_devices`)
+    /// and establish sessions with devices we did not know about
+    /// (`missing_devices`), so the caller can rebuild and retry the send.
+    async fn repair_recipient_sessions(
+        &mut self,
+        recipient: ServiceId,
+        extra_devices: &[DeviceId],
+        missing_devices: &[DeviceId],
+    ) -> Result<(), MessageSenderError> {
+        for device_id in extra_devices {
+            tracing::debug!("dropping session with device {}", device_id);
+            self.protocol_store
+                .delete_service_addr_device_session(
+                    &recipient.to_protocol_address(*device_id)?,
+                )
+                .await?;
+        }
+
+        let mut rng = rng();
+
+        for device_id in missing_devices {
+            tracing::debug!(
+                "creating session with missing device {}",
+                device_id
+            );
+            let remote_address = recipient.to_protocol_address(*device_id)?;
+            let pre_key = self
+                .identified_ws
+                .get_pre_key(&recipient, *device_id)
+                .await?;
+
+            process_prekey_bundle(
+                &remote_address,
+                &self
+                    .local_aci
+                    .to_protocol_address(self.device_id)
+                    .expect("valid device id"),
+                &mut self.protocol_store.clone(),
+                &mut self.protocol_store,
+                &pre_key,
+                SystemTime::now(),
+                &mut rng,
+            )
+            .await
+            .map_err(|e| {
+                error!(%e, ?recipient, "failed to create session");
+                MessageSenderError::UntrustedIdentity { address: recipient }
+            })?;
+        }
+
+        Ok(())
     }
 
     /// Upload contact details to the CDN and send a sync message


### PR DESCRIPTION
Makes reusing and repurposing this easier in #453; was easy to pick out.