### PR TITLE
Multi recipient API

### DIFF
--- a/src/push_service/mod.rs
+++ b/src/push_service/mod.rs
@@ -3,11 +3,12 @@ use std::{sync::LazyLock, time::Duration};
 use crate::{
     configuration::{Endpoint, ServiceCredentials, SignalServers},
     prelude::ServiceConfiguration,
-    utils::serde_device_id_vec,
+    utils::{serde_device_id_vec, serde_service_id_vec},
     websocket::{SignalWebSocket, WebSocketType},
 };
 
 use libsignal_core::DeviceId;
+use libsignal_protocol::ServiceId;
 use protobuf::ProtobufResponseExt;
 use reqwest::{Method, RequestBuilder};
 use reqwest_websocket::Upgrade;
@@ -70,6 +71,18 @@ pub struct MismatchedDevices {
 pub struct StaleDevices {
     #[serde(with = "serde_device_id_vec")]
     pub stale_devices: Vec<DeviceId>,
+}
+
+/// `PUT /v1/messages/multi_recipient` success response.
+///
+/// Mirrors `SendMultiRecipientMessageResponse` on the server: the service
+/// identifiers in the request that do not correspond to registered users. Only
+/// populated when a group send endorsement token was supplied.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendMultiRecipientMessageResponse {
+    #[serde(default, with = "serde_service_id_vec")]
+    pub uuids404: Vec<ServiceId>,
 }
 
 #[derive(Clone)]
@@ -291,5 +304,56 @@ mod tests {
     fn serde_json_form_empty_vec() {
         // If we're trying to send and empty payload, serde_json must be able to make a Vec out of it
         assert!(serde_json::to_vec(b"").is_ok());
+    }
+
+    #[test]
+    fn multi_recipient_response_decodes_uuids404() {
+        use super::{
+            AccountMismatchedDevices, AccountStaleDevices,
+            SendMultiRecipientMessageResponse,
+        };
+        use libsignal_protocol::{Aci, ServiceId};
+
+        // Stories: no uuids404 array is sent.
+        let story: SendMultiRecipientMessageResponse =
+            serde_json::from_str("{}").unwrap();
+        assert!(story.uuids404.is_empty());
+
+        let aci = Aci::from(uuid::Uuid::nil());
+        let pni = libsignal_protocol::Pni::from(uuid::Uuid::from_u128(
+            0x1234_5678_1234_5678_1234_5678_1234_5678,
+        ));
+        let json = format!(
+            r#"{{"uuids404":["{}","{}"]}}"#,
+            aci.service_id_string(),
+            pni.service_id_string()
+        );
+        let resp: SendMultiRecipientMessageResponse =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(resp.uuids404.len(), 2);
+        assert_eq!(resp.uuids404[0], ServiceId::Aci(aci));
+        assert_eq!(resp.uuids404[1], ServiceId::Pni(pni));
+
+        // 409 / 410 bodies carry the same per-recipient sub-shape as the 1:1
+        // endpoints, wrapped per-account.
+        let mismatched: Vec<AccountMismatchedDevices> = serde_json::from_str(
+            &format!(
+                r#"[{{"uuid":"{}","devices":{{"missingDevices":[1,2],"extraDevices":[3]}}}}]"#,
+                aci.service_id_string()
+            ),
+        )
+        .unwrap();
+        assert_eq!(mismatched.len(), 1);
+        assert_eq!(mismatched[0].uuid, ServiceId::Aci(aci));
+        assert_eq!(mismatched[0].devices.missing_devices.len(), 2);
+        assert_eq!(mismatched[0].devices.extra_devices.len(), 1);
+
+        let stale: Vec<AccountStaleDevices> = serde_json::from_str(&format!(
+            r#"[{{"uuid":"{}","devices":{{"staleDevices":[5]}}}}]"#,
+            aci.service_id_string()
+        ))
+        .unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].devices.stale_devices.len(), 1);
     }
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -11,7 +11,7 @@ use rand::{rng, CryptoRng, Rng};
 use tracing::{debug, error, info, trace, warn};
 use tracing_futures::Instrument;
 use uuid::Uuid;
-use zkgroup::GROUP_IDENTIFIER_LEN;
+use zkgroup::{groups::GroupSendFullToken, GROUP_IDENTIFIER_LEN};
 
 use crate::{
     cipher::{get_preferred_protocol_address, ServiceCipher},
@@ -28,8 +28,10 @@ use crate::{
     push_service::*,
     service_address::ServiceIdExt,
     session_store::SessionStoreExt,
-    unidentified_access::UnidentifiedAccess,
-    utils::{serde_device_id, serde_service_id},
+    unidentified_access::{
+        CombinedUnidentifiedSenderAccessKeys, UnidentifiedAccess,
+    },
+    utils::{serde_device_id, serde_service_id, BASE64_RELAXED},
     websocket::{self, SignalWebSocket},
 };
 
@@ -68,6 +70,40 @@ pub struct SentMessage {
     pub used_identity_key: IdentityKey,
     pub unidentified: bool,
     pub needs_sync: bool,
+}
+
+/// Authorization for `PUT /v1/messages/multi_recipient`.
+///
+/// For non-story multi-recipient sends Signal requires **exactly one** of:
+/// - a combined unidentified-access key (the bitwise XOR of every
+///   recipient's 16-byte UAK), sent base64-encoded in the
+///   `Unidentified-Access-Key` header, or
+/// - a group-send endorsement full token, sent base64-encoded in the
+///   `Group-Send-Token` header.
+///
+/// Stories carry neither header; pass `None` for `access`.
+#[derive(Clone)]
+pub enum MultiRecipientAccess {
+    /// Combined unidentified-access keys.
+    UnidentifiedAccessKey(CombinedUnidentifiedSenderAccessKeys),
+    /// A group-send endorsement token covering the recipients.
+    GroupSendToken(GroupSendFullToken),
+}
+
+impl MultiRecipientAccess {
+    /// `(header name, base64-encoded value)` for the access strategy.
+    pub(crate) fn header(&self) -> (&'static str, String) {
+        use base64::Engine;
+        match self {
+            MultiRecipientAccess::UnidentifiedAccessKey(keys) => {
+                ("Unidentified-Access-Key", BASE64_RELAXED.encode(keys.0))
+            },
+            MultiRecipientAccess::GroupSendToken(token) => (
+                "Group-Send-Token",
+                BASE64_RELAXED.encode(zkgroup::serialize(token)),
+            ),
+        }
+    }
 }
 
 /// Attachment specification to be used for uploading.

--- a/src/unidentified_access.rs
+++ b/src/unidentified_access.rs
@@ -5,3 +5,60 @@ pub struct UnidentifiedAccess {
     pub key: Vec<u8>,
     pub certificate: SenderCertificate,
 }
+
+/// Bitwise XOR of the 16-byte unidentified access keys for every recipient
+/// of a multi-recipient sealed-sender message.
+///
+/// Mirrors the server's `CombinedUnidentifiedSenderAccessKeys`, which is base64-
+/// encoded into the `Unidentified-Access-Key` header of
+/// `PUT /v1/messages/multi_recipient`.
+///
+/// Construct with [`CombinedUnidentifiedSenderAccessKeys::from_access_keys`]
+/// from the per-recipient [`UnidentifiedAccess::key`]s; round-trips losslessly
+/// for an empty recipient set (yields the all-zero key).
+#[derive(Clone, Copy)]
+pub struct CombinedUnidentifiedSenderAccessKeys(pub [u8; 16]);
+
+impl CombinedUnidentifiedSenderAccessKeys {
+    /// XOR every `UnidentifiedAccess::key` (`UNIDENTIFIED_ACCESS_KEY_LENGTH`
+    /// of 16 bytes each) into a single combined access key.
+    pub fn from_access_keys<'a>(
+        keys: impl IntoIterator<Item = &'a Vec<u8>>,
+    ) -> Self {
+        let mut combined = [0u8; 16];
+        for key in keys {
+            for (acc, b) in combined.iter_mut().zip(key.iter().take(16)) {
+                *acc ^= *b;
+            }
+        }
+        Self(combined)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn combined_access_key_xors_recipients() {
+        let a = vec![0u8; 16];
+        let b = (0..16).collect::<Vec<u8>>();
+        let c = vec![0xff; 16];
+
+        let combined =
+            CombinedUnidentifiedSenderAccessKeys::from_access_keys([
+                &a, &b, &c,
+            ]);
+        // a XOR b XOR c == b XOR c (a is zero)
+        let expected: [u8; 16] = std::array::from_fn(|i| b[i] ^ c[i]);
+        assert_eq!(combined.0, expected);
+    }
+
+    #[test]
+    fn combined_access_key_empty_is_zero() {
+        let combined = CombinedUnidentifiedSenderAccessKeys::from_access_keys(
+            std::iter::empty::<&Vec<u8>>(),
+        );
+        assert_eq!(combined.0, [0u8; 16]);
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -526,6 +526,44 @@ pub mod serde_service_id {
     }
 }
 
+/// Serde adapter for a `Vec<ServiceId>` represented as a JSON array of
+/// service-id strings (the wire form used by Signal's multi-recipient endpoints;
+/// see `SendMultiRecipientMessageResponse.uuids404`).
+pub mod serde_service_id_vec {
+    use libsignal_protocol::ServiceId;
+    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(
+        ids: &Vec<ServiceId>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(ids.len()))?;
+        for id in ids {
+            seq.serialize_element(&id.service_id_string())?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<Vec<ServiceId>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<String>::deserialize(deserializer)?
+            .into_iter()
+            .map(|s| {
+                ServiceId::parse_from_service_id_string(&s).ok_or_else(|| {
+                    serde::de::Error::custom("invalid service ID string")
+                })
+            })
+            .collect()
+    }
+}
+
 pub mod serde_aci {
     use libsignal_core::Aci;
     use serde::{Deserialize, Deserializer, Serializer};

--- a/src/websocket/request.rs
+++ b/src/websocket/request.rs
@@ -52,6 +52,17 @@ impl WebSocketRequestMessageBuilder {
         Ok(self.header("content-type", "application/json").request)
     }
 
+    /// Attach a raw body (e.g. the Sealed Sender v2 multi-recipient MRM
+    /// payload) with an explicit `Content-Type` header.
+    pub fn body(
+        mut self,
+        content_type: &str,
+        body: Vec<u8>,
+    ) -> WebSocketRequestMessage {
+        self.request.body = Some(body);
+        self.header("content-type", content_type).request
+    }
+
     pub fn build(self) -> WebSocketRequestMessage {
         self.request
     }

--- a/src/websocket/sender.rs
+++ b/src/websocket/sender.rs
@@ -1,6 +1,6 @@
 use crate::{
-    push_service::response::error_mapper,
-    sender::{OutgoingPushMessages, SendMessageResponse},
+    push_service::{response::error_mapper, SendMultiRecipientMessageResponse},
+    sender::{MultiRecipientAccess, OutgoingPushMessages, SendMessageResponse},
     unidentified_access::UnidentifiedAccess,
     utils::BASE64_RELAXED,
 };
@@ -27,7 +27,6 @@ error_mapper! {
 // Signal-Server: controllers/MessageController.java:466
 // (PUT /v1/messages/multi_recipient)
 error_mapper! {
-    #[allow(dead_code)]
     put_multi_recipient_messages_errors:
         // 409: mismatched devices, MessageController.java:670
         CONFLICT => MultiRecipientMismatchedDevices(Vec<crate::push_service::AccountMismatchedDevices>),
@@ -69,5 +68,62 @@ impl<C: WebSocketType> SignalWebSocket<C> {
             )
             .json(&messages)?;
         self.request_json_with(request, put_messages_errors).await
+    }
+}
+
+/// Media type for the Sealed Sender v2 multi-recipient payload.
+///
+/// Matches `MultiRecipientMessageProvider.MEDIA_TYPE` on the server. Only the
+/// raw bytes (as produced by `libsignal_protocol::sealed_sender_multi_recipient_encrypt`)
+/// are sent; the server re-parses and fans out per recipient.
+const MULTI_RECIPIENT_MEDIA_TYPE: &str = "application/vnd.signal-messenger.mrm";
+
+/// `PUT /v1/messages/multi_recipient`: deliver a single Sealed Sender v2
+/// multi-recipient payload to all of its recipients.
+///
+/// The body content type is [`MULTI_RECIPIENT_MEDIA_TYPE`] and the body is
+/// the raw bytes returned by
+/// `libsignal_protocol::sealed_sender_multi_recipient_encrypt` — the server
+/// re-parses the multi-recipient message and fans it out per recipient.
+///
+/// Multi-recipient sends are *unauthenticated* (the access header authorizes
+/// delivery), mirroring libsignal's `send_multi_recipient_message` on the
+/// unauth chat connection and Android's unauth `messageApi.sendGroupMessage`.
+///
+/// `access` sets the authorization header per the [`MultiRecipientAccess`]
+/// variant; pass `None` for stories. The 200 response lists any group-send
+/// endorsement recipients the server could not resolve as registered users.
+///
+/// `409`/`410` become [`ServiceError::MultiRecipientMismatchedDevices`] /
+/// [`ServiceError::MultiRecipientStaleDevices`] respectively, rather than
+/// the single-recipient variants decoded by
+/// [`SignalWebSocket::send_messages`].
+impl SignalWebSocket<Unidentified> {
+    pub async fn send_multi_recipient_messages(
+        &mut self,
+        timestamp: u64,
+        online: bool,
+        urgent: bool,
+        story: bool,
+        payload: &[u8],
+        access: Option<MultiRecipientAccess>,
+    ) -> Result<SendMultiRecipientMessageResponse, ServiceError> {
+        // Match the query-parameter form used by the Java client
+        // (GROUP_MESSAGE_PATH
+        // /v1/messages/multi_recipient?ts=...&online=...&urgent=...&story=...).
+        let path = format!(
+            "/v1/messages/multi_recipient?ts={timestamp}&online={online}&urgent={urgent}&story={story}"
+        );
+
+        let mut builder = WebSocketRequestMessage::new(Method::PUT).path(path);
+        if let Some(access) = access.as_ref() {
+            let (name, value) = access.header();
+            builder = builder.header(name, value);
+        }
+        let request =
+            builder.body(MULTI_RECIPIENT_MEDIA_TYPE, payload.to_vec());
+
+        self.request_json_with(request, put_multi_recipient_messages_errors)
+            .await
     }
 }


### PR DESCRIPTION
Picks the multi-recipient API code from #453. Together with #471 these should be the easiest parts to review and merge... (This also technically replaces #454)

Fixes #451 